### PR TITLE
fix: rename exception from PicorbcNotFoundError to PicorbcMissingError

### DIFF
--- a/lib/tasks/funicular.rake
+++ b/lib/tasks/funicular.rake
@@ -21,7 +21,7 @@ namespace :funicular do
         debug_mode: debug_mode
       )
       compiler.compile
-    rescue Funicular::Compiler::PicorbcNotFoundError => e
+    rescue Funicular::Compiler::PicorbcMissingError => e
       puts "ERROR: #{e.message}"
       exit 1
     rescue => e


### PR DESCRIPTION
 ## What happened

Inspired by your awesome session in RubyKaigi 2026, I was trying to take a look at Funicular in my Rails project and encountered this `NameError` today. The `funicular:compile` rake task rescues `Funicular::Compiler::PicorbcNotFoundError`, but the actual class defined in `lib/funicular/compiler.rb` is `PicorbcMissingError`.

## Fix

Just renamed the class in the rescue to match the actual definition.

(I noticed there are no existing issues or PRs in this project so far, so I'm not sure if external contributions are welcome. Feel free to close this if it's not appropriate. Thank you!)