### PR TITLE
SSR and Hydration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 # but are not tracked here.
 /lib/funicular/vendor/picoruby/
 /lib/funicular/vendor/picorbc/
+private_docs/

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Then, dig [docs/](docs/):
 - [Forms](docs/forms.md)
 - [Styling](docs/styling.md)
 - [Realtime (ActionCable)](docs/realtime.md)
+- [Server-Side Rendering (SSR) and Hydration](docs/ssr.md)
 - [Client-Side Stores](docs/stores.md) — IndexedDB-backed caching with DSL
 - [Advanced Features](docs/advanced-features.md)
 - [Rails Integration](docs/rails-integration.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -405,12 +405,12 @@ end
 
 - Rails applications with SPA features
 - Small to medium SPAs (dashboards, admin panels, chat apps)
+- Content pages needing SEO and a fast first paint (via SSR + hydration; see [ssr.md](ssr.md))
 - Ruby teams doing frontend development
 - Rapid prototyping of interactive UIs
 
 ### Not Ideal For
 
-- SEO-critical applications (no SSR support for now, but planning...)
 - Large-scale SPAs with complex state management needs
 - Performance-critical applications (WebAssembly overhead)
 - Mobile applications (use React Native or native solutions)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -176,11 +176,14 @@ end
 | Mode | Description | Funicular Support |
 |------|-------------|-------------------|
 | **CSR** | Render in browser | ✅ Yes |
-| SSR | Server-side rendering | ❌ No (for now...) |
+| **SSR + hydration** | Render HTML on the Rails server, hydrate in the browser | ✅ Yes |
 | SSG | Static site generation | ❌ No |
 | ISR | Incremental static regen | ❌ No |
 
-**Reason**: PicoRuby.wasm runs only in browsers. Rails serves JSON APIs + assets.
+**How SSR works**: the same component classes run under CRuby on the Rails
+server (the mrblib runtime is loaded into the Rails process) and their VDOM is
+serialized to an HTML string by `VDOM::HTMLSerializer`. The browser then
+hydrates that markup instead of rebuilding it. See [Server-Side Rendering](ssr.md).
 
 ### 8. Template System
 
@@ -378,7 +381,9 @@ state.messages.map { |msg| div(key: msg.id) { msg.content } }
 
 ### Limitations
 
-❌ **No SSR**: PicoRuby.wasm is browser-only (for now...)
+⚠️ **SSR is v1**: server-side rendering + hydration works (see [ssr.md](ssr.md)),
+but currently serializes a single state payload for the top routed component
+and injects data as plain hashes rather than via the Model layer.
 
 ❌ **No npm Ecosystem**: Limited to Ruby gems
 

--- a/docs/ssr.md
+++ b/docs/ssr.md
@@ -1,36 +1,21 @@
 # Server-Side Rendering (SSR) and Hydration
 
-Funicular can render your components to HTML on the Rails server and then
-hydrate that markup in the browser. The same component classes run on both
-sides: on the server under CRuby, and in the browser under PicoRuby.wasm.
+Funicular can render your components to HTML on the Rails server and then hydrate that markup in the browser. The same component classes run on both sides: on the server under CRuby, and in the browser under PicoRuby.wasm.
 
-This gives you a fast first paint and SEO-friendly, data-filled HTML for public
-pages, while keeping the full single-page application experience after the page
-loads.
+This gives you a fast first paint and SEO-friendly, data-filled HTML for public pages, while keeping the full single-page application experience after the page loads.
 
 ## How it works
 
-1. The Funicular runtime (the `mrblib/` framework code) is loaded into your
-   Rails process. It is plain Ruby; the few methods that touch the browser
-   (DOM patching, `fetch`, History API, IndexedDB) are never called on the
-   server because `Funicular.server?` is true there.
-2. `Funicular::SSR.render` resolves the request path to a component using the
-   routes you defined in `app/funicular/initializer.rb`, builds its VDOM, and
-   serializes it to an HTML string with `Funicular::VDOM::HTMLSerializer`.
-3. The server injects data into the component's state and also embeds the same
-   state as `window.__FUNICULAR_STATE__`.
-4. In the browser, `Funicular.start` detects the embedded state and hydrates
-   the server HTML: it rebuilds the VDOM from the same state, attaches event
-   listeners and refs to the existing DOM nodes, and then behaves like a normal
-   SPA. No DOM is rebuilt.
+1. The Funicular runtime (the `mrblib/` framework code) is loaded into your Rails process. It is plain Ruby; the few methods that touch the browser (DOM patching, `fetch`, History API, IndexedDB) are never called on the server because `Funicular.server?` is true there.
+2. `Funicular::SSR.render` resolves the request path to a component using the routes you defined in `app/funicular/initializer.rb`, builds its VDOM, and serializes it to an HTML string with `Funicular::VDOM::HTMLSerializer`.
+3. The server injects data into the component's state and also embeds the same state as `window.__FUNICULAR_STATE__`.
+4. In the browser, `Funicular.start` detects the embedded state and hydrates the server HTML: it rebuilds the VDOM from the same state, attaches event listeners and refs to the existing DOM nodes, and then behaves like a normal SPA. No DOM is rebuilt.
 
-Event handlers (`onclick`, `oninput`, ...) are not serialized; they are Procs
-that are re-bound during hydration.
+Event handlers (`onclick`, `oninput`, ...) are not serialized; they are Procs that are re-bound during hydration.
 
 ## Writing an isomorphic component
 
-A component that supports SSR should render from its `state`, and only fetch
-data on mount when that state is missing:
+A component that supports SSR should render from its `state`, and only fetch data on mount when that state is missing:
 
 ```ruby
 class ChannelIndexComponent < Funicular::Component
@@ -55,14 +40,11 @@ class ChannelIndexComponent < Funicular::Component
 end
 ```
 
-The top routed component owns the data in its state and passes it to children
-as `props`. Nested components are rendered in the same server pass, so they do
-not need their own serialized state.
+The top routed component owns the data in its state and passes it to children as `props`. Nested components are rendered in the same server pass, so they do not need their own serialized state.
 
 ## Server side (Rails)
 
-In a controller, call `Funicular::SSR.render` and pass the data you want to
-inject as `state`:
+In a controller, call `Funicular::SSR.render` and pass the data you want to inject as `state`:
 
 ```ruby
 class HomeController < ApplicationController
@@ -85,9 +67,7 @@ class HomeController < ApplicationController
 end
 ```
 
-In the view, place the rendered HTML inside the `#app` container and embed the
-state. When `@ssr` is absent, the container is empty and the client renders
-from scratch (plain CSR):
+In the view, place the rendered HTML inside the `#app` container and embed the state. When `@ssr` is absent, the container is empty and the client renders from scratch (plain CSR):
 
 ```erb
 <%= funicular_app_container(@ssr ? @ssr[:html] : "") %>
@@ -98,24 +78,16 @@ from scratch (plain CSR):
 <script type="application/x-mrb" src="<%= asset_path('app.mrb') %>"></script>
 ```
 
-`Funicular::SSR.render` returns `{ html:, state:, component: }`. When no route
-matches the path, `html` is `""` so the page falls back to client-side
-rendering.
+`Funicular::SSR.render` returns `{ html:, state:, component: }`. When no route matches the path, `html` is `""` so the page falls back to client-side rendering.
 
 ## Client side
 
-No extra code is needed. `Funicular.start` automatically hydrates when
-`window.__FUNICULAR_STATE__` is present; otherwise it mounts normally. If the
-server and client markup disagree (for example, a nondeterministic render), a
-warning is logged and Funicular falls back to a full client render.
+No extra code is needed. `Funicular.start` automatically hydrates when `window.__FUNICULAR_STATE__` is present; otherwise it mounts normally. If the server and client markup disagree (for example, a nondeterministic render), a warning is logged and Funicular falls back to a full client render.
 
-For determinism, avoid `Time.now`, randomness, or any value that differs
-between server and client inside `render`.
+For determinism, avoid `Time.now`, randomness, or any value that differs between server and client inside `render`.
 
 ## Current limitations (v1)
 
-- A single state payload is serialized, for the top routed component. Child
-  components derive their data from props or fetch it on mount.
-- Server-side data is injected as plain hashes; the `Model` layer is not used
-  to fetch data on the server.
+- A single state payload is serialized, for the top routed component. Child components derive their data from props or fetch it on mount.
+- Server-side data is injected as plain hashes; the `Model` layer is not used to fetch data on the server.
 - Suspense renders its resolved/empty branch on the server (no timers).

--- a/docs/ssr.md
+++ b/docs/ssr.md
@@ -42,6 +42,46 @@ end
 
 The top routed component owns the data in its state and passes it to children as `props`. Nested components are rendered in the same server pass, so they do not need their own serialized state.
 
+### Keep the data shape identical on both sides
+
+The server and client must build the same VDOM, so the data your `render` reads has to look the same in both places:
+
+- **Use string keys for injected nested data.** Top-level state keys are symbolized (so `state.channels` works), but nested hashes are read with string keys (`ch["id"]`). The client receives the injected state through `JSON.parse`, which always produces string keys, so the server must inject string-keyed hashes too. Build them explicitly (e.g. `{ "id" => c.id, "name" => c.name }`) rather than relying on symbol keys.
+- **Normalize fetched models to that same shape.** When `component_mounted` fetches via a `Model` on the client-only path, convert the returned instances into the same string-keyed hashes the server injects, so `render` reads them the same way:
+
+  ```ruby
+  def component_mounted
+    return unless state.posts.empty?
+    Post.all { |posts, _| patch(posts: posts.map { |p| post_to_h(p) }) }
+  end
+
+  def post_to_h(post)
+    { "id" => post.id, "title" => post.title }
+  end
+  ```
+
+### Interactive and login-gated components
+
+Components built with `form_for` (and the rest of the rendering DSL) render on the server too, then hydrate into working forms. Because the server controller knows who is signed in, you can inject that into the state and branch on it, so the same markup renders on both sides with no hydration mismatch:
+
+```ruby
+def render
+  # ... article / comments rendered from injected state ...
+  if state.current_user
+    form_for(:comment, on_submit: :handle_submit) do |f|
+      f.textarea :body
+      f.submit "Post comment"
+    end
+  else
+    link_to "/login", navigate: true do
+      span { "Log in to comment" }
+    end
+  end
+end
+```
+
+Event handlers are not serialized, so the server emits the form's static markup and the client binds the submit/input handlers during hydration.
+
 ## Server side (Rails)
 
 In a controller, call `Funicular::SSR.render` and pass the data you want to inject as `state`:
@@ -79,6 +119,8 @@ In the view, place the rendered HTML inside the `#app` container and embed the s
 ```
 
 `Funicular::SSR.render` returns `{ html:, state:, component: }`. When no route matches the path, `html` is `""` so the page falls back to client-side rendering.
+
+The SSR markup lives inside `#app`, so page-level SEO tags are plain Rails: set `<title>` and a `<meta name="description">` from the controller (for example, the post title for a `/blog/:id` page) in your layout/view as usual. The server-rendered, data-filled `#app` content is what search engines index.
 
 ## Client side
 

--- a/docs/ssr.md
+++ b/docs/ssr.md
@@ -82,7 +82,9 @@ In the view, place the rendered HTML inside the `#app` container and embed the s
 
 ## Client side
 
-No extra code is needed. `Funicular.start` automatically hydrates when `window.__FUNICULAR_STATE__` is present; otherwise it mounts normally. If the server and client markup disagree (for example, a nondeterministic render), a warning is logged and Funicular falls back to a full client render.
+No extra code is needed. `Funicular.start` automatically hydrates when `window.__FUNICULAR_STATE__` is present; otherwise it mounts normally.
+
+Before hydrating, Funicular does a lightweight structural check: the root tag of the freshly built VDOM must match the server-rendered element. If they disagree (for example, from a nondeterministic render or stale state), Funicular logs a warning in development and recovers by rendering a fresh DOM tree and swapping it in for the server markup. The page stays usable; only the first-paint reuse is lost for that subtree, and the warning is silent in production.
 
 For determinism, avoid `Time.now`, randomness, or any value that differs between server and client inside `render`.
 
@@ -91,3 +93,4 @@ For determinism, avoid `Time.now`, randomness, or any value that differs between
 - A single state payload is serialized, for the top routed component. Child components derive their data from props or fetch it on mount.
 - Server-side data is injected as plain hashes; the `Model` layer is not used to fetch data on the server.
 - Suspense renders its resolved/empty branch on the server (no timers).
+- The hydration mismatch check compares only the root element tag of each component. Deeper structural mismatches inside a matching root are not detected; the full-render fallback covers the common root-level case.

--- a/docs/ssr.md
+++ b/docs/ssr.md
@@ -1,0 +1,121 @@
+# Server-Side Rendering (SSR) and Hydration
+
+Funicular can render your components to HTML on the Rails server and then
+hydrate that markup in the browser. The same component classes run on both
+sides: on the server under CRuby, and in the browser under PicoRuby.wasm.
+
+This gives you a fast first paint and SEO-friendly, data-filled HTML for public
+pages, while keeping the full single-page application experience after the page
+loads.
+
+## How it works
+
+1. The Funicular runtime (the `mrblib/` framework code) is loaded into your
+   Rails process. It is plain Ruby; the few methods that touch the browser
+   (DOM patching, `fetch`, History API, IndexedDB) are never called on the
+   server because `Funicular.server?` is true there.
+2. `Funicular::SSR.render` resolves the request path to a component using the
+   routes you defined in `app/funicular/initializer.rb`, builds its VDOM, and
+   serializes it to an HTML string with `Funicular::VDOM::HTMLSerializer`.
+3. The server injects data into the component's state and also embeds the same
+   state as `window.__FUNICULAR_STATE__`.
+4. In the browser, `Funicular.start` detects the embedded state and hydrates
+   the server HTML: it rebuilds the VDOM from the same state, attaches event
+   listeners and refs to the existing DOM nodes, and then behaves like a normal
+   SPA. No DOM is rebuilt.
+
+Event handlers (`onclick`, `oninput`, ...) are not serialized; they are Procs
+that are re-bound during hydration.
+
+## Writing an isomorphic component
+
+A component that supports SSR should render from its `state`, and only fetch
+data on mount when that state is missing:
+
+```ruby
+class ChannelIndexComponent < Funicular::Component
+  def initialize_state
+    { channels: [] }
+  end
+
+  def component_mounted
+    # Client-only fallback: if the server did not inject channels, fetch them.
+    Channel.all { |channels, _| patch(channels: channels.map(&:as_json)) } if state.channels.empty?
+  end
+
+  def render
+    div do
+      state.channels.each do |ch|
+        link_to "/chat/#{ch["id"]}", navigate: true, key: ch["id"] do
+          div { "# #{ch["name"]}" }
+        end
+      end
+    end
+  end
+end
+```
+
+The top routed component owns the data in its state and passes it to children
+as `props`. Nested components are rendered in the same server pass, so they do
+not need their own serialized state.
+
+## Server side (Rails)
+
+In a controller, call `Funicular::SSR.render` and pass the data you want to
+inject as `state`:
+
+```ruby
+class HomeController < ApplicationController
+  def index
+    if request.path == "/explore"
+      @ssr = Funicular::SSR.render(
+        path: "/explore",
+        state: { channels: explore_channels }
+      )
+    end
+  end
+
+  private
+
+  def explore_channels
+    Channel.order(:name).map do |c|
+      { "id" => c.id, "name" => c.name, "description" => c.description }
+    end
+  end
+end
+```
+
+In the view, place the rendered HTML inside the `#app` container and embed the
+state. When `@ssr` is absent, the container is empty and the client renders
+from scratch (plain CSR):
+
+```erb
+<%= funicular_app_container(@ssr ? @ssr[:html] : "") %>
+<% if @ssr %>
+  <%= funicular_state_tag(@ssr[:state]) %>
+<% end %>
+
+<script type="application/x-mrb" src="<%= asset_path('app.mrb') %>"></script>
+```
+
+`Funicular::SSR.render` returns `{ html:, state:, component: }`. When no route
+matches the path, `html` is `""` so the page falls back to client-side
+rendering.
+
+## Client side
+
+No extra code is needed. `Funicular.start` automatically hydrates when
+`window.__FUNICULAR_STATE__` is present; otherwise it mounts normally. If the
+server and client markup disagree (for example, a nondeterministic render), a
+warning is logged and Funicular falls back to a full client render.
+
+For determinism, avoid `Time.now`, randomness, or any value that differs
+between server and client inside `render`.
+
+## Current limitations (v1)
+
+- A single state payload is serialized, for the top routed component. Child
+  components derive their data from props or fetch it on mount.
+- Server-side data is injected as plain hashes; the `Model` layer is not used
+  to fetch data on the server.
+- Suspense renders its resolved/empty branch on the server (no timers).

--- a/lib/funicular.rb
+++ b/lib/funicular.rb
@@ -3,6 +3,7 @@
 require_relative "funicular/version"
 require_relative "funicular/configuration"
 require_relative "funicular/compiler"
+require_relative "funicular/ssr"
 
 module Funicular
   class Error < StandardError; end

--- a/lib/funicular/compiler.rb
+++ b/lib/funicular/compiler.rb
@@ -11,6 +11,20 @@ module Funicular
     PICORBC_DIR = File.expand_path("vendor/picorbc", __dir__)
     PICORBC_JS  = File.join(PICORBC_DIR, "picorbc.js")
 
+    # Ordered list of application source files under app/funicular/.
+    # Order matters: models -> stores -> components -> initializer, so that
+    # later files can reference classes defined earlier. Shared by the .mrb
+    # compiler (client build) and the SSR runtime (server class loading).
+    def self.source_files(source_dir)
+      models_files = Dir.glob(File.join(source_dir, "models", "**", "*.rb")).sort
+      stores_files = Dir.glob(File.join(source_dir, "stores", "**", "*.rb")).sort
+      components_files = Dir.glob(File.join(source_dir, "components", "**", "*.rb")).sort
+      initializer_files = Dir.glob(File.join(source_dir, "*_initializer.rb")).sort +
+                          Dir.glob(File.join(source_dir, "initializer.rb")).sort
+
+      models_files + stores_files + components_files + initializer_files
+    end
+
     attr_reader :source_dir, :output_file, :debug_mode, :logger
 
     def initialize(source_dir:, output_file:, debug_mode: false, logger: nil)
@@ -66,14 +80,7 @@ module Funicular
     end
 
     def gather_source_files
-      models_files = Dir.glob(File.join(source_dir, "models", "**", "*.rb")).sort
-      stores_files = Dir.glob(File.join(source_dir, "stores", "**", "*.rb")).sort
-      components_files = Dir.glob(File.join(source_dir, "components", "**", "*.rb")).sort
-      initializer_files = Dir.glob(File.join(source_dir, "*_initializer.rb")).sort +
-                          Dir.glob(File.join(source_dir, "initializer.rb")).sort
-
-      # Order: models -> stores -> components -> initializer
-      all_files = models_files + stores_files + components_files + initializer_files
+      all_files = self.class.source_files(source_dir)
 
       if all_files.empty?
         raise "No Ruby files found in #{source_dir}"

--- a/lib/funicular/compiler.rb
+++ b/lib/funicular/compiler.rb
@@ -92,8 +92,6 @@ module Funicular
     def log(message)
       if logger
         logger.info(message)
-        # Also output to stdout so logs are visible in terminal during development
-        puts message if debug_mode
       else
         puts message
       end

--- a/lib/funicular/helpers/picoruby_helper.rb
+++ b/lib/funicular/helpers/picoruby_helper.rb
@@ -27,6 +27,31 @@ module Funicular
         tag.script("", src: src, **options)
       end
 
+      # Renders the SSR #app container with the server-rendered HTML inside.
+      #
+      #   <%= funicular_app_container(@ssr[:html]) %>
+      #
+      # On the client, Funicular hydrates this element instead of rebuilding
+      # it. Pass an empty string (the default) to fall back to plain CSR.
+      def funicular_app_container(html = "", id: "app", **options)
+        content_tag(:div, raw(html.to_s), { id: id }.merge(options))
+      end
+
+      # Emits the initial state for client hydration as a global JS variable.
+      #
+      #   <%= funicular_state_tag(@ssr[:state]) %>
+      #   # => <script>window.__FUNICULAR_STATE__ = {...};</script>
+      #
+      # The JSON is escaped so it cannot break out of the <script> element.
+      def funicular_state_tag(state = {})
+        json = JSON.generate(state || {})
+        # Escape characters that could break out of the <script> element or
+        # confuse the HTML parser, using JS unicode escapes that remain valid
+        # JSON/JS string content.
+        safe = json.gsub("<", "\\u003c").gsub(">", "\\u003e").gsub("&", "\\u0026")
+        raw("<script>window.__FUNICULAR_STATE__ = #{safe};</script>")
+      end
+
       private
 
       def picoruby_src_for(source)

--- a/lib/funicular/ssr.rb
+++ b/lib/funicular/ssr.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require_relative "ssr/runtime"
+
+module Funicular
+  # Server-side rendering entry point.
+  #
+  # Usage (typically from a Rails controller / view helper):
+  #
+  #   result = Funicular::SSR.render(
+  #     path: request.path,
+  #     state: { channels: Channel.all.as_json }
+  #   )
+  #   # result[:html]  -> HTML string for the #app container
+  #   # result[:state] -> data to embed as window.__FUNICULAR_STATE__
+  #
+  module SSR
+    # Render the component mapped to `path` to an HTML string, seeding it with
+    # server-provided `state`. Returns a hash:
+    #   { html:, state:, component: }
+    # When no route matches, html is "" so the caller can fall back to plain
+    # client-side rendering (empty #app container).
+    def self.render(path:, state: {}, props: {}, source_dir: nil)
+      Runtime.boot!(source_dir || default_source_dir)
+
+      router = Funicular.router
+      raise "Funicular router is not configured; check app/funicular/initializer.rb" unless router
+
+      component_class, params = router.match(path)
+      return { html: "", state: {}, component: nil } unless component_class
+
+      instance = component_class.new(symbolize_keys(params).merge(props))
+      instance.seed_state(state)
+      html = Funicular::VDOM::HTMLSerializer.serialize(instance.build_vdom)
+
+      { html: html, state: state, component: component_class }
+    end
+
+    def self.default_source_dir
+      raise "source_dir is required outside Rails" unless defined?(Rails) && Rails.respond_to?(:root)
+      Rails.root.join("app", "funicular")
+    end
+
+    def self.symbolize_keys(hash)
+      return {} unless hash
+      out = {}
+      hash.each { |k, v| out[k.to_sym] = v }
+      out
+    end
+  end
+end

--- a/lib/funicular/ssr/runtime.rb
+++ b/lib/funicular/ssr/runtime.rb
@@ -58,13 +58,29 @@ module Funicular
         # canonical order. Running the initializer registers routes into
         # Funicular.router (server-safe: Funicular.start skips all DOM work).
         #
+        # Funicular model files are loaded so that the constants they define
+        # (e.g. Channel, Session) are available when the initializer evaluates
+        # `load_schemas({ Channel => "channel", ... })`. If a Funicular model
+        # shares a name with a same-named ActiveRecord model that Rails has
+        # already auto-loaded, Ruby raises TypeError (superclass mismatch).
+        # In that case we rescue and continue: the AR constant is already defined
+        # and is all that load_schemas needs (it ignores the hash on the server).
+        #
         # Loaded once per process. Restart the server to pick up changes.
         def boot!(source_dir)
           load_framework!
           return if @app_loaded
 
           files = Funicular::Compiler.source_files(source_dir.to_s)
-          files.each { |file| Kernel.load(file) }
+          files.each do |file|
+            begin
+              Kernel.load(file)
+            rescue TypeError => e
+              # Funicular model name conflicts with an already-loaded AR model.
+              # The constant is already defined; safe to skip.
+              warn "[Funicular SSR] Skipped #{File.basename(file)}: #{e.message}"
+            end
+          end
           @app_loaded = true
         end
 

--- a/lib/funicular/ssr/runtime.rb
+++ b/lib/funicular/ssr/runtime.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require "json"
+require_relative "../compiler"
+
+module Funicular
+  module SSR
+    # Loads the PicoRuby (mrblib) framework runtime and the application's
+    # component classes into the CRuby process so the server can build VDOM
+    # and serialize it to HTML.
+    #
+    # The mrblib runtime is plain Ruby; the only JS access happens inside
+    # methods that SSR never calls (mount, patcher, fetch, history, ...).
+    # `Funicular.server = true` makes the few JS-touching entry points
+    # (Funicular.start, Router#start, FileUpload.mount, Debug) no-ops.
+    module Runtime
+      MRBLIB_DIR = File.expand_path("../../../mrblib", __dir__)
+
+      # Load order is by dependency at *class-body* evaluation time. Most
+      # files reference JS / other classes only inside methods, so only a
+      # few real dependencies exist (vdom before html_serializer; styles and
+      # vdom before component; component before error_boundary).
+      LOAD_ORDER = %w[
+        environment_inquirer
+        vdom
+        html_serializer
+        differ
+        patcher
+        styles
+        debug
+        component
+        error_boundary
+        router
+        model
+        store
+        store_singleton
+        store_collection
+        form_builder
+        http
+        cable
+        file_upload
+        funicular
+      ].freeze
+
+      class << self
+        # Load the framework runtime once. Idempotent.
+        def load_framework!
+          return if @framework_loaded
+
+          LOAD_ORDER.each do |name|
+            require File.join(MRBLIB_DIR, "#{name}.rb")
+          end
+          Funicular.server = true
+          @framework_loaded = true
+        end
+
+        # Load the application's component/model/store/initializer files in the
+        # canonical order. Running the initializer registers routes into
+        # Funicular.router (server-safe: Funicular.start skips all DOM work).
+        #
+        # Loaded once per process. Restart the server to pick up changes.
+        def boot!(source_dir)
+          load_framework!
+          return if @app_loaded
+
+          files = Funicular::Compiler.source_files(source_dir.to_s)
+          files.each { |file| Kernel.load(file) }
+          @app_loaded = true
+        end
+
+        # Test/escape hatch: forget loaded application state so a different
+        # app (or a reload) can be booted. Does not unload the framework.
+        def reset_app!
+          @app_loaded = false
+        end
+
+        def framework_loaded?
+          !!@framework_loaded
+        end
+      end
+    end
+  end
+end

--- a/minitest/fixtures/funicular_app/components/greeting_component.rb
+++ b/minitest/fixtures/funicular_app/components/greeting_component.rb
@@ -1,0 +1,16 @@
+class GreetingComponent < Funicular::Component
+  def initialize_state
+    { title: "Default Title", items: [] }
+  end
+
+  def render
+    div(class: "greeting") do
+      h1 { state.title }
+      ul do
+        state.items.each do |item|
+          li(key: item["id"]) { item["name"] }
+        end
+      end
+    end
+  end
+end

--- a/minitest/fixtures/funicular_app/initializer.rb
+++ b/minitest/fixtures/funicular_app/initializer.rb
@@ -1,0 +1,5 @@
+Funicular.start(container: "app") do |router|
+  router.get("/greet", to: GreetingComponent, as: "greet")
+  router.get("/greet/:id", to: GreetingComponent, as: "greet_item")
+  router.set_default("/greet")
+end

--- a/minitest/hydration_test.rb
+++ b/minitest/hydration_test.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# Exercises the hydration mismatch guard under CRuby. The structural decision
+# (`hydration_match?`) and the dev warning (`warn_hydration_mismatch`) are pure
+# Ruby, so they are tested here without a DOM. The actual recovery swap done by
+# `full_render_fallback` (Renderer + replaceChild) is JS-only and is covered by
+# the browser/manual verification step, not here.
+#
+# A plain Hash stands in for the server DOM node: hydration_match? only reads
+# `dom_element[:tagName]`, which a Hash answers the same way a JS::Element does.
+class HydrationMatchTest < Minitest::Test
+  def setup
+    Funicular::SSR::Runtime.load_framework!
+    Funicular.env = "development"
+  end
+
+  def teardown
+    Funicular.env = "development"
+  end
+
+  # Builds the probe at runtime (Class.new) so the suite matches its picotest
+  # twin and never references Funicular::Component at load time. render is never
+  # invoked here (we feed vnodes directly); it only satisfies the abstract API.
+  def probe
+    klass = Class.new(Funicular::Component) do
+      def render
+        div { "x" }
+      end
+
+      def match?(vnode, dom)
+        hydration_match?(vnode, dom)
+      end
+
+      def warn_for(vnode, dom)
+        warn_hydration_mismatch(vnode, dom)
+      end
+    end
+    klass.new
+  end
+
+  def el(tag)
+    Funicular::VDOM::Element.new(tag, {}, ["x"])
+  end
+
+  # --- hydration_match? (the decision that drives the fallback) ---------
+
+  def test_matches_when_root_tags_agree
+    assert_equal true, probe.match?(el("div"), { tagName: "DIV" })
+  end
+
+  def test_detects_mismatched_root_tag
+    assert_equal false, probe.match?(el("div"), { tagName: "SPAN" })
+  end
+
+  def test_tag_comparison_is_case_insensitive
+    assert_equal true, probe.match?(el("h1"), { tagName: "H1" })
+  end
+
+  def test_non_element_vnode_is_treated_as_match
+    assert_equal true, probe.match?(Funicular::VDOM::Text.new("hi"), { tagName: "DIV" })
+  end
+
+  def test_missing_dom_tag_name_is_treated_as_match
+    assert_equal true, probe.match?(el("div"), {})
+  end
+
+  # --- warn_hydration_mismatch (dev-only diagnostics) -------------------
+
+  def test_warning_fires_in_development
+    out, _err = capture_io do
+      probe.warn_for(el("div"), { tagName: "SPAN" })
+    end
+    assert_includes out, "Hydration mismatch"
+    assert_includes out, "<div>"
+    assert_includes out, "<span>"
+  end
+
+  def test_warning_is_silent_in_production
+    Funicular.env = "production"
+    out, _err = capture_io do
+      probe.warn_for(el("div"), { tagName: "SPAN" })
+    end
+    assert_equal "", out
+  end
+end

--- a/minitest/ssr_test.rb
+++ b/minitest/ssr_test.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# Exercises the SSR half of Funicular under CRuby: the shared HTMLSerializer
+# and the full path of loading the mrblib runtime + a fixture app, then
+# rendering a routed component to HTML with injected state.
+class SSRTest < Minitest::Test
+  APP_DIR = File.expand_path("fixtures/funicular_app", __dir__)
+
+  def setup
+    Funicular::SSR::Runtime.load_framework!
+  end
+
+  # --- HTMLSerializer (pure Ruby) ---------------------------------------
+
+  def serialize(vnode)
+    Funicular::VDOM::HTMLSerializer.serialize(vnode)
+  end
+
+  def el(tag, props = {}, children = [])
+    Funicular::VDOM::Element.new(tag, props, children)
+  end
+
+  def test_serializes_element_with_attributes
+    assert_equal '<div class="box" id="x"></div>',
+                 serialize(el("div", { class: "box", id: "x" }))
+  end
+
+  def test_escapes_text_content
+    assert_equal "<p>a &amp; b &lt;c&gt;</p>",
+                 serialize(el("p", {}, ["a & b <c>"]))
+  end
+
+  def test_escapes_attribute_values
+    assert_equal '<div title="&quot;hi&quot;"></div>',
+                 serialize(el("div", { title: '"hi"' }))
+  end
+
+  def test_skips_event_handlers
+    html = serialize(el("button", { onclick: :handle }, ["Go"]))
+    assert_equal "<button>Go</button>", html
+  end
+
+  def test_boolean_attribute_present_and_absent
+    assert_equal '<input disabled="disabled">',
+                 serialize(el("input", { disabled: true }))
+    assert_equal "<input>",
+                 serialize(el("input", { disabled: false }))
+  end
+
+  def test_void_element_self_closes
+    assert_equal "<br>", serialize(el("br"))
+    assert_equal '<img src="/a.png">', serialize(el("img", { src: "/a.png" }))
+  end
+
+  def test_blocks_javascript_uri
+    assert_equal "<a>x</a>",
+                 serialize(el("a", { href: "javascript:alert(1)" }, ["x"]))
+  end
+
+  # --- Full SSR render (runtime + fixture app) --------------------------
+
+  def test_render_injects_server_state
+    result = Funicular::SSR.render(
+      path: "/greet",
+      state: { title: "Channels", items: [{ "id" => 1, "name" => "general" },
+                                          { "id" => 2, "name" => "random" }] },
+      source_dir: APP_DIR
+    )
+
+    assert_includes result[:html], "<h1>Channels</h1>"
+    assert_includes result[:html], "general"
+    assert_includes result[:html], "random"
+    assert_equal GreetingComponent, result[:component]
+  end
+
+  def test_render_uses_initialize_state_without_injection
+    result = Funicular::SSR.render(path: "/greet", source_dir: APP_DIR)
+    assert_includes result[:html], "<h1>Default Title</h1>"
+  end
+
+  def test_render_unmatched_route_returns_empty
+    result = Funicular::SSR.render(path: "/no/such/path", source_dir: APP_DIR)
+    assert_equal "", result[:html]
+    assert_nil result[:component]
+  end
+
+  def test_route_params_become_props
+    # Renders without raising; :id from the path is passed as a prop.
+    result = Funicular::SSR.render(path: "/greet/42", source_dir: APP_DIR)
+    assert_includes result[:html], "greeting"
+  end
+end

--- a/mrblib/component.rb
+++ b/mrblib/component.rb
@@ -754,6 +754,13 @@ module Funicular
       br hr
     ]
 
+    # The HTML tag DSL methods are public: besides being called inside render
+    # (implicit self), they are invoked by collaborators such as FormBuilder
+    # with an explicit receiver (@component.div). A private method would forbid
+    # that under CRuby (it is tolerated under mruby), which would break SSR of
+    # any component using form_for. Keep them public on both VMs.
+    public
+
     HTML_TAGS.each do |tag|
       define_method(tag) do |props = {}, &block|
         # @type self: Component
@@ -795,6 +802,8 @@ module Funicular
         element
       end
     end
+
+    private
 
     # Helper to add children in DSL blocks
     def add_child(child)

--- a/mrblib/component.rb
+++ b/mrblib/component.rb
@@ -62,6 +62,25 @@ module Funicular
       {}
     end
 
+    # Merge externally provided state into the component before rendering.
+    # Used by SSR to inject server data, and by client hydration to restore
+    # the same state from window.__FUNICULAR_STATE__ so the first client
+    # render matches the server HTML. Top-level keys are symbolized so they
+    # are reachable via state.foo (StateAccessor uses symbol keys); nested
+    # values are left untouched (components read them with string keys).
+    def seed_state(state_hash)
+      return self if state_hash.nil?
+      return self if state_hash.respond_to?(:empty?) && state_hash.empty?
+
+      symbolized = {} #: Hash[Symbol, untyped]
+      state_hash.each do |key, value|
+        symbolized[key.to_sym] = value
+      end
+      @state = @state.merge(symbolized)
+      @state_accessor = nil
+      self
+    end
+
     # Load all registered suspense data
     # Called automatically in component_mounted if suspense definitions exist
     def load_suspense_data
@@ -289,6 +308,57 @@ module Funicular
         @child_components.each do |child|
           child.mounted = true
           child.component_mounted if child.respond_to?(:component_mounted)
+        end
+
+        component_mounted if respond_to?(:component_mounted)
+      rescue => e
+        component_raised(e) if respond_to?(:component_raised)
+        raise e
+      end
+    end
+
+    # Hydrate this component against server-rendered DOM.
+    #
+    # Unlike mount, which builds a fresh DOM tree via VDOM::Renderer, hydrate
+    # reuses the existing DOM produced by the server: it builds the VDOM,
+    # associates it with the existing nodes, and only attaches event listeners
+    # and refs (plus wiring child components). The first client render must
+    # match the server HTML, which is why state is seeded from
+    # window.__FUNICULAR_STATE__ before calling this.
+    def hydrate(dom_element)
+      return if @mounted
+      raise "hydrate: missing server DOM element" unless dom_element
+
+      begin
+        component_will_mount if respond_to?(:component_will_mount)
+
+        # The router/start sets the container; without it, unmount could not
+        # detach this subtree later. Derive it from the existing DOM.
+        @container ||= dom_element.parentNode
+        @dom_element = dom_element
+
+        new_vdom = build_vdom
+        check_hydration_match!(new_vdom, dom_element)
+
+        # Wire child components first so their instances exist for collection.
+        hydrate_child_components(new_vdom, dom_element)
+
+        # Reuse the same positional walks as mount: they skip Component vnodes
+        # (children manage their own events/refs during their own hydrate).
+        bind_events(dom_element, new_vdom)
+        collect_refs(dom_element, new_vdom)
+        collect_child_components(new_vdom)
+
+        @vdom = new_vdom
+        @mounted = true
+
+        load_suspense_data if self.class.suspense_definitions.any?
+
+        @child_components.each do |child|
+          unless child.mounted
+            child.mounted = true
+            child.component_mounted if child.respond_to?(:component_mounted)
+          end
         end
 
         component_mounted if respond_to?(:component_mounted)
@@ -582,6 +652,43 @@ module Funicular
         end
       else
         VDOM::Text.new(value.to_s)
+      end
+    end
+
+    # Lightweight structural check: the root tag of the freshly built VDOM
+    # must match the server-rendered element. A mismatch means server and
+    # client disagree (nondeterministic render or stale state); the caller
+    # falls back to a full client render.
+    def check_hydration_match!(vnode, dom_element)
+      return unless vnode.is_a?(VDOM::Element)
+      actual = dom_element[:tagName]
+      return unless actual  # non-element node; let later steps surface issues
+      expected = vnode.tag.to_s.downcase
+      got = actual.to_s.downcase
+      unless expected == got
+        raise "Hydration mismatch: expected <#{expected}>, found <#{got}>"
+      end
+    end
+
+    # Walk the VDOM and existing DOM in parallel to hydrate nested components.
+    # Uses the same positional indexing as bind_events/collect_refs so the
+    # three walks agree on which DOM node maps to which vnode.
+    def hydrate_child_components(vnode, dom_element)
+      return unless vnode.is_a?(VDOM::Element)
+      return unless dom_element
+
+      dom_children = dom_element.children.to_a
+      vnode.children.each_with_index do |child, index|
+        child_dom = dom_children[index]
+        next unless child_dom
+
+        if child.is_a?(VDOM::Component)
+          instance = child.component_class.new(child.props)
+          child.instance = instance
+          instance.hydrate(child_dom)
+        elsif child.is_a?(VDOM::Element)
+          hydrate_child_components(child, child_dom)
+        end
       end
     end
 

--- a/mrblib/component.rb
+++ b/mrblib/component.rb
@@ -338,16 +338,24 @@ module Funicular
         @dom_element = dom_element
 
         new_vdom = build_vdom
-        check_hydration_match!(new_vdom, dom_element)
 
-        # Wire child components first so their instances exist for collection.
-        hydrate_child_components(new_vdom, dom_element)
+        if hydration_match?(new_vdom, dom_element)
+          # Wire child components first so their instances exist for collection.
+          hydrate_child_components(new_vdom, dom_element)
 
-        # Reuse the same positional walks as mount: they skip Component vnodes
-        # (children manage their own events/refs during their own hydrate).
-        bind_events(dom_element, new_vdom)
-        collect_refs(dom_element, new_vdom)
-        collect_child_components(new_vdom)
+          # Reuse the same positional walks as mount: they skip Component vnodes
+          # (children manage their own events/refs during their own hydrate).
+          bind_events(dom_element, new_vdom)
+          collect_refs(dom_element, new_vdom)
+          collect_child_components(new_vdom)
+        else
+          # Server and client disagree on structure (nondeterministic render or
+          # stale state). Recover by discarding the server DOM and rendering a
+          # fresh tree, the same way mount does. The page stays usable; only the
+          # first-paint reuse is lost for this subtree.
+          warn_hydration_mismatch(new_vdom, dom_element)
+          @dom_element = full_render_fallback(new_vdom, dom_element)
+        end
 
         @vdom = new_vdom
         @mounted = true
@@ -659,15 +667,36 @@ module Funicular
     # must match the server-rendered element. A mismatch means server and
     # client disagree (nondeterministic render or stale state); the caller
     # falls back to a full client render.
-    def check_hydration_match!(vnode, dom_element)
-      return unless vnode.is_a?(VDOM::Element)
+    def hydration_match?(vnode, dom_element)
+      return true unless vnode.is_a?(VDOM::Element)
       actual = dom_element[:tagName]
-      return unless actual  # non-element node; let later steps surface issues
-      expected = vnode.tag.to_s.downcase
-      got = actual.to_s.downcase
-      unless expected == got
-        raise "Hydration mismatch: expected <#{expected}>, found <#{got}>"
-      end
+      return true unless actual  # non-element node; let later steps surface issues
+      vnode.tag.to_s.downcase == actual.to_s.downcase
+    end
+
+    # Emit a development-only warning describing a hydration mismatch. Uses
+    # puts so the message reaches the browser console (same idiom as the
+    # ErrorBoundary logger), and is silent in production.
+    def warn_hydration_mismatch(vnode, dom_element)
+      return unless Funicular.env.development?
+      expected = vnode.is_a?(VDOM::Element) ? vnode.tag.to_s.downcase : vnode.class.to_s
+      got = dom_element[:tagName].to_s.downcase
+      puts "[Funicular] Hydration mismatch: expected <#{expected}>, found <#{got}>; " \
+           "falling back to full client render"
+    end
+
+    # Recover from a hydration mismatch by rendering a fresh DOM tree and
+    # swapping it in for the server-rendered node. Mirrors mount, minus the
+    # appendChild: the stale node already has a place in the document, so we
+    # replaceChild instead.
+    def full_render_fallback(new_vdom, server_dom)
+      fresh = VDOM::Renderer.new.render(new_vdom)
+      parent = server_dom.parentNode
+      parent.replaceChild(fresh, server_dom) if parent
+      bind_events(fresh, new_vdom)
+      collect_refs(fresh, new_vdom)
+      collect_child_components(new_vdom)
+      fresh
     end
 
     # Walk the VDOM and existing DOM in parallel to hydrate nested components.

--- a/mrblib/debug.rb
+++ b/mrblib/debug.rb
@@ -4,6 +4,9 @@ module Funicular
       attr_accessor :enabled
 
       def enabled?
+        # Disabled on the server: SSR instantiates components per request and
+        # must not accumulate them in the debug registry.
+        return false if Funicular.server?
         @enabled ||= Funicular.env.development?
       end
 

--- a/mrblib/file_upload.rb
+++ b/mrblib/file_upload.rb
@@ -1,4 +1,11 @@
-require 'rng'
+# 'rng' is a PicoRuby gem available only in the wasm build. When the runtime
+# is loaded under CRuby for SSR it is absent; FileUpload is client-only and
+# its methods are never called on the server (see Funicular.server?).
+begin
+  require 'rng'
+rescue LoadError
+  # not available outside wasm environment
+end
 
 module Funicular
   module FileUpload
@@ -31,6 +38,7 @@ module Funicular
     JAVASCRIPT
 
     def self.mount
+      return if Funicular.server?
       script = JS.document.createElement("script")
       script[:textContent] = JS_HELPER_CODE
       JS.document.body.appendChild(script)

--- a/mrblib/funicular.rb
+++ b/mrblib/funicular.rb
@@ -18,7 +18,7 @@ module Funicular
   # Guard against redefinition: when the mrblib runtime is loaded into a
   # CRuby/Rails process for SSR, lib/funicular/version.rb has already defined
   # VERSION for the CRuby gem. In the wasm build VERSION is undefined here.
-  VERSION = '0.1.0' unless defined?(VERSION)
+  VERSION = '0.1.0' unless Funicular.const_defined?(:VERSION)
 
   def self.version
     VERSION

--- a/mrblib/funicular.rb
+++ b/mrblib/funicular.rb
@@ -15,10 +15,26 @@ rescue LoadError
 end
 
 module Funicular
-  VERSION = '0.1.0'
+  # Guard against redefinition: when the mrblib runtime is loaded into a
+  # CRuby/Rails process for SSR, lib/funicular/version.rb has already defined
+  # VERSION for the CRuby gem. In the wasm build VERSION is undefined here.
+  VERSION = '0.1.0' unless defined?(VERSION)
 
   def self.version
     VERSION
+  end
+
+  # True when the runtime is loaded under CRuby on the server (SSR) rather
+  # than running as PicoRuby.wasm in the browser. JS-dependent entry points
+  # become no-ops in this mode. Defaults to false (browser).
+  @server = false
+
+  def self.server?
+    @server
+  end
+
+  def self.server=(value)
+    @server = value ? true : false
   end
 
   def self.env
@@ -44,12 +60,53 @@ module Funicular
     @router
   end
 
+  # Read the SSR state embedded by the server (funicular_state_tag) as a
+  # Ruby Hash with string keys. Returns {} when absent or on the server.
+  # Goes through JSON.stringify/parse for a reliable JS->Ruby conversion.
+  def self.window_state
+    return {} if server?
+    win = JS.global[:window]
+    return {} unless win
+    raw = win[:__FUNICULAR_STATE__]
+    return {} if raw.nil?
+    json_str = JS.global[:JSON].stringify(raw)
+    JSON.parse(json_str.to_s)
+  rescue => e
+    puts "[Funicular] Failed to read window state: #{e.message}"
+    {}
+  end
+
+  # True when the server embedded hydration state on the page.
+  def self.has_ssr_state?
+    return false if server?
+    win = JS.global[:window]
+    return false unless win
+    !win[:__FUNICULAR_STATE__].nil?
+  rescue
+    false
+  end
+
+  # The first element child of a container, or nil. Used to find the
+  # server-rendered root for hydration.
+  def self.first_element_child(container_element)
+    child = container_element[:firstElementChild]
+    child.is_a?(JS::Element) ? child : nil
+  end
+
   # Load schemas for models
   # Usage:
   #   Funicular.load_schemas({ User => "user", Session => "session" }) do
   #     Funicular.start(container: 'app') { |router| ... }
   #   end
   def self.load_schemas(models, &block)
+    # On the server there is no fetch and no need for client-side schemas:
+    # SSR injects plain data into component state directly. Just run the
+    # block so route registration (Funicular.start) still happens.
+    if server?
+      block.call if block
+      return
+    end
+
     schemas_loaded = 0
     total_schemas = models.size
 
@@ -78,7 +135,20 @@ module Funicular
   # Usage:
   #   Funicular.start(MyComponent, container: 'app')
   #   Funicular.start(MyComponent, container: 'app', props: { name: 'John' })
-  def self.start(component_class = nil, container: 'app', props: {}, &block)
+  def self.start(component_class = nil, container: 'app', props: {}, hydrate: false, &block)
+    # On the server we only need route registration so SSR can resolve a
+    # path to a component. Skip all DOM/JS work (container lookup, popstate
+    # listener, debug export).
+    if server?
+      if block
+        router = Router.new(nil)
+        @router = router
+        block.call(router)
+        return router
+      end
+      return nil
+    end
+
     # Export debug configuration to JavaScript
     export_debug_config
 
@@ -95,19 +165,29 @@ module Funicular
       raise "Container element not found: #{container}"
     end
 
+    # Hydrate automatically when the server embedded state, unless the caller
+    # explicitly opted out.
+    hydrate = true if hydrate == false && has_ssr_state?
+
     # If block is given, use router mode
     if block
       router = Router.new(container_element)
       @router = router
       block.call(router)
-      router.start
+      router.start(hydrate: hydrate)
       return router
     end
 
     # Otherwise, mount single component (backward compatible)
     if component_class
       instance = component_class.new(props)
-      instance.mount(container_element)
+      server_root = hydrate ? first_element_child(container_element) : nil
+      if server_root
+        instance.seed_state(window_state)
+        instance.hydrate(server_root)
+      else
+        instance.mount(container_element)
+      end
       return instance
     end
 
@@ -149,6 +229,7 @@ module Funicular
 
   # Export debug_color to JavaScript global variable
   def self.export_debug_config
+    return if server?
     if JS.global[:window]
       JS.global[:window][:FUNICULAR_DEBUG_COLOR] = @debug_color # steep:ignore
     end

--- a/mrblib/html_serializer.rb
+++ b/mrblib/html_serializer.rb
@@ -1,0 +1,118 @@
+module Funicular
+  module VDOM
+    # HTMLSerializer is a string-emitting counterpart of VDOM::Renderer.
+    # While Renderer builds a live DOM tree via JS (createElement/appendChild),
+    # HTMLSerializer walks the same VNode tree and produces an HTML string.
+    #
+    # It is pure Ruby with no JS dependency, so it runs under both mruby
+    # (in the browser, if ever needed) and CRuby (on the Rails server for SSR).
+    #
+    # Event handler props (on*) are intentionally skipped: they are Procs that
+    # cannot be serialized. They are re-bound on the client during hydration.
+    class HTMLSerializer
+      # Elements that have no closing tag and no children.
+      VOID_ELEMENTS = %w[
+        area base br col embed hr img input link meta param source track wbr
+      ]
+
+      # Props that must never be emitted as HTML attributes.
+      SKIP_PROPS = %i[ref key children_block]
+
+      def self.serialize(vnode)
+        new.render(vnode)
+      end
+
+      def render(vnode)
+        case vnode&.type
+        when :element
+          render_element(vnode)
+        when :text
+          render_text(vnode)
+        when :component
+          render_component(vnode)
+        when nil
+          ""
+        else
+          raise "Unknown vnode type: #{vnode&.type}"
+        end
+      end
+
+      private
+
+      def render_element(element)
+        tag = element.tag
+        attrs = serialize_props(element.props)
+
+        if VOID_ELEMENTS.include?(tag)
+          "<#{tag}#{attrs}>"
+        else
+          "<#{tag}#{attrs}>#{render_children(element.children)}</#{tag}>"
+        end
+      end
+
+      def render_children(children)
+        parts = []
+        children.each do |child|
+          if child.is_a?(VNode)
+            parts << render(child)
+          elsif child.is_a?(String)
+            parts << escape_html(child)
+          elsif child.is_a?(Array)
+            parts << render_children(child)
+          elsif !child.nil?
+            parts << escape_html(child.to_s)
+          end
+        end
+        parts.join
+      end
+
+      def render_text(text)
+        escape_html(text.content)
+      end
+
+      def render_component(component_vnode)
+        instance = component_vnode.component_class.new(component_vnode.props)
+        component_vnode.instance = instance
+        render(instance.build_vdom)
+      end
+
+      def serialize_props(props)
+        parts = []
+        props.each do |key, value|
+          key_str = key.to_s
+          next if SKIP_PROPS.include?(key)
+          # Event handlers are bound on the client, never serialized.
+          next if key_str.start_with?("on")
+
+          if URL_ATTRIBUTES.include?(key_str) &&
+             value.to_s.strip.downcase.start_with?("javascript:")
+            # Prevent XSS via javascript: URIs (mirrors Renderer#render_element).
+            next
+          end
+
+          if BOOLEAN_ATTRIBUTES.include?(key_str)
+            # Boolean attributes are absent when false/nil, otherwise present.
+            next if value.nil? || value.to_s == "false"
+            parts << " #{key_str}=\"#{key_str}\""
+          else
+            parts << " #{key_str}=\"#{escape_attr(value.to_s)}\""
+          end
+        end
+        parts.join
+      end
+
+      # Minimal HTML escaping that works the same under mruby and CRuby.
+      # Avoids any dependency on CGI/ERB::Util.
+      def escape_html(str)
+        str.to_s
+           .gsub("&", "&amp;")
+           .gsub("<", "&lt;")
+           .gsub(">", "&gt;")
+      end
+
+      def escape_attr(str)
+        escape_html(str).gsub('"', "&quot;")
+      end
+    end
+  end
+end

--- a/mrblib/router.rb
+++ b/mrblib/router.rb
@@ -44,8 +44,22 @@ module Funicular
       @default_route = path
     end
 
+    # Resolve a path to [component_class, params] without any DOM/JS work.
+    # Public entry point used by server-side rendering.
+    def match(path)
+      find_route(path)
+    end
+
     # Start listening to popstate
-    def start
+    #
+    # When hydrate is true and the container already holds server-rendered
+    # markup, the initial route hydrates that DOM instead of mounting fresh.
+    def start(hydrate: false)
+      # No browser history on the server.
+      return if Funicular.server?
+
+      @hydrate_initial = hydrate
+
       # Clean up existing listener if any (prevents duplicate registration)
       if @popstate_callback_id
         JS::Object.removeEventListener(@popstate_callback_id)
@@ -57,8 +71,10 @@ module Funicular
         handle_route_change
       end
 
-      # Handle initial route
-      if current_location_path == '/' && @default_route
+      # Handle initial route. Skip the default-route redirect when hydrating
+      # server content: the server already rendered for the current path.
+      hydrating_now = @hydrate_initial && Funicular.first_element_child(@container)
+      if !hydrating_now && current_location_path == '/' && @default_route
         # Use replaceState to not add a new entry to the history
         JS.global.history.replaceState(JS::Bridge.to_js({}), '', @default_route)
       end
@@ -95,6 +111,11 @@ module Funicular
     def handle_route_change
       path = current_location_path
 
+      # Hydration only applies to the very first navigation. Consume the flag
+      # here so an unmatched initial route does not leave it set for later.
+      hydrate_now = @hydrate_initial
+      @hydrate_initial = false
+
       # Find matching route
       component_class, params = find_route(path)
 
@@ -113,6 +134,22 @@ module Funicular
       @current_path = path
       @current_component = component_class.new(params)
       # @type ivar @current_component: Funicular::Component
+
+      server_root = hydrate_now ? Funicular.first_element_child(@container) : nil
+
+      if server_root
+        begin
+          @current_component.seed_state(Funicular.window_state)
+          @current_component.hydrate(server_root)
+          return
+        rescue => e
+          # Server/client disagreed: discard server DOM and render fresh.
+          puts "[Funicular] Hydration failed, falling back to full render: #{e.message}"
+          @container[:innerHTML] = ''
+          @current_component = component_class.new(params)
+        end
+      end
+
       @current_component.mount(@container)
     end
 

--- a/test/html_serializer_test.rb
+++ b/test/html_serializer_test.rb
@@ -1,0 +1,69 @@
+# HTMLSerializer is the one piece of genuinely shared SSR logic: the same
+# string-emitting code runs under CRuby (Rails server, covered by
+# minitest/ssr_test.rb) and under PicoRuby/mruby (this file). Keeping both
+# suites in lockstep guards against mruby/CRuby divergence in the shared
+# subset, which is the main risk of the SSR feature.
+class HTMLSerializerTest < Picotest::Test
+  def serialize(vnode)
+    Funicular::VDOM::HTMLSerializer.serialize(vnode)
+  end
+
+  def el(tag, props = {}, children = [])
+    Funicular::VDOM::Element.new(tag, props, children)
+  end
+
+  def test_serializes_element_with_attributes
+    assert_equal('<div class="box" id="x"></div>',
+                 serialize(el('div', {class: 'box', id: 'x'})))
+  end
+
+  def test_serializes_nested_children
+    inner = el('span', {}, ['hi'])
+    assert_equal('<div><span>hi</span></div>',
+                 serialize(el('div', {}, [inner])))
+  end
+
+  def test_escapes_text_content
+    assert_equal('<p>a &amp; b &lt;c&gt;</p>',
+                 serialize(el('p', {}, ['a & b <c>'])))
+  end
+
+  def test_escapes_attribute_values
+    assert_equal('<div title="&quot;hi&quot;"></div>',
+                 serialize(el('div', {title: '"hi"'})))
+  end
+
+  def test_skips_event_handlers
+    assert_equal('<button>Go</button>',
+                 serialize(el('button', {onclick: :handle}, ['Go'])))
+  end
+
+  def test_boolean_attribute_present_when_true
+    assert_equal('<input disabled="disabled">',
+                 serialize(el('input', {disabled: true})))
+  end
+
+  def test_boolean_attribute_absent_when_false
+    assert_equal('<input>',
+                 serialize(el('input', {disabled: false})))
+  end
+
+  def test_void_element_has_no_closing_tag
+    assert_equal('<br>', serialize(el('br')))
+    assert_equal('<img src="/a.png">', serialize(el('img', {src: '/a.png'})))
+  end
+
+  def test_blocks_javascript_uri
+    assert_equal('<a>x</a>',
+                 serialize(el('a', {href: 'javascript:alert(1)'}, ['x'])))
+  end
+
+  def test_text_vnode_is_escaped
+    assert_equal('&lt;b&gt;',
+                 serialize(Funicular::VDOM::Text.new('<b>')))
+  end
+
+  def test_nil_vnode_serializes_to_empty_string
+    assert_equal('', serialize(nil))
+  end
+end

--- a/test/hydration_test.rb
+++ b/test/hydration_test.rb
@@ -1,0 +1,50 @@
+# Hydration mismatch guard, mruby/PicoRuby side. The structural decision
+# (`hydration_match?`) is pure Ruby and shared between server and client, so it
+# is tested under both VMs (see minitest/hydration_test.rb for the CRuby twin)
+# to guard against divergence. The DOM swap performed on mismatch
+# (`full_render_fallback`) is JS-only and is verified in the browser, not here.
+#
+# A plain Hash stands in for the server DOM node: hydration_match? only reads
+# `dom_element[:tagName]`, which a Hash answers like a JS::Element does.
+#
+# The probe subclass is built at runtime via Class.new so that
+# Funicular::Component is referenced only inside a method (matching the other
+# picotests); referencing it in a class body resolves at load time and fails.
+class HydrationTest < Picotest::Test
+  def probe
+    klass = Class.new(Funicular::Component) do
+      def render
+        div { "x" }
+      end
+
+      def match?(vnode, dom)
+        hydration_match?(vnode, dom)
+      end
+    end
+    klass.new
+  end
+
+  def el(tag)
+    Funicular::VDOM::Element.new(tag, {}, ['x'])
+  end
+
+  def test_matches_when_root_tags_agree
+    assert_equal(true, probe.match?(el('div'), {tagName: 'DIV'}))
+  end
+
+  def test_detects_mismatched_root_tag
+    assert_equal(false, probe.match?(el('div'), {tagName: 'SPAN'}))
+  end
+
+  def test_tag_comparison_is_case_insensitive
+    assert_equal(true, probe.match?(el('h1'), {tagName: 'H1'}))
+  end
+
+  def test_non_element_vnode_is_treated_as_match
+    assert_equal(true, probe.match?(Funicular::VDOM::Text.new('hi'), {tagName: 'DIV'}))
+  end
+
+  def test_missing_dom_tag_name_is_treated_as_match
+    assert_equal(true, probe.match?(el('div'), {}))
+  end
+end


### PR DESCRIPTION
This pull request adds first-class support for server-side rendering (SSR) and hydration to Funicular, allowing components to be rendered to HTML on the Rails server and hydrated in the browser for improved SEO and faster first paint. It introduces a new SSR API, documentation, helpers for Rails integration, and a deterministic hydration guard to ensure client and server markup match. The changes also refactor source file loading for consistent behavior between client and server.

**SSR and Hydration Feature:**

* Introduced a new SSR API (`Funicular::SSR.render`) and runtime (`lib/funicular/ssr.rb`, `lib/funicular/ssr/runtime.rb`) that loads Funicular component code in the Rails process, renders the VDOM to HTML, and hydrates it on the client. [[1]](diffhunk://#diff-6189ed3dab98faddc08c80867e0814c6c0ffe5083439c0b03f2caae5d57fcf9dR1-R51) [[2]](diffhunk://#diff-82e2972d87d61cd4d0fb719e8cc3a764470395fd981cd19567dce4dae30115b2R1-R99)
* Added a comprehensive guide to SSR and hydration in `docs/ssr.md`, and updated all relevant documentation to reflect SSR support and its limitations. [[1]](diffhunk://#diff-bb69bbe5ac23fd026d5c5a20a3829d067734abe39270e2b8424a2fb916c81f22R1-R138) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R68) [[3]](diffhunk://#diff-0b5ca119d2be595aa307d34512d9679e49186307ef94201e4b3dfa079aa89938R408-L413) [[4]](diffhunk://#diff-140eef3ba41bdcf401d507408084181f2c0ac627532b61e0f7906ea7cc926782L179-R186) [[5]](diffhunk://#diff-140eef3ba41bdcf401d507408084181f2c0ac627532b61e0f7906ea7cc926782L381-R386)

**Rails Integration Helpers:**

* Added `funicular_app_container` and `funicular_state_tag` helpers for embedding server-rendered HTML and state in Rails views, enabling seamless hydration.

**Compiler and Source Loading Refactor:**

* Refactored source file ordering and loading into a reusable method (`Compiler.source_files`) to ensure consistent evaluation order for both client compilation and server-side SSR boot. [[1]](diffhunk://#diff-3ea85bedbc40007354a37aeac4edb8d5d8e1f775c35e1e620e36ba5a6147c5f2R14-R27) [[2]](diffhunk://#diff-3ea85bedbc40007354a37aeac4edb8d5d8e1f775c35e1e620e36ba5a6147c5f2L69-R83)

**Hydration Mismatch Guard:**

* Added a deterministic hydration guard and tests to detect and recover from mismatches between server-rendered and client VDOM, with dev-only warnings.

**Testing and Fixtures:**

* Added SSR/hydration-related test fixtures and example components to support and verify the new SSR behavior. [[1]](diffhunk://#diff-a1d029ef0636da24bcc6f4f734c4b2d9243d252c7a3fa28e70cd396190fc704dR1-R16) [[2]](diffhunk://#diff-d1c504bccac53b933125c2474ccf03f65ed164706798a832466feefc2be92f44R1-R5)

These changes collectively enable SSR in Funicular, improve first paint and SEO, and provide robust integration points for Rails applications.