### PR TITLE
Add new layer "Store" using picoruby-indexeddb and fix bug

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -131,6 +131,8 @@ GEM
     net-smtp (0.5.1)
       net-protocol
     nio4r (2.7.5)
+    nokogiri (1.19.0-aarch64-linux-gnu)
+      racc (~> 1.4)
     nokogiri (1.19.0-x86_64-linux-gnu)
       racc (~> 1.4)
     pp (0.6.3)
@@ -203,6 +205,7 @@ GEM
     zeitwerk (2.7.4)
 
 PLATFORMS
+  aarch64-linux
   x86_64-linux
 
 DEPENDENCIES

--- a/README.md
+++ b/README.md
@@ -72,6 +72,11 @@ cd picoruby/mrbgems/picoruby-funicular
 The CRubyGem side (`lib/`, `funicular.gemspec`, etc.) can be developed and tested independently inside that directory, but `rake copy_wasm` — which vendorsthe PicoRuby.wasm and picorbc wasm artifacts into the gem — relies on sibling directories within the picoruby repository (`mrbgems/picoruby-wasm/npm/`).
 Running it from a standalone checkout will fail.
 
+## Testing
+
+- CRubygem (Rails integration) test: `rake test` in this repository
+- PicoGem Funicular test: `rake test:gems:picoruby[picoruby-funicular]` in picoruby where mrbgems/picoruby-funicular exists as a submodule
+
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/picoruby/funicular.

--- a/docs/data-fetching.md
+++ b/docs/data-fetching.md
@@ -5,6 +5,7 @@ Funicular provides multiple layers for data fetching: low-level HTTP client, hig
 ## Table of Contents
 
 - [HTTP Client](#http-client)
+  - [Response Cache](#response-cache)
 - [Object-REST Mapper (Model)](#object-rest-mapper-model)
 - [Suspense / Loading States](#suspense--loading-states)
 - [Best Practices](#best-practices)
@@ -80,6 +81,40 @@ Funicular::HTTP.post('/api/posts', post_data) do |response|
   # CSRF token automatically included
 end
 ```
+
+### Response Cache
+
+GET responses can be cached in IndexedDB to cut perceived latency on
+repeated requests. The cache is opt-in per call via the `cache:` keyword,
+which sets a TTL in seconds:
+
+```ruby
+# First call: network fetch + cache write.
+# Subsequent calls within 60s: served synchronously from IndexedDB.
+Funicular::HTTP.get('/api/posts', cache: 60) do |response|
+  # response.data, response.status, response.ok behave as usual
+end
+```
+
+Cache key is the full URL string (path + query). Only successful (2xx) GET
+responses are written. POST/PATCH/PUT/DELETE ignore `cache:` (a warning is
+printed if it is passed).
+
+The cache lazily initializes on first use, but you can call
+`Funicular::HTTP.cache_init!` once at boot to pay the open cost upfront.
+Falls back to in-memory storage transparently when IndexedDB is
+unavailable.
+
+```ruby
+Funicular::HTTP.cache_init!         # idempotent
+
+Funicular::HTTP.cache_purge('/api/posts')  # invalidate one entry
+Funicular::HTTP.cache_clear                # invalidate everything
+```
+
+Invalidation is explicit: non-GET requests do **not** auto-purge related
+GET cache entries. If your API changes data through POST/PATCH/DELETE,
+invalidate the affected URLs manually.
 
 ## Object-REST Mapper (Model)
 

--- a/docs/rails-integration.md
+++ b/docs/rails-integration.md
@@ -150,13 +150,15 @@ app/funicular/
   models/              # UI models
     user.rb
     session.rb
+  stores/              # State management (IndexedDB, caches, etc.)
+    draft_store.rb
   components/          # UI components
     login_component.rb
     chat_component.rb
   initializer.rb       # Application initialization (optional)
 ```
 
-The `initializer.rb` file (or any file ending with `_initializer.rb`) is loaded last, after all models and components. Use it for application setup code like routing configuration.
+The `initializer.rb` file (or any file ending with `_initializer.rb`) is loaded last, after all models, stores, and components. Use it for application setup code like routing configuration.
 
 ### Compilation
 
@@ -229,11 +231,13 @@ end
 Funicular concatenates files in the following order:
 
 1. `app/funicular/models/**/*.rb` (alphabetically)
-2. `app/funicular/components/**/*.rb` (alphabetically)
-3. `app/funicular/initializer.rb` and `app/funicular/*_initializer.rb`
+2. `app/funicular/stores/**/*.rb` (alphabetically)
+3. `app/funicular/components/**/*.rb` (alphabetically)
+4. `app/funicular/initializer.rb` and `app/funicular/*_initializer.rb`
 
 This ensures that:
-- Model classes are defined before components that depend on them
+- Model classes are defined before stores and components that depend on them
+- Stores are defined before components that use them
 - Components are defined before initialization code that uses them
 
 ### Routing

--- a/lib/funicular/compiler.rb
+++ b/lib/funicular/compiler.rb
@@ -67,12 +67,13 @@ module Funicular
 
     def gather_source_files
       models_files = Dir.glob(File.join(source_dir, "models", "**", "*.rb")).sort
+      stores_files = Dir.glob(File.join(source_dir, "stores", "**", "*.rb")).sort
       components_files = Dir.glob(File.join(source_dir, "components", "**", "*.rb")).sort
       initializer_files = Dir.glob(File.join(source_dir, "*_initializer.rb")).sort +
                           Dir.glob(File.join(source_dir, "initializer.rb")).sort
 
-      # Order: models -> components -> initializer
-      all_files = models_files + components_files + initializer_files
+      # Order: models -> stores -> components -> initializer
+      all_files = models_files + stores_files + components_files + initializer_files
 
       if all_files.empty?
         raise "No Ruby files found in #{source_dir}"

--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -5,6 +5,7 @@ MRuby::Gem::Specification.new('picoruby-funicular') do |spec|
 
   unless ENV['TEST_TASK']
     spec.add_dependency 'picoruby-wasm'
+    spec.add_dependency 'picoruby-indexeddb'
   end
   spec.add_dependency 'picoruby-json'
   spec.add_dependency 'mruby-object-ext', gemdir: "#{MRUBY_ROOT}/mrbgems/picoruby-mruby/lib/mruby/mrbgems/mruby-object-ext"

--- a/mrblib/cable.rb
+++ b/mrblib/cable.rb
@@ -233,7 +233,8 @@ module Funicular
         return if @pending_commands.empty?
         begin
           json = JSON.generate(@pending_commands)
-          JS.global[:localStorage]&.setItem(STORAGE_KEY, json)
+          storage = JS.global[:localStorage]
+          storage.setItem(STORAGE_KEY, json) if storage.is_a?(JS::Object)
         rescue => e
           puts "[Cable] Error saving to localStorage: #{e.message}"
         end
@@ -242,12 +243,10 @@ module Funicular
       # Load pending commands from localStorage
       def load_pending_from_storage
         begin
-          stored = JS.global[:localStorage]&.getItem(STORAGE_KEY)
-          if stored
-            JSON.parse(stored.to_s)
-          else
-            []
-          end
+          storage = JS.global[:localStorage]
+          return [] unless storage.is_a?(JS::Object)
+          stored = storage.getItem(STORAGE_KEY)
+          stored.is_a?(String) ? JSON.parse(stored) : []
         rescue => e
           puts "[Cable] Error loading from localStorage: #{e.message}"
           []
@@ -257,7 +256,8 @@ module Funicular
       # Clear pending commands from localStorage
       def clear_pending_storage
         begin
-          JS.global[:localStorage]&.removeItem(STORAGE_KEY)
+          storage = JS.global[:localStorage]
+          storage.removeItem(STORAGE_KEY) if storage.is_a?(JS::Object)
         rescue => e
           puts "[Cable] Error clearing localStorage: #{e.message}"
         end

--- a/mrblib/component.rb
+++ b/mrblib/component.rb
@@ -495,42 +495,25 @@ module Funicular
 
     private
 
-    # Normalize state value by converting JS::Object to Ruby native types
+    # Normalize state value for storage. Primitives are already auto-
+    # converted to Ruby native values by picoruby-wasm, so only composite
+    # JS::Object values (array / plain object / function / symbol / bigint)
+    # and nested Ruby collections need handling here.
     def normalize_state_value(value)
-      if value.is_a?(Hash)
-        # Recursively normalize hash values
+      case value
+      when Hash
         normalized = {} #: Hash[untyped, untyped]
-        value.each do |k, v|
-          normalized[k] = normalize_state_value(v)
-        end
+        value.each { |k, v| normalized[k] = normalize_state_value(v) }
         normalized
-      elsif value.is_a?(Array)
-        # Recursively normalize array elements
+      when Array
         value.map { |v| normalize_state_value(v) }
-      elsif value.is_a?(JS::Object)
-        # Convert JS::Object to appropriate Ruby type
-        case value.type
-        when :string
-          value.to_s
-        when :number
-          # Check if it's an integer or float
-          num = value.to_f
-          num == num.to_i ? num.to_i : num
-        when :boolean
-          # JS::Object#== now supports direct comparison with Ruby true/false
-          value == true
-        when :null, :undefined
-          nil
-        when :array
+      when JS::Object
+        if value.type == :array
           value.to_a.map { |v| normalize_state_value(v) }
-        when :object
-          # For plain objects, keep as JS::Object or convert to hash if needed
-          value
         else
           value
         end
       else
-        # Return as-is for Ruby native types
         value
       end
     end

--- a/mrblib/component.rb
+++ b/mrblib/component.rb
@@ -508,7 +508,7 @@ module Funicular
       when Array
         value.map { |v| normalize_state_value(v) }
       when JS::Object
-        if value.type == :array
+        if value.typeof == :array
           value.to_a.map { |v| normalize_state_value(v) }
         else
           value
@@ -529,7 +529,10 @@ module Funicular
       cleanup_events
 
       unless patches.empty?
-        @dom_element = VDOM::Patcher.new.apply(@dom_element, patches)
+        new_dom_element = VDOM::Patcher.new.apply(@dom_element, patches)
+        # apply returns JS::Object (it must accept text-node patches), but
+        # the component's root is always an Element. Narrow to JS::Element.
+        @dom_element = new_dom_element if new_dom_element.is_a?(JS::Element)
       end
 
       bind_events(@dom_element, new_vdom)

--- a/mrblib/differ.rb
+++ b/mrblib/differ.rb
@@ -90,9 +90,22 @@ module Funicular
         end
       end
 
+      # Produce a single composite patch describing a keyed-children diff.
+      #
+      # The earlier implementation emitted independent `[index, ...]` patches
+      # for inserts, removes and updates. The patcher consumed them as
+      # `replaceChild`, which is unsafe whenever insert and remove indices
+      # overlap (e.g. switching between two equal-length sets of keyed
+      # children with disjoint keys): inserts overwrite old nodes in place,
+      # then the descending removes drop the just-inserted new nodes and
+      # the DOM ends up empty.
+      #
+      # The new shape is `[[:keyed_children, ops, removes]]`, applied as
+      # three phases by the patcher:
+      #   1. removes (descending old_index, against the original DOM snapshot)
+      #   2. content updates for kept children (against the snapshot, no move)
+      #   3. inserts in ascending new_index using insertBefore on the live DOM
       def self.diff_children_with_keys(old_children, new_children)
-        patches = [] #: Array[patch_t]
-
         # 1. Build key map from old children
         old_key_map = {} #: Hash[untyped, [Integer, child_t]]
         old_children.each_with_index do |child, index|
@@ -101,63 +114,59 @@ module Funicular
           end
         end
 
-        # 2. Track matched old indices
         matched_old_indices = {} #: Hash[Integer, bool]
+        ops = [] #: Array[Array[untyped]]
+        has_change = false
 
-        # 3. Process new children
+        # 2. Process new children, recording one op per new position
         new_children.each_with_index do |new_child, new_index|
           if new_child.is_a?(VNode) && new_child.respond_to?(:key) && new_child.key
             key = new_child.key
-
             if old_key_map[key]
               old_index, old_child = old_key_map[key]
               matched_old_indices[old_index] = true
-
-              # Diff existing element
               child_patches = diff(old_child, new_child)
-              unless child_patches.empty?
-                patches << [new_index, child_patches]
-              end
+              ops << [:keep, old_index, new_index, child_patches]
+              has_change = true unless child_patches.empty?
             else
-              # Insert new element
-              patches << [new_index, [[:replace, new_child, nil]]] # old_node is nil for insertion
+              ops << [:insert, new_index, new_child]
+              has_change = true
             end
           else
-            # Fallback to index-based for elements without keys
-            # Even if old_child.nil?, diff will handle it (insertion)
+            # Unkeyed new child: positional fallback. Match it with the
+            # old child at the same index only when that old child is
+            # itself unkeyed (otherwise the keyed old child is matched
+            # separately via its key, and the unkeyed new is a fresh insert).
             old_child = old_children[new_index]
-            child_patches = diff(old_child, new_child)
-            unless child_patches.empty?
-              patches << [new_index, child_patches]
+            old_is_keyed = old_child.is_a?(VNode) && old_child.respond_to?(:key) && old_child.key
+            if old_child.nil? || old_is_keyed
+              ops << [:insert, new_index, new_child]
+              has_change = true
+            else
+              matched_old_indices[new_index] = true
+              child_patches = diff(old_child, new_child)
+              ops << [:keep, new_index, new_index, child_patches]
+              has_change = true unless child_patches.empty?
             end
           end
         end
 
-        # 4. Remove unmatched old elements
+        # 3. Collect unmatched keyed old children to remove. Unkeyed olds
+        #    that do not match any new positional slot are left untouched
+        #    (matches the prior behavior of diff_children_with_keys).
+        removes = [] #: Array[[Integer, child_t]]
         old_children.each_with_index do |old_child, old_index|
           next unless old_child.is_a?(VNode)
           next if matched_old_indices[old_index]
-
-          if old_child.respond_to?(:key) && old_child.key # Only remove keyed children
-            patches << [old_index, [[:remove, old_child]]]
+          if old_child.respond_to?(:key) && old_child.key
+            removes << [old_index, old_child]
+            has_change = true
           end
         end
 
-        # Sort patches: updates first, removes last (descending index)
-        patches.sort { |a, b|
-          a_is_remove = a[1].length == 1 && a[1][0][0] == :remove
-          b_is_remove = b[1].length == 1 && b[1][0][0] == :remove
+        return [] unless has_change
 
-          if a_is_remove && b_is_remove
-            b[0] <=> a[0] # Sort remove patches by descending index
-          elsif a_is_remove
-            1 # Remove patches come after non-remove patches
-          elsif b_is_remove
-            -1 # Non-remove patches come before remove patches
-          else
-            a[0] <=> b[0] # Sort non-remove patches by ascending index
-          end
-        }
+        [[:keyed_children, ops, removes]]
       end
 
       def self.diff_children_by_index(old_children, new_children)

--- a/mrblib/funicular.rb
+++ b/mrblib/funicular.rb
@@ -91,7 +91,7 @@ module Funicular
       container
     end
 
-    unless container_element
+    unless container_element.is_a?(JS::Element)
       raise "Container element not found: #{container}"
     end
 

--- a/mrblib/http.rb
+++ b/mrblib/http.rb
@@ -1,5 +1,10 @@
 module Funicular
   module HTTP
+    CACHE_DB_NAME = 'funicular_http_cache'.freeze
+    CACHE_STORE = 'responses'.freeze
+
+    @cache = nil
+
     class Response
       attr_reader :data, :status, :ok
 
@@ -21,23 +26,73 @@ module Funicular
       end
     end
 
-    def self.get(url, &block)
-      request("GET", url, nil, &block)
+    # Open (or reuse) the response cache store. Idempotent and safe to call
+    # multiple times. Falls back to the in-memory backing if browser
+    # IndexedDB is unavailable.
+    def self.cache_init!
+      cache = @cache
+      return cache if cache
+      @cache = IndexedDB::KVS.open(CACHE_DB_NAME, store: CACHE_STORE)
     end
 
-    def self.post(url, body = nil, &block)
+    # Drop a single cached entry by URL key. No-op if the cache is not
+    # initialized.
+    def self.cache_purge(url)
+      cache = @cache
+      return nil unless cache
+      cache.delete(url)
+      nil
+    end
+
+    # Drop every cached entry. No-op if the cache is not initialized.
+    def self.cache_clear
+      cache = @cache
+      return nil unless cache
+      cache.clear
+      nil
+    end
+
+    # Internal: read the cache for *url*. Returns the parsed entry hash or
+    # nil. Lazily initializes the cache on first use so callers can pass
+    # `cache:` without booting the SPA shell first.
+    def self.cache_lookup(url)
+      cache_init! unless @cache
+      cache = @cache
+      return nil unless cache
+      cache[url]
+    end
+
+    # Internal: write *entry* (a Hash with status/data/cached_at) to the
+    # cache. Awaits one extra Promise so the next request reliably hits.
+    def self.cache_write(url, entry)
+      cache_init! unless @cache
+      cache = @cache
+      return nil unless cache
+      cache[url] = entry
+      nil
+    end
+
+    def self.get(url, cache: nil, &block)
+      request("GET", url, nil, cache: cache, &block)
+    end
+
+    def self.post(url, body = nil, cache: nil, &block)
+      warn_unsupported_cache("post") if cache
       request("POST", url, body, &block)
     end
 
-    def self.patch(url, body = nil, &block)
+    def self.patch(url, body = nil, cache: nil, &block)
+      warn_unsupported_cache("patch") if cache
       request("PATCH", url, body, &block)
     end
 
-    def self.delete(url, &block)
+    def self.delete(url, cache: nil, &block)
+      warn_unsupported_cache("delete") if cache
       request("DELETE", url, nil, &block)
     end
 
-    def self.put(url, body = nil, &block)
+    def self.put(url, body = nil, cache: nil, &block)
+      warn_unsupported_cache("put") if cache
       request("PUT", url, body, &block)
     end
 
@@ -46,43 +101,82 @@ module Funicular
     def self.csrf_token
       meta = JS.document.querySelector('meta[name="csrf-token"]')
       if meta
-        # Use getAttribute method (direct method call on JS::Object)
         token_obj = meta.getAttribute('content')
-        # Convert JS::Object to Ruby string
         token_obj ? token_obj.to_s : nil
       else
         nil
       end
     end
 
-    private
+    class << self
+      private
 
-    def self.request(method, url, body, &block)
-      # @type var options: Hash[Symbol, String | Hash[String, String]]
-      options = { method: method, credentials: "include" }
-
-      headers = {} #: Hash[String, String]
-
-      if body
-        headers["Content-Type"] = "application/json"
-        options[:body] = JSON.generate(body)
+      def warn_unsupported_cache(verb)
+        puts "[Funicular::HTTP] cache: option is GET-only; ignoring on #{verb.upcase}"
       end
 
-      # Add CSRF token for non-GET requests
-      if method != "GET"
-        token = csrf_token
-        headers["X-CSRF-Token"] = token if token
+      def now_seconds
+        # JavaScript Date.now() returns ms since epoch
+        ms = JS.global[:Date].now # steep:ignore
+        (ms.to_i / 1000)
       end
 
-      options[:headers] = headers unless headers.empty?
+      def cache_hit?(entry, ttl)
+        return false unless entry.is_a?(Hash)
+        cached_at = entry["cached_at"]
+        return false unless cached_at.is_a?(Integer)
+        (now_seconds - cached_at) <= ttl
+      end
 
-      JS.global.fetch(url, options) do |response|
-        status = response.status.to_i
-        json_text = response.to_binary
-        data = JSON.parse(json_text)
-        # @type var status: Integer
-        http_response = Response.new(status, data)
-        block.call(http_response) if block
+      def serve_from_cache(entry, &block)
+        status = entry["status"].to_i
+        data = entry["data"]
+        block.call(Response.new(status, data)) if block
+      end
+
+      def request(method, url, body, cache: nil, &block)
+        if method == "GET" && cache.is_a?(Integer) && cache > 0
+          entry = cache_lookup(url)
+          if cache_hit?(entry, cache)
+            serve_from_cache(entry, &block)
+            return
+          end
+        end
+
+        # @type var options: Hash[Symbol, String | Hash[String, String]]
+        options = { method: method, credentials: "include" }
+
+        headers = {} #: Hash[String, String]
+
+        if body
+          headers["Content-Type"] = "application/json"
+          options[:body] = JSON.generate(body)
+        end
+
+        if method != "GET"
+          token = csrf_token
+          headers["X-CSRF-Token"] = token if token
+        end
+
+        options[:headers] = headers unless headers.empty?
+
+        JS.global.fetch(url, options) do |response|
+          status = response.status.to_i
+          json_text = response.to_binary
+          data = JSON.parse(json_text)
+          # @type var status: Integer
+          http_response = Response.new(status, data)
+
+          if method == "GET" && cache.is_a?(Integer) && cache > 0 && http_response.ok
+            cache_write(url, {
+              "status" => status,
+              "data" => data,
+              "cached_at" => now_seconds
+            })
+          end
+
+          block.call(http_response) if block
+        end
       end
     end
   end

--- a/mrblib/patcher.rb
+++ b/mrblib/patcher.rb
@@ -20,7 +20,9 @@ module Funicular
               result = new_element
             end
           when :props
-            update_props(element, patch[1])
+            # Props patches only make sense for Element nodes (text nodes have
+            # no attributes); narrow before delegating.
+            update_props(element, patch[1]) if element.is_a?(JS::Element)
           when :update_and_rebind
             instance, internal_patches, new_vdom = patch[1], patch[2], patch[3]
             old_dom_element = instance.dom_element
@@ -29,7 +31,7 @@ module Funicular
             new_dom_element = Patcher.new(@doc).apply(old_dom_element, internal_patches)
 
             # Update the instance's reference to its root DOM element if it changed
-            if new_dom_element != old_dom_element
+            if new_dom_element != old_dom_element && new_dom_element.is_a?(JS::Element)
               instance.dom_element = new_dom_element
             end
 
@@ -37,11 +39,13 @@ module Funicular
             instance.vdom = new_vdom
 
             # Re-collect refs using the new DOM element
-            instance.collect_refs(new_dom_element, new_vdom)
+            if new_dom_element.is_a?(JS::Element)
+              instance.collect_refs(new_dom_element, new_vdom)
 
-            # Re-bind events using the new DOM element
-            instance.cleanup_events
-            instance.bind_events(new_dom_element, new_vdom)
+              # Re-bind events using the new DOM element
+              instance.cleanup_events
+              instance.bind_events(new_dom_element, new_vdom)
+            end
 
             # Call component_updated on the child instance
             instance.component_updated if instance.respond_to?(:component_updated)
@@ -67,7 +71,7 @@ module Funicular
                 case child_patch[0]
                 when :replace
                   new_child_element = create_element(child_patch[1])
-                  element.appendChild(new_child_element)
+                  element.appendChild(new_child_element) if element.is_a?(JS::Element)
                 when :remove
                   # Nothing to remove if child doesn't exist
                 when Integer
@@ -75,7 +79,9 @@ module Funicular
                   # But if it does, recursively process it
                 end
               end
-            else
+            elsif child_element.is_a?(JS::Object)
+              # Recurse into the child node. apply handles both Element and
+              # text Node cases (the latter only meaningfully via :replace).
               apply(child_element, child_patches)
             end
           end

--- a/mrblib/patcher.rb
+++ b/mrblib/patcher.rb
@@ -58,6 +58,64 @@ module Funicular
             old_vnode = patch[1]
             unmount_component(old_vnode)
             element.parentElement&.removeChild(element)
+          when :keyed_children
+            # Composite patch produced by Differ.diff_children_with_keys.
+            # Applied in three phases against `element`:
+            #   1. snapshot DOM children, then remove unmatched keyed old
+            #      children (descending old_index so the snapshot indices
+            #      remain valid as removes happen).
+            #   2. apply content updates to kept children in place. The
+            #      lookup is by snapshot[old_index], so updates are stable
+            #      regardless of subsequent insertions.
+            #   3. insert new children at their new_index using
+            #      insertBefore on the live DOM. Processed in ascending
+            #      new_index order so each insertion fixes its own
+            #      position before later inserts run.
+            ops = patch[1]
+            removes = patch[2]
+
+            child_nodes = element[:childNodes]
+            snapshot = child_nodes.is_a?(JS::Object) ? child_nodes.to_a : [] #: Array[untyped]
+
+            # Phase 1: removes (descending old_index)
+            sorted_removes = removes.sort { |a, b| b[0] <=> a[0] }
+            sorted_removes.each do |entry|
+              old_index = entry[0]
+              old_vnode = entry[1]
+              target = snapshot[old_index]
+              next if target.nil?
+              unmount_component(old_vnode)
+              parent_el = target.parentElement
+              parent_el.removeChild(target) if parent_el
+            end
+
+            # Phase 2: updates against the snapshot (no movement)
+            ops.each do |op|
+              next unless op[0] == :keep
+              old_index = op[1]
+              child_patches = op[3]
+              next if child_patches.empty?
+              target = snapshot[old_index]
+              next if target.nil?
+              apply(target, child_patches)
+            end
+
+            # Phase 3: inserts in ascending new_index order
+            ops.each do |op|
+              next unless op[0] == :insert
+              new_index = op[1]
+              new_vnode = op[2]
+              new_node = create_element(new_vnode)
+              next if new_node.nil?
+              live_nodes = element[:childNodes]
+              live_arr = live_nodes.is_a?(JS::Object) ? live_nodes.to_a : [] #: Array[untyped]
+              ref = live_arr[new_index]
+              if ref.nil?
+                element.appendChild(new_node) if element.is_a?(JS::Element)
+              else
+                element.insertBefore(new_node, ref) if element.is_a?(JS::Element)
+              end
+            end
           when Integer
             child_index = patch[0]
             child_patches = patch[1]
@@ -97,6 +155,8 @@ module Funicular
       end
 
       def update_props(element, props_patch)
+        return unless element.is_a?(JS::Element)
+
         props_patch.each do |key, value|
           key_str = key.to_s
 

--- a/sig/component.rbs
+++ b/sig/component.rbs
@@ -12,9 +12,9 @@ module Funicular
 
     attr_accessor props: Hash[Symbol, untyped]
     attr_accessor vdom: VDOM::VNode | VDOM::Text | nil
-    attr_accessor dom_element: JS::Object
+    attr_accessor dom_element: JS::Element
     attr_accessor mounted: bool
-    attr_reader refs: Hash[Symbol, JS::Object]
+    attr_reader refs: Hash[Symbol, JS::Element]
     @event_listeners: Array[Integer]
     @child_components: Array[Component]
     @suspense_data: Hash[Symbol, untyped]
@@ -53,10 +53,10 @@ module Funicular
     def suspense: (fallback: ^() -> void, ?error: ^(untyped) -> void) { () -> void } -> void
 
     def patch: (Hash[Symbol, untyped] new_state) -> void
-    def mount: (JS::Object container) -> void
+    def mount: (JS::Element container) -> void
     def unmount: () -> void
     def render: () -> (VDOM::VNode | String | Integer | Float | Array[untyped] | nil)
-    def bind_events: (JS::Object dom_element, VDOM::VNode | VDOM::Text | nil vnode) -> void
+    def bind_events: (JS::Element dom_element, VDOM::VNode | VDOM::Text | nil vnode) -> void
     def build_vdom: () -> (VDOM::VNode | VDOM::Text | nil)
 
     # Lifecycle hooks (public, can be overridden in subclasses)
@@ -91,7 +91,7 @@ module Funicular
     private def re_render: () -> void
     private def normalize_vnode: (untyped value) -> (VDOM::Element | VDOM::Text | VDOM::Component | nil)
     private def add_data_component_attribute: (VDOM::VNode vnode) -> void
-    private def collect_refs: (JS::Object dom_element, VDOM::VNode | VDOM::Text | nil vnode, ?Hash[Symbol, JS::Object] refs_map) -> Hash[Symbol, JS::Object]
+    private def collect_refs: (JS::Element dom_element, VDOM::VNode | VDOM::Text | nil vnode, ?Hash[Symbol, JS::Element] refs_map) -> Hash[Symbol, JS::Element]
     private def cleanup_events: () -> void
     private def cleanup_suspense_timers: () -> void
     private def add_child: (untyped child) -> void

--- a/sig/funicular.rbs
+++ b/sig/funicular.rbs
@@ -6,7 +6,7 @@ module Funicular
   def self.env=: (EnvironmentInquirer | String environment) -> EnvironmentInquirer?
   def self.router: () -> Router?
   def self.load_schemas: (Hash[singleton(Model), String] models) ?{ () -> void } -> void
-  def self.start: (?singleton(Component)? component_class, ?container: String | JS::Object, ?props: Hash[Symbol, untyped]) ?{ (Router router) -> void } -> (Component | Router)
+  def self.start: (?singleton(Component)? component_class, ?container: String | JS::Element, ?props: Hash[Symbol, untyped]) ?{ (Router router) -> void } -> (Component | Router)
   def self.configure_forms: () ?{ (Hash[Symbol, String]) -> void } -> void
   def self.configure_debug: () ?{ (self) -> void } -> void
   def self.export_debug_config: () -> void

--- a/sig/http.rbs
+++ b/sig/http.rbs
@@ -1,5 +1,10 @@
 module Funicular
   module HTTP
+    CACHE_DB_NAME: String
+    CACHE_STORE: String
+
+    self.@cache: IndexedDB::KVS?
+
     class Response
       attr_reader data: untyped
       attr_reader status: Integer
@@ -10,13 +15,23 @@ module Funicular
       def error_message: () -> String?
     end
 
-    def self.get: (String url) { (Response) -> void } -> void
-    def self.post: (String url, ?Hash[untyped, untyped]? body) { (Response) -> void } -> void
-    def self.patch: (String url, ?Hash[untyped, untyped]? body) { (Response) -> void } -> void
-    def self.delete: (String url) { (Response) -> void } -> void
-    def self.put: (String url, ?Hash[untyped, untyped]? body) { (Response) -> void } -> void
+    def self.cache_init!: () -> IndexedDB::KVS
+    def self.cache_purge: (String url) -> nil
+    def self.cache_clear: () -> nil
+    def self.cache_lookup: (String url) -> untyped
+    def self.cache_write: (String url, Hash[String, untyped] entry) -> nil
+
+    def self.get: (String url, ?cache: Integer?) { (Response) -> void } -> void
+    def self.post: (String url, ?Hash[untyped, untyped]? body, ?cache: Integer?) { (Response) -> void } -> void
+    def self.patch: (String url, ?Hash[untyped, untyped]? body, ?cache: Integer?) { (Response) -> void } -> void
+    def self.delete: (String url, ?cache: Integer?) { (Response) -> void } -> void
+    def self.put: (String url, ?Hash[untyped, untyped]? body, ?cache: Integer?) { (Response) -> void } -> void
     def self.csrf_token: () -> String?
 
-    private def self.request: (String method, String url, Hash[untyped, untyped]? body) { (Response) -> void } -> void
+    private def self.warn_unsupported_cache: (String verb) -> void
+    private def self.now_seconds: () -> Integer
+    private def self.cache_hit?: (untyped entry, Integer ttl) -> bool
+    private def self.serve_from_cache: (Hash[String, untyped] entry) { (Response) -> void } -> void
+    private def self.request: (String method, String url, Hash[untyped, untyped]? body, ?cache: Integer?) { (Response) -> void } -> void
   end
 end

--- a/sig/patcher.rbs
+++ b/sig/patcher.rbs
@@ -8,7 +8,8 @@ module Funicular
       # can recurse into it; Element-only operations are narrowed inside.
       def apply: (JS::Object element, Array[patch_t] patches) -> JS::Object
 
-      private def update_props: (JS::Element element, Hash[Symbol, String?] props_patch) -> void
+      # Accepts JS::Object since callers narrow via is_a?(JS::Element) at runtime
+      private def update_props: (JS::Object element, Hash[Symbol, String?] props_patch) -> void
       private def create_element: (untyped vnode) -> JS::Object
       private def unmount_component: (VDOM::VNode vnode) -> void
     end

--- a/sig/patcher.rbs
+++ b/sig/patcher.rbs
@@ -3,10 +3,12 @@ module Funicular
     BOOLEAN_ATTRIBUTES: Array[String]
 
     class Patcher
-      def initialize: (?JS::Object? doc) -> void
+      def initialize: (?JS::Element? doc) -> void
+      # `apply` accepts any DOM node so text-node patches (e.g. :replace)
+      # can recurse into it; Element-only operations are narrowed inside.
       def apply: (JS::Object element, Array[patch_t] patches) -> JS::Object
 
-      private def update_props: (JS::Object element, Hash[Symbol, String?] props_patch) -> void
+      private def update_props: (JS::Element element, Hash[Symbol, String?] props_patch) -> void
       private def create_element: (untyped vnode) -> JS::Object
       private def unmount_component: (VDOM::VNode vnode) -> void
     end

--- a/sig/router.rbs
+++ b/sig/router.rbs
@@ -19,7 +19,7 @@ module Funicular
     attr_reader current_component: Component?
     attr_reader current_path: String?
 
-    def initialize: (JS::Object container) -> void
+    def initialize: (JS::Element container) -> void
     def get: (String path, to: singleton(Component), ?as: String?, ?constraints: route_constraints_t?) -> void
     def post: (String path, to: singleton(Component), ?as: String?, ?constraints: route_constraints_t?) -> void
     def put: (String path, to: singleton(Component), ?as: String?, ?constraints: route_constraints_t?) -> void

--- a/sig/vdom.rbs
+++ b/sig/vdom.rbs
@@ -32,18 +32,18 @@ module Funicular
     class Renderer
       @error_boundary_stack: Array[Funicular::ErrorBoundary]
 
-      def initialize: (?JS::Object? doc) -> void
-      def render: (VDOM::VNode | VDOM::Text | nil vnode, ?JS::Object? parent) -> JS::Object
+      def initialize: (?JS::Element? doc) -> void
+      def render: (VDOM::VNode | VDOM::Text | nil vnode, ?JS::Element? parent) -> JS::Element
 
       private def current_error_boundary: () -> ErrorBoundary?
-      private def render_element: (Element element, JS::Object? parent) -> JS::Object
-      private def render_text: (VDOM::Text text, JS::Object? parent) -> JS::Object
-      private def render_component: (VDOM::Component component_vnode, JS::Object? parent) -> JS::Object
+      private def render_element: (Element element, JS::Element? parent) -> JS::Element
+      private def render_text: (VDOM::Text text, JS::Element? parent) -> JS::Element
+      private def render_component: (VDOM::Component component_vnode, JS::Element? parent) -> JS::Element
     end
 
     def self.create_element: (String tag, ?Hash[Symbol, untyped] props, *child_t children) -> Element
     def self.create_text: (String content) -> Text
-    def self.render: (VNode vnode, JS::Object container) -> void
+    def self.render: (VNode vnode, JS::Element container) -> void
     def self.diff: (VNode? old_vnode, VNode? new_vnode) -> Array[patch_t]
     def self.patch: (JS::Object element, Array[patch_t] patches) -> JS::Object
 

--- a/test/vdom_differ_test.rb
+++ b/test/vdom_differ_test.rb
@@ -149,8 +149,8 @@ class VDOMDifferTest < Picotest::Test
       Funicular::VDOM::Element.new('li', {key: 'a', class: 'first'})
     ])
     patches = @differ.diff(old_element, new_element)
-    # No patches should be generated since the elements themselves haven't changed
-    # (just their positions, which will be handled by remove+insert)
+    # No content changes (just position swap) means no patches.
+    # Reorder-only is not considered a change in the current implementation.
     assert_equal([], patches)
   end
 
@@ -166,9 +166,23 @@ class VDOMDifferTest < Picotest::Test
     ])
     patches = @differ.diff(old_element, new_element)
     assert_equal(1, patches.length)
-    assert_equal(1, patches[0][0]) # Child index 1 (where 'c' should be inserted)
-    new_c = new_element.children[1]
-    assert_equal([[:replace, new_c, nil]], patches[0][1])
+    assert_equal(:keyed_children, patches[0][0])
+    ops = patches[0][1]
+    removes = patches[0][2]
+    # 'a' kept at index 0
+    assert_equal(:keep, ops[0][0])
+    assert_equal(0, ops[0][1]) # old_index
+    assert_equal(0, ops[0][2]) # new_index
+    # 'c' inserted at new_index 1
+    assert_equal(:insert, ops[1][0])
+    assert_equal(1, ops[1][1]) # new_index
+    assert_equal('c', ops[1][2].key)
+    # 'b' kept (old_index=1 -> new_index=2)
+    assert_equal(:keep, ops[2][0])
+    assert_equal(1, ops[2][1]) # old_index
+    assert_equal(2, ops[2][2]) # new_index
+    # No removes
+    assert_equal([], removes)
   end
 
   def test_diff_children_with_keys_element_removed
@@ -183,9 +197,21 @@ class VDOMDifferTest < Picotest::Test
     ])
     patches = @differ.diff(old_element, new_element)
     assert_equal(1, patches.length)
-    assert_equal(1, patches[0][0]) # Child index 1 (where 'b' was)
-    old_b = old_element.children[1]
-    assert_equal([[:remove, old_b]], patches[0][1])
+    assert_equal(:keyed_children, patches[0][0])
+    ops = patches[0][1]
+    removes = patches[0][2]
+    # 'a' kept at old_index=0 -> new_index=0
+    assert_equal(:keep, ops[0][0])
+    assert_equal(0, ops[0][1])
+    assert_equal(0, ops[0][2])
+    # 'c' kept at old_index=2 -> new_index=1
+    assert_equal(:keep, ops[1][0])
+    assert_equal(2, ops[1][1])
+    assert_equal(1, ops[1][2])
+    # 'b' (old_index=1) removed
+    assert_equal(1, removes.length)
+    assert_equal(1, removes[0][0]) # old_index
+    assert_equal('b', removes[0][1].key)
   end
 
   def test_diff_children_with_keys_element_props_changed
@@ -199,8 +225,16 @@ class VDOMDifferTest < Picotest::Test
     ])
     patches = @differ.diff(old_element, new_element)
     assert_equal(1, patches.length)
-    assert_equal(0, patches[0][0]) # Child index 0
-    assert_equal([[:props, {class: 'baz'}]], patches[0][1])
+    assert_equal(:keyed_children, patches[0][0])
+    ops = patches[0][1]
+    # 'a' kept with props change
+    assert_equal(:keep, ops[0][0])
+    assert_equal(0, ops[0][1]) # old_index
+    assert_equal(0, ops[0][2]) # new_index
+    assert_equal([[:props, {class: 'baz'}]], ops[0][3]) # child_patches
+    # 'b' kept with no change
+    assert_equal(:keep, ops[1][0])
+    assert_equal([], ops[1][3])
   end
 
   def test_diff_children_with_keys_mixed_with_without_keys
@@ -213,10 +247,17 @@ class VDOMDifferTest < Picotest::Test
       Funicular::VDOM::Element.new('p') # No key, different tag
     ])
     patches = @differ.diff(old_element, new_element)
-    # Should detect that child index 1 changed from span to p
+    # Should detect change in unkeyed child at index 1
     assert_equal(1, patches.length)
-    assert_equal(1, patches[0][0])
-    assert_equal([[:replace, new_element.children[1], old_element.children[1]]], patches[0][1])
+    assert_equal(:keyed_children, patches[0][0])
+    ops = patches[0][1]
+    # 'a' kept
+    assert_equal(:keep, ops[0][0])
+    # unkeyed span->p triggers replace inside keep
+    assert_equal(:keep, ops[1][0])
+    assert_equal(1, ops[1][1]) # old_index
+    assert_equal(1, ops[1][2]) # new_index
+    assert_equal([[:replace, new_element.children[1], old_element.children[1]]], ops[1][3])
   end
 
   # Component diff tests

--- a/test/vdom_patcher_test.rb
+++ b/test/vdom_patcher_test.rb
@@ -2,6 +2,8 @@
 module JS
   class Object
   end
+  class Element < Object
+  end
 end
 
 class VDOMPatcherTest < Picotest::Test
@@ -74,6 +76,21 @@ class VDOMPatcherTest < Picotest::Test
       new_child
     end
 
+    def insertBefore(new_child, ref_child)
+      if ref_child.nil?
+        @children << new_child
+      else
+        index = @children.index(ref_child)
+        if index
+          @children.insert(index, new_child)
+        else
+          @children << new_child
+        end
+      end
+      new_child.parent_element = self if new_child.respond_to?(:parent_element=)
+      new_child
+    end
+
     def [](key)
       case key.to_s
       when 'tagName'
@@ -94,9 +111,11 @@ class VDOMPatcherTest < Picotest::Test
     end
 
     def is_a?(klass)
-      # Mock JS::Object check
-      if klass.to_s == 'JS::Object'
-        false # We're not actually a JS::Object
+      # Mock JS::Element check for patcher compatibility
+      if klass == JS::Element
+        true
+      elsif klass.to_s == 'JS::Object'
+        true
       else
         super
       end


### PR DESCRIPTION
This pull request introduces a response cache for HTTP GET requests, improves documentation for the data fetching and Rails integration layers, and makes several robustness improvements to state normalization and DOM patching. It also updates the file compilation order to support a new `stores/` directory and adds a dependency on `picoruby-indexeddb`. The most important changes are summarized below.

---

### HTTP Response Caching

* Added an opt-in response cache for GET requests in `Funicular::HTTP`, using IndexedDB with in-memory fallback. Includes cache TTL, explicit invalidation methods, and integration with the HTTP API. [[1]](diffhunk://#diff-82a887f0b4e413e7ed3f940c015278b2d3ddee5adbfd4a9fc104a38424a59527R3-R7) [[2]](diffhunk://#diff-82a887f0b4e413e7ed3f940c015278b2d3ddee5adbfd4a9fc104a38424a59527L24-R95) [[3]](diffhunk://#diff-82a887f0b4e413e7ed3f940c015278b2d3ddee5adbfd4a9fc104a38424a59527L49-R145) [[4]](diffhunk://#diff-82a887f0b4e413e7ed3f940c015278b2d3ddee5adbfd4a9fc104a38424a59527R169-R183)
* Updated documentation in `docs/data-fetching.md` to describe the response cache, its usage, and invalidation patterns. [[1]](diffhunk://#diff-301a2998dd7e5ac817d73935d870810d96b51411a60a5be855aed24289ba5557R8) [[2]](diffhunk://#diff-301a2998dd7e5ac817d73935d870810d96b51411a60a5be855aed24289ba5557R85-R118)
* Added `picoruby-indexeddb` as a dependency in `mrbgem.rake` to support the cache backend.

### Rails Integration & Compilation

* Introduced a `stores/` directory for state management, updated documentation and file concatenation order to ensure stores are loaded after models and before components. [[1]](diffhunk://#diff-00c3d12fca7bc97b45e5a5173678ac00da75a48e72d78212ffb79ae7d427c051R153-R161) [[2]](diffhunk://#diff-00c3d12fca7bc97b45e5a5173678ac00da75a48e72d78212ffb79ae7d427c051L232-R240) [[3]](diffhunk://#diff-3ea85bedbc40007354a37aeac4edb8d5d8e1f775c35e1e620e36ba5a6147c5f2R70-R76)

### Robustness & Correctness

* Improved state normalization in `mrblib/component.rb` to better handle JS objects and Ruby collections for storage.
* Fixed root DOM element assignment in `re_render` to ensure type safety.
* Improved error handling for localStorage access in `mrblib/cable.rb` to avoid JS errors in restricted environments. [[1]](diffhunk://#diff-11c045ce4afd142595f0fdb0502ff7fcbacb96bcd3f4a0a5c229ac80dca8437cL236-R237) [[2]](diffhunk://#diff-11c045ce4afd142595f0fdb0502ff7fcbacb96bcd3f4a0a5c229ac80dca8437cL245-R249) [[3]](diffhunk://#diff-11c045ce4afd142595f0fdb0502ff7fcbacb96bcd3f4a0a5c229ac80dca8437cL260-R260)
* Stricter check for container element existence in `Funicular.start`.

### Virtual DOM Diffing

* Refactored keyed children diffing in `mrblib/differ.rb` to produce a single composite patch, preventing DOM corruption in edge cases and improving patch application order. [[1]](diffhunk://#diff-b68feb67617b3a4f7fc3f2a036003538bcd6c0c969082cccdb0e758436db0223R93-L95) [[2]](diffhunk://#diff-b68feb67617b3a4f7fc3f2a036003538bcd6c0c969082cccdb0e758436db0223L104-R169)

### Testing & Documentation

* Added a new "Testing" section to `README.md` with instructions for both CRubyGem and PicoGem test runs.