### PR TITLE
Validator

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -386,6 +386,7 @@ end
 - [**Components and State**](docs/components-and-state.md) - Component lifecycle, state management, props
 - [**Styling**](docs/styling.md) - CSS-in-Ruby Styles DSL, conditional styles, variants
 - [**Forms**](docs/forms.md) - Form builder, validation, error handling
+- [**Validations**](docs/validations.md) - Model validators, errors, reusing ActiveRecord validations
 
 ### Features
 - [**Routing and Navigation**](docs/routing-and-navigation.md) - Router, URL helpers, link_to

--- a/docs/forms.md
+++ b/docs/forms.md
@@ -140,7 +140,7 @@ class LoginComponent < Funicular::Component
     form_for(:user, on_submit: :handle_submit) do |f|
       f.email_field(:email, class: "w-full p-2 border rounded")
       # If errors[:email] exists, it's displayed in red below the field
-      # Field automatically gets border-red-500 class
+      # Field automatically gets the funicular-field-error class
 
       f.password_field(:password, class: "w-full p-2 border rounded")
       # If errors[:password] exists, it's displayed in red below the field
@@ -153,10 +153,11 @@ end
 
 ### Error Behavior
 
-When `state.errors` contains a key matching a field name:
-1. The error message is displayed below the field
-2. The field gets an error class added (default: `border-red-500`)
-3. Error messages are styled with `error_class` (default: `text-red-600 text-sm mt-1`)
+When `state.errors` contains a key matching a field name (the value may be a single message string or an array of messages — the first is shown):
+1. The error message is displayed in a `<div>` below the field, styled with the `error_class` (default: `funicular-error`).
+2. The field itself gets the `field_error_class` added (default: `funicular-field-error`).
+
+These two defaults are **semantic class names whose CSS the gem ships and injects for you**: `picoruby_include_tag` writes a small `<style>` block (`assets/funicular.css`) that styles `.funicular-field-error` (red border, light-red fill, red ring) and `.funicular-error` (red message text). This is why error highlighting works out of the box with no CSS-framework setup — important because a tool like Tailwind only scans your app's own sources and never sees class names emitted from inside the gem. Pass `picoruby_include_tag(base_styles: false)` if you want to provide the styles yourself.
 
 ## Nested Fields
 
@@ -207,9 +208,11 @@ end
 
 ## Customizing Error Styles
 
+By default, error fields use the gem's `funicular-field-error` / `funicular-error` classes (styled by the stylesheet `picoruby_include_tag` injects). You can override them globally or per form.
+
 ### Global Configuration
 
-Configure error display styles globally:
+Configure error display classes globally:
 
 ```ruby
 # In your initializer (e.g., app/funicular/initializer.rb)
@@ -230,6 +233,8 @@ form_for(:user,
   f.submit("Submit")
 end
 ```
+
+> **If you override with utility classes (e.g., Tailwind), make sure your CSS pipeline actually generates them.** The class names you set here live in your Ruby code under `app/funicular/`, which Tailwind scans, so utilities there are fine. But because these classes are applied from inside the framework, keep using class names your build is aware of — or rely on the shipped `funicular-*` defaults, which need no setup.
 
 ## Form Submission
 

--- a/docs/validations.md
+++ b/docs/validations.md
@@ -1,0 +1,70 @@
+# Model Validations
+
+`Funicular::Model` has an ActiveModel-style validation API, so a model can validate itself in the browser (under PicoRuby) with no server round-trip. Validations can be declared directly on the client model, derived from the matching ActiveRecord model on the server, or both at once.
+
+## Declaring validators
+
+Declare validations in a `Funicular::Model` subclass exactly as you would in Rails:
+
+```ruby
+class User < Funicular::Model
+  validates :display_name, presence: true, length: { maximum: 30 }
+  validates :age, numericality: { only_integer: true, greater_than: 0 }, allow_blank: true
+end
+```
+
+The standard validators are provided as `Funicular::Model::Validations::PresenceValidator` and friends: `presence`, `absence`, `length` (`minimum`/`maximum`/`is`/`in`), `format` (`with:`/`without:`), `numericality` (`only_integer`, `greater_than`, `less_than`, `equal_to`, ...), `inclusion` (`in:`), `exclusion` (`in:`), `acceptance`, and `confirmation`. The shared options `allow_nil` and `allow_blank` are honored for every validator in a `validates` call.
+
+## Running validations
+
+`valid?` runs every validator and populates `errors`; `invalid?` is its inverse. `errors` is a small `Funicular::Model::Errors`: `errors[:attr]` returns an array of messages, `errors.messages` returns the `{ attribute => [messages] }` hash, and `errors.full_messages` returns human-readable strings.
+
+`Model.create` and `Model#update` validate first and behave like `ActiveRecord#save`: when the instance is invalid they skip the HTTP request and hand the errors to your callback, so you can show them without a network trip:
+
+```ruby
+user.update(display_name: name) do |success, result|
+  if success
+    # saved
+  elsif result.respond_to?(:messages)
+    patch(errors: result.messages)   # client-side validation errors, shown inline
+  else
+    patch(message: "Error: #{result}", is_error: true)  # server error
+  end
+end
+```
+
+`form_for` reads `state.errors[:field]` and renders the message beside each field, so `patch(errors: model.errors.messages)` is all a form needs to display inline errors. The server still validates and may return a 422; client validation is an additive pre-flight layer.
+
+## Reusing ActiveRecord validations
+
+Most apps already declare `validates` on their ActiveRecord models. Rather than restating those rules on the client, build the schema with `Funicular::Schema.build`: it introspects the AR model via `validators_on` and merges the derived rules inline into each attribute entry, which `load_schema` then turns into client validators.
+
+```ruby
+class Api::SchemaController < ApplicationController
+  def user
+    render json: Funicular::Schema.build(
+      User,
+      attributes: {
+        "display_name" => { type: "string", readonly: false },
+        "username"     => { type: "string", readonly: true }
+      },
+      endpoints: { "update" => { method: "PATCH", path: "/users/:id" } },
+      except: { username: [:format] }
+    )
+  end
+end
+```
+
+The emitted `display_name` entry becomes `{ type: "string", readonly: false, validations: { "presence" => true, "length" => { "maximum" => 30 } } }` — the validators ride along with the attribute, so there is nothing extra to declare or keep in sync.
+
+The exposure policy is an attribute allowlist plus a per-kind denylist. Validations are derived only for the attributes you declare (already public in `attributes`), so nothing outside the schema is ever introspected. `except:` suppresses specific kinds for specific attributes. Validators that cannot run on the client are skipped automatically: `uniqueness` (database-only), any custom validator, and conditional/context validators (`if:`, `unless:`, `on:`).
+
+(`Funicular::Schema.validations_for(model, names, except:)` is also available if you prefer to emit a separate top-level `validations:` block instead of the inline form; `load_schema` accepts either.)
+
+Client-declared validators and schema-derived ones merge. If the same kind is declared for an attribute on both sides, the client declaration wins and the schema-derived duplicate is dropped, so frontend-only validations always keep working.
+
+## The `format` regexp caveat
+
+On the client, `Regexp` is a thin wrapper over the JavaScript `RegExp` engine, not Ruby's Onigmo, so a few Ruby-only constructs differ. Write client `format` patterns in JavaScript syntax: use `^...$` rather than `\A...\z`, and avoid extended (`/x`) mode, POSIX classes like `[[:alpha:]]`, and `\h`/`\H`.
+
+When deriving a `format` validator from ActiveRecord, `Funicular::Schema` translates the common anchors (`\A` to `^`, `\z`/`\Z` to `$`) and carries the `i`/`m` flags, but it skips (with a warning) any pattern using a construct JavaScript cannot accept. `format` is therefore the prime candidate for the `except:` denylist; declare such a validator directly on the `Funicular::Model` in JS-compatible syntax instead.

--- a/lib/funicular.rb
+++ b/lib/funicular.rb
@@ -3,6 +3,7 @@
 require_relative "funicular/version"
 require_relative "funicular/configuration"
 require_relative "funicular/compiler"
+require_relative "funicular/schema"
 require_relative "funicular/ssr"
 
 module Funicular

--- a/lib/funicular/assets/funicular.css
+++ b/lib/funicular/assets/funicular.css
@@ -1,0 +1,23 @@
+/* Funicular base styles.
+ *
+ * Injected into the page by picoruby_include_tag so that class names emitted
+ * from inside the gem (which the host app's CSS pipeline never sees -- e.g.
+ * Tailwind only scans the app's own sources) still render. Keep this minimal
+ * and namespaced under .funicular-* so it cannot clash with app styles.
+ *
+ * Apps that prefer their own utilities can override per form via
+ * form_for(..., field_error_class: "...", error_class: "..."). */
+
+.funicular-field-error {
+  border-color: #ef4444 !important; /* red-500, wins over a base border color */
+  background-color: #fef2f2;        /* red-50 */
+  box-shadow: 0 0 0 1px #ef4444;
+}
+
+.funicular-error {
+  margin-top: 0.25rem;
+  color: #dc2626;                   /* red-600 */
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  font-weight: 500;
+}

--- a/lib/funicular/helpers/picoruby_helper.rb
+++ b/lib/funicular/helpers/picoruby_helper.rb
@@ -11,6 +11,14 @@ module Funicular
         local_dist:  "/picoruby/dist/init.iife.js"
       }.freeze
 
+      # Minimal CSS the gem ships for class names it emits itself (e.g.
+      # FormBuilder error states). Read once; see assets/funicular.css.
+      BASE_CSS_PATH = File.expand_path("../assets/funicular.css", __dir__)
+
+      def self.base_css
+        @base_css ||= File.read(BASE_CSS_PATH)
+      end
+
       # Renders a <script> tag that bootstraps PicoRuby.wasm.
       #
       # The source is determined by Funicular.configuration based on the
@@ -20,11 +28,18 @@ module Funicular
       #   <%= picoruby_include_tag source: :cdn %>
       #   <%= picoruby_include_tag source: :local_dist, defer: true %>
       #
-      # Any extra options are passed straight through as HTML attributes.
-      def picoruby_include_tag(source: nil, **options)
+      # Also emits Funicular's small base stylesheet (so gem-emitted class names
+      # such as form error states render without host-CSS setup); pass
+      # base_styles: false to skip it. Any extra options become HTML attributes
+      # on the <script> tag.
+      def picoruby_include_tag(source: nil, base_styles: true, **options)
         resolved_source = source ? source.to_sym : Funicular.configuration.source_for(Rails.env)
         src = picoruby_src_for(resolved_source)
-        tag.script("", src: src, **options)
+        script = tag.script("", src: src, **options)
+        return script unless base_styles
+
+        style = tag.style(PicorubyHelper.base_css.html_safe, "data-funicular-base": "")
+        safe_join([style, script])
       end
 
       # Renders the SSR #app container with the server-rendered HTML inside.

--- a/lib/funicular/schema.rb
+++ b/lib/funicular/schema.rb
@@ -1,0 +1,167 @@
+# frozen_string_literal: true
+
+module Funicular
+  # Derives client-side validation rules from an ActiveModel/ActiveRecord
+  # class so they can be embedded in the JSON returned by a schema controller
+  # and reused by Funicular::Model on the client.
+  #
+  # Security model: validations are derived ONLY for the attribute names the
+  # caller passes (the schema's existing attribute allowlist), so nothing
+  # outside the already-public schema is ever introspected. A per-attribute
+  # `except` denylist suppresses specific validator kinds.
+  module Schema
+    # Validator kinds that have a client-side counterpart in
+    # Funicular::Model::Validations. Others (notably :uniqueness, which needs
+    # the database, and any custom validator) are skipped.
+    SUPPORTED_KINDS = %i[
+      presence absence length format numericality
+      inclusion exclusion acceptance confirmation
+    ].freeze
+
+    # Build a full schema hash, merging derived validations inline into each
+    # attribute entry (the shape Funicular::Model.load_schema consumes):
+    #
+    #   Funicular::Schema.build(User,
+    #     attributes: { "display_name" => { type: "string", readonly: false } },
+    #     endpoints:  { "update" => { method: "PATCH", path: "/users/:id" } },
+    #     except:     { username: [:format] })
+    #   # => { attributes: { "display_name" => { type:, readonly:,
+    #   #        validations: { "presence" => true, "length" => {...} } } },
+    #   #      endpoints: {...} }
+    #
+    # Only the attributes you declare are introspected (allowlist); `except`
+    # drops specific kinds per attribute (denylist).
+    def self.build(model_class, attributes:, endpoints: {}, except: {})
+      merged = {}
+      attributes.each do |name, definition|
+        rules = rules_for(model_class, name, except_kinds(except, name))
+        merged[name] = rules.empty? ? definition : definition.merge(validations: rules)
+      end
+      { attributes: merged, endpoints: endpoints }
+    end
+
+    # Returns { "attr" => { "presence" => true, "length" => { "maximum" => 30 } } }
+    # for the given attribute names only. Useful when emitting validations as a
+    # separate block rather than inline (see #build for the inline form).
+    def self.validations_for(model_class, attribute_names, except: {})
+      result = {}
+      attribute_names.each do |name|
+        rules = rules_for(model_class, name, except_kinds(except, name))
+        result[name.to_s] = rules unless rules.empty?
+      end
+      result
+    end
+
+    # Derive the { kind => options } rules for a single attribute.
+    def self.rules_for(model_class, name, skip_kinds)
+      attr = name.to_sym
+      rules = {}
+      model_class.validators_on(attr).each do |validator|
+        kind = validator.kind
+        next unless SUPPORTED_KINDS.include?(kind)
+        next if skip_kinds.include?(kind)
+        # Conditional/context validators can't be evaluated on the client.
+        next if conditional?(validator.options)
+
+        serialized = serialize(kind, validator.options)
+        next if serialized.nil?
+        rules[kind.to_s] = serialized
+      end
+      rules
+    end
+
+    def self.except_kinds(except, name)
+      Array(except[name.to_sym] || except[name.to_s]).map(&:to_sym)
+    end
+
+    def self.conditional?(options)
+      options.key?(:if) || options.key?(:unless) || options.key?(:on)
+    end
+
+    def self.serialize(kind, options)
+      case kind
+      when :presence, :absence, :acceptance, :confirmation
+        true
+      when :length
+        serialize_length(options)
+      when :numericality
+        serialize_numericality(options)
+      when :inclusion, :exclusion
+        serialize_set(options)
+      when :format
+        RegexpTranslator.translate(options[:with])
+      end
+    end
+
+    def self.serialize_length(options)
+      opts = {}
+      [:minimum, :maximum, :is].each do |k|
+        opts[k.to_s] = options[k] if options[k].is_a?(Integer)
+      end
+      if (range = options[:in] || options[:within]).is_a?(Range)
+        opts["minimum"] = range.min
+        opts["maximum"] = range.max
+      end
+      opts.empty? ? nil : opts
+    end
+
+    def self.serialize_numericality(options)
+      opts = {}
+      opts["only_integer"] = true if options[:only_integer]
+      [:greater_than, :greater_than_or_equal_to, :equal_to,
+       :less_than, :less_than_or_equal_to, :other_than].each do |k|
+        opts[k.to_s] = options[k] if options[k].is_a?(Numeric)
+      end
+      opts.empty? ? true : opts
+    end
+
+    def self.serialize_set(options)
+      list = options[:in] || options[:within]
+      list = list.to_a if list.is_a?(Range)
+      return nil unless list.is_a?(Array)
+      return nil unless list.all? { |v| json_scalar?(v) }
+      { "in" => list }
+    end
+
+    def self.json_scalar?(value)
+      value.is_a?(String) || value.is_a?(Numeric) ||
+        value == true || value == false || value.nil?
+    end
+
+    # Best-effort translation of a Ruby Regexp into a JS-RegExp-compatible
+    # source. The client runs Regexp as a JS RegExp wrapper, so Ruby-only
+    # constructs are either translated (\A, \z, \Z anchors) or, when they have
+    # no safe JS equivalent, the validator is skipped with a warning.
+    module RegexpTranslator
+      # Substrings that JS RegExp cannot accept; presence means "skip".
+      INCOMPATIBLE = ['[[:', '\\h', '\\H', '\\G', '(?>'].freeze
+
+      def self.translate(regexp)
+        return nil unless regexp.is_a?(Regexp)
+
+        if (regexp.options & Regexp::EXTENDED) != 0
+          return skip("extended (x) mode")
+        end
+
+        source = regexp.source
+        if INCOMPATIBLE.any? { |token| source.include?(token) }
+          return skip("uses a construct unsupported by JS RegExp")
+        end
+
+        js_source = source.gsub('\\A', '^').gsub('\\z', '$').gsub('\\Z', '$')
+
+        flags = +''
+        flags << 'i' if (regexp.options & Regexp::IGNORECASE) != 0
+        flags << 'm' if (regexp.options & Regexp::MULTILINE) != 0
+
+        { 'with' => js_source, 'flags' => flags }
+      end
+
+      def self.skip(reason)
+        warn "[Funicular::Schema] skipping a format validator: #{reason}; " \
+             "declare it directly in the Funicular::Model if needed"
+        nil
+      end
+    end
+  end
+end

--- a/lib/funicular/ssr/runtime.rb
+++ b/lib/funicular/ssr/runtime.rb
@@ -31,6 +31,8 @@ module Funicular
         component
         error_boundary
         router
+        0_validations
+        1_validators
         model
         store
         store_singleton

--- a/minitest/schema_test.rb
+++ b/minitest/schema_test.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "active_model"
+
+# Exercises Funicular::Schema.validations_for: deriving client validation rules
+# from an ActiveModel class, honoring the attribute allowlist and the per-kind
+# denylist, skipping unsupported/conditional validators, and translating the
+# `format` regexp for the JS RegExp engine.
+class SchemaDerivationTest < Minitest::Test
+  class Account
+    include ActiveModel::Validations
+    attr_accessor :name, :email, :age, :role, :code, :score
+
+    # Custom validator (kind :even) stands in for any non-standard validator
+    # the client has no counterpart for; it must be skipped during derivation.
+    class EvenValidator < ActiveModel::EachValidator
+      def validate_each(record, attribute, value); end
+    end
+
+    validates :name, presence: true, length: { maximum: 30 }
+    validates :email, format: { with: /\A[^@\s]+@[^@\s]+\z/ }
+    validates :age, numericality: { only_integer: true, greater_than: 0 }
+    validates :role, inclusion: { in: %w[admin user] }
+    validates :code, presence: true, if: -> { false }      # conditional -> skipped
+    validates :score, even: true                           # unsupported kind -> skipped
+  end
+
+  def derive(attrs, except: {})
+    Funicular::Schema.validations_for(Account, attrs, except: except)
+  end
+
+  def test_presence_and_length
+    result = derive(["name"])
+    assert_equal({ "presence" => true, "length" => { "maximum" => 30 } }, result["name"])
+  end
+
+  def test_only_listed_attributes_are_introspected
+    result = derive(["name"])
+    assert_equal ["name"], result.keys
+  end
+
+  def test_numericality_and_inclusion
+    result = derive(["age", "role"])
+    assert_equal({ "only_integer" => true, "greater_than" => 0 }, result["age"]["numericality"])
+    assert_equal({ "in" => %w[admin user] }, result["role"]["inclusion"])
+  end
+
+  def test_format_translates_ruby_anchors
+    result = derive(["email"])
+    fmt = result["email"]["format"]
+    # \A and \z become ^ and $ for JS RegExp.
+    assert_equal "^[^@\\s]+@[^@\\s]+$", fmt["with"]
+  end
+
+  def test_denylist_suppresses_a_kind
+    result = derive(["name"], except: { name: [:length] })
+    assert_equal({ "presence" => true }, result["name"])
+  end
+
+  def test_conditional_validator_is_skipped
+    result = derive(["code"])
+    assert_nil result["code"]
+  end
+
+  def test_unsupported_kind_is_skipped
+    result = derive(["score"])
+    assert_nil result["score"]
+  end
+
+  def test_build_inlines_validations_into_attributes
+    schema = Funicular::Schema.build(
+      Account,
+      attributes: {
+        "display_name" => { type: "string", readonly: false },
+        "name" => { type: "string", readonly: false }
+      },
+      endpoints: { "update" => { method: "PATCH", path: "/x/:id" } },
+      except: { name: [:length] }
+    )
+    # Attribute with no validators is untouched.
+    assert_equal({ type: "string", readonly: false }, schema[:attributes]["display_name"])
+    # Validators are merged inline; denylist drops :length here.
+    assert_equal(
+      { type: "string", readonly: false, validations: { "presence" => true } },
+      schema[:attributes]["name"]
+    )
+    assert_equal({ "update" => { method: "PATCH", path: "/x/:id" } }, schema[:endpoints])
+  end
+
+  def test_extended_regexp_is_skipped
+    klass = Class.new do
+      include ActiveModel::Validations
+      def self.name; "Extended"; end
+      attr_accessor :token
+      validates :token, format: { with: /
+        \A \d+ \z   # an integer, written with x-mode whitespace
+      /x }
+    end
+    result = nil
+    capture_io do  # silence the skip warning
+      result = Funicular::Schema.validations_for(klass, ["token"])
+    end
+    assert_nil result["token"]
+  end
+end

--- a/minitest/validations_test.rb
+++ b/minitest/validations_test.rb
@@ -1,0 +1,183 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# Load the mrblib runtime before defining model subclasses below, since their
+# class bodies reference Funicular::Model and call `validates` at load time.
+Funicular::SSR::Runtime.load_framework!
+
+# Exercises the client-side validation framework under CRuby (the same code
+# runs in the browser under PicoRuby; see test/validations_test.rb).
+class ValidationsTest < Minitest::Test
+  # A fresh, isolated model class with the given schema so validators declared
+  # in one test never leak into another.
+  def model_class(attributes = { "name" => false, "age" => false }, endpoints = {})
+    klass = Class.new(Funicular::Model)
+    attrs = {}
+    attributes.each { |name, readonly| attrs[name] = { "type" => "string", "readonly" => readonly } }
+    klass.load_schema("attributes" => attrs, "endpoints" => endpoints)
+    klass
+  end
+
+  # --- individual validators -------------------------------------------
+
+  def test_presence
+    k = model_class
+    k.class_eval { validates :name, presence: true }
+    blank = k.new("name" => "")
+    assert_equal false, blank.valid?
+    assert_equal ["can't be blank"], blank.errors[:name]
+    assert_equal true, k.new("name" => "Alice").valid?
+  end
+
+  def test_length_maximum_and_minimum
+    k = model_class
+    k.class_eval { validates :name, length: { minimum: 2, maximum: 5 } }
+
+    short = k.new("name" => "a"); short.valid?
+    assert_equal ["is too short (minimum is 2 characters)"], short.errors[:name]
+
+    long = k.new("name" => "abcdef"); long.valid?
+    assert_equal ["is too long (maximum is 5 characters)"], long.errors[:name]
+
+    assert_equal true, k.new("name" => "abc").valid?
+  end
+
+  def test_format
+    k = model_class
+    k.class_eval { validates :name, format: { with: /^[a-z]+$/ } }
+    assert_equal true, k.new("name" => "abc").valid?
+    bad = k.new("name" => "ABC"); bad.valid?
+    assert_equal ["is invalid"], bad.errors[:name]
+  end
+
+  def test_numericality
+    k = model_class
+    k.class_eval { validates :age, numericality: { only_integer: true, greater_than: 0 } }
+    nan = k.new("age" => "abc"); nan.valid?
+    assert_equal ["is not a number"], nan.errors[:age]
+    assert_equal true, k.new("age" => "10").valid?
+    low = k.new("age" => "0"); low.valid?
+    assert_equal ["must be greater than 0"], low.errors[:age]
+    frac = k.new("age" => "1.5"); frac.valid?
+    assert_equal ["must be an integer"], frac.errors[:age]
+  end
+
+  def test_inclusion_and_exclusion
+    inc = model_class
+    inc.class_eval { validates :name, inclusion: { in: ["a", "b"] } }
+    assert_equal true, inc.new("name" => "a").valid?
+    assert_equal false, inc.new("name" => "z").valid?
+
+    exc = model_class
+    exc.class_eval { validates :name, exclusion: { in: ["admin"] } }
+    assert_equal false, exc.new("name" => "admin").valid?
+    assert_equal true, exc.new("name" => "alice").valid?
+  end
+
+  def test_allow_blank_skips_validation
+    k = model_class
+    k.class_eval { validates :name, length: { minimum: 3 }, allow_blank: true }
+    assert_equal true, k.new("name" => "").valid?
+    assert_equal false, k.new("name" => "ab").valid?
+  end
+
+  def test_valid_clears_previous_errors
+    k = model_class
+    k.class_eval { validates :name, presence: true }
+    m = k.new("name" => "")
+    m.valid?
+    m.instance_variable_set("@name", "now set")
+    assert_equal true, m.valid?
+    assert_equal [], m.errors[:name]
+  end
+
+  # --- schema-derived validators + merge -------------------------------
+
+  def test_load_schema_merges_and_dedupes
+    k = Class.new(Funicular::Model)
+    k.class_eval { validates :name, presence: true } # client-declared
+    k.load_schema(
+      "attributes" => {
+        "name" => { "type" => "string", "readonly" => false },
+        "age" => { "type" => "string", "readonly" => false }
+      },
+      "endpoints" => {},
+      "validations" => {
+        "name" => { "presence" => true, "length" => { "maximum" => 3 } },
+        "age" => { "presence" => true }
+      }
+    )
+
+    name_kinds = k.validators_on(:name).map(&:kind).sort
+    # presence appears once (client wins, schema presence deduped) + length merged
+    assert_equal [:length, :presence], name_kinds
+    assert_equal [:presence], k.validators_on(:age).map(&:kind)
+  end
+
+  def test_inline_attribute_validations_are_registered
+    # The shape produced by Funicular::Schema.build: validations nested inside
+    # each attribute entry.
+    k = Class.new(Funicular::Model)
+    k.load_schema(
+      "attributes" => {
+        "name" => {
+          "type" => "string", "readonly" => false,
+          "validations" => { "presence" => true, "length" => { "maximum" => 3 } }
+        }
+      },
+      "endpoints" => {}
+    )
+    assert_equal [:length, :presence], k.validators_on(:name).map(&:kind).sort
+    assert_equal false, k.new("name" => "toolong").valid?
+    assert_equal true, k.new("name" => "ok").valid?
+  end
+
+  def test_format_from_schema_rebuilds_regexp
+    k = Class.new(Funicular::Model)
+    k.load_schema(
+      "attributes" => { "name" => { "type" => "string", "readonly" => false } },
+      "endpoints" => {},
+      "validations" => { "name" => { "format" => { "with" => "^[a-z]+$", "flags" => "i" } } }
+    )
+    assert_equal true, k.new("name" => "ABC").valid? # 'i' flag honored
+    assert_equal false, k.new("name" => "123").valid?
+  end
+
+  # --- create/update auto-validation -----------------------------------
+
+  def test_create_short_circuits_when_invalid
+    k = model_class({ "name" => false }, "create" => { "method" => "POST", "path" => "/things" })
+    k.class_eval { validates :name, presence: true }
+
+    got_instance = :unset
+    got_error = :unset
+    # Invalid -> returns before any HTTP call, yields the errors.
+    k.create({ "name" => "" }) do |instance, error|
+      got_instance = instance
+      got_error = error
+    end
+
+    assert_nil got_instance
+    assert_instance_of Funicular::Model::Errors, got_error
+    assert_equal ["can't be blank"], got_error[:name]
+  end
+
+  def test_update_short_circuits_when_invalid
+    k = model_class({ "name" => false }, "update" => { "method" => "PATCH", "path" => "/things/:id" })
+    k.class_eval { validates :name, presence: true }
+
+    m = k.new("name" => "ok")
+    m.instance_variable_set("@id", 1)
+
+    got_success = :unset
+    got_result = :unset
+    m.update("name" => "") do |success, result|
+      got_success = success
+      got_result = result
+    end
+
+    assert_equal false, got_success
+    assert_equal ["can't be blank"], got_result[:name]
+  end
+end

--- a/mrblib/0_validations.rb
+++ b/mrblib/0_validations.rb
@@ -35,7 +35,7 @@ module Funicular
       end
 
       def full_messages
-        result = []
+        result = [] #: Array[String]
         @messages.each do |attribute, msgs|
           human = humanize(attribute)
           msgs.each { |m| result << "#{human} #{m}" }
@@ -85,7 +85,7 @@ module Funicular
         def kind
           name = self.class.to_s.split("::").last.to_s
           name = name[0...-9] if name.end_with?("Validator")
-          name.downcase.to_sym
+          name.to_s.downcase.to_sym
         end
 
         def validate(record)
@@ -135,14 +135,15 @@ module Funicular
           return if attributes.empty?
           attrs = attributes.map { |a| a.to_sym }
 
-          shared = {}
+          shared = {} #: Hash[Symbol, untyped]
           SHARED_OPTIONS.each { |k| shared[k] = options[k] if options.key?(k) }
 
           options.each do |key, opts|
             next if SHARED_OPTIONS.include?(key)
             klass = validator_class_for(key)
             next unless klass
-            base = (opts == true) ? {} : opts
+            base = {} #: Hash[Symbol, untyped]
+            base = opts unless opts == true
             validator_options = shared.merge(base) # per-validator options win
             validators << klass.new(attributes: attrs, **validator_options)
           end
@@ -157,7 +158,8 @@ module Funicular
           return if validators.any? { |v| v.attributes.include?(attr) && v.kind == k }
           klass = validator_class_for(kind)
           return unless klass
-          validator_options = (opts == true) ? {} : symbolize_keys(opts)
+          validator_options = {} #: Hash[Symbol, untyped]
+          validator_options = symbolize_keys(opts) unless opts == true
           validators << klass.new(attributes: [attr], **validator_options)
         end
 
@@ -171,7 +173,7 @@ module Funicular
 
         def symbolize_keys(hash)
           return hash unless hash.is_a?(Hash)
-          out = {}
+          out = {} #: Hash[Symbol, untyped]
           hash.each { |k, v| out[k.to_sym] = v }
           out
         end
@@ -189,7 +191,10 @@ module Funicular
 
       def valid?
         errors.clear
-        self.class.validators.each { |validator| validator.validate(self) }
+        # Steep does not know whether `self.class` extends ClassMethods
+        # @type var cls: untyped
+        cls = self.class
+        cls.validators.each { |validator| validator.validate(self) }
         errors.empty?
       end
 

--- a/mrblib/0_validations.rb
+++ b/mrblib/0_validations.rb
@@ -1,0 +1,201 @@
+# Attribute validations for Funicular::Model, modeled on ActiveModel.
+#
+# This file is named with a "0_" prefix on purpose: the mruby build
+# concatenates mrblib/**/*.rb in alphabetical order, so this loads before
+# model.rb (which does `include Validations`) and before 1_validators.rb
+# (the concrete validators). Keep this file free of Ruby-only regexp features
+# (\A, \z, $1, ...): on the client, Regexp is a thin JS RegExp wrapper.
+module Funicular
+  class Model
+    # A small slice of ActiveModel::Errors: messages keyed by attribute.
+    # Consumed by FormBuilder, which reads errors[:field].
+    class Errors
+      def initialize
+        @messages = {}
+      end
+
+      def add(attribute, message)
+        key = attribute.to_sym
+        (@messages[key] ||= []) << message
+        message
+      end
+
+      # Always returns an array (possibly empty) for the attribute.
+      def [](attribute)
+        @messages[attribute.to_sym] || []
+      end
+
+      def added?(attribute)
+        !self[attribute].empty?
+      end
+
+      # { attribute_symbol => ["message", ...] }
+      def messages
+        @messages
+      end
+
+      def full_messages
+        result = []
+        @messages.each do |attribute, msgs|
+          human = humanize(attribute)
+          msgs.each { |m| result << "#{human} #{m}" }
+        end
+        result
+      end
+
+      def clear
+        @messages = {}
+      end
+
+      def empty?
+        @messages.all? { |_attr, msgs| msgs.empty? }
+      end
+
+      def any?
+        !empty?
+      end
+
+      private
+
+      def humanize(attribute)
+        words = attribute.to_s.split("_")
+        first = words[0].to_s
+        first = first[0].to_s.upcase + first[1..-1].to_s
+        ([first] + words[1..-1].to_a).join(" ")
+      end
+    end
+
+    module Validations
+      def self.included(base)
+        base.extend(ClassMethods)
+      end
+
+      # Base class for attribute validators, mirroring
+      # ActiveModel::Validations::EachValidator.
+      class EachValidator
+        attr_reader :attributes, :options
+
+        def initialize(attributes:, **options)
+          @attributes = attributes
+          @options = options
+        end
+
+        # PresenceValidator -> :presence. Validator names are single words,
+        # so a plain downcase is enough (no regexp needed).
+        def kind
+          name = self.class.to_s.split("::").last.to_s
+          name = name[0...-9] if name.end_with?("Validator")
+          name.downcase.to_sym
+        end
+
+        def validate(record)
+          attributes.each do |attribute|
+            value = record.read_attribute_for_validation(attribute)
+            next if options[:allow_nil] && value.nil?
+            next if options[:allow_blank] && blank?(value)
+            validate_each(record, attribute, value)
+          end
+        end
+
+        def validate_each(record, attribute, value)
+          raise "#{self.class} must implement validate_each"
+        end
+
+        private
+
+        def blank?(value)
+          return true if value.nil?
+          return value.strip.empty? if value.is_a?(String)
+          return value.empty? if value.respond_to?(:empty?)
+          false
+        end
+
+        def present?(value)
+          !blank?(value)
+        end
+      end
+
+      module ClassMethods
+        # Validators declared on this model class.
+        def validators
+          @validators ||= []
+        end
+
+        def validators_on(attribute)
+          attr = attribute.to_sym
+          validators.select { |v| v.attributes.include?(attr) }
+        end
+
+        # Options that configure every validator in a `validates` call rather
+        # than naming a validator of their own (mirrors ActiveModel).
+        SHARED_OPTIONS = [:allow_nil, :allow_blank, :if, :unless, :on, :strict]
+
+        # validates :a, :b, presence: true, length: { maximum: 30 }, allow_blank: true
+        def validates(*attributes, **options)
+          return if attributes.empty?
+          attrs = attributes.map { |a| a.to_sym }
+
+          shared = {}
+          SHARED_OPTIONS.each { |k| shared[k] = options[k] if options.key?(k) }
+
+          options.each do |key, opts|
+            next if SHARED_OPTIONS.include?(key)
+            klass = validator_class_for(key)
+            next unless klass
+            base = (opts == true) ? {} : opts
+            validator_options = shared.merge(base) # per-validator options win
+            validators << klass.new(attributes: attrs, **validator_options)
+          end
+        end
+
+        # Append a single schema-derived validator (from load_schema), unless a
+        # validator of the same kind is already declared for the attribute in
+        # the subclass body. Frontend declarations win, avoiding duplicates.
+        def add_schema_validator(attribute, kind, opts)
+          attr = attribute.to_sym
+          k = kind.to_sym
+          return if validators.any? { |v| v.attributes.include?(attr) && v.kind == k }
+          klass = validator_class_for(kind)
+          return unless klass
+          validator_options = (opts == true) ? {} : symbolize_keys(opts)
+          validators << klass.new(attributes: [attr], **validator_options)
+        end
+
+        private
+
+        def validator_class_for(key)
+          class_name = "#{key.to_s.capitalize}Validator"
+          return nil unless Funicular::Model::Validations.const_defined?(class_name)
+          Funicular::Model::Validations.const_get(class_name)
+        end
+
+        def symbolize_keys(hash)
+          return hash unless hash.is_a?(Hash)
+          out = {}
+          hash.each { |k, v| out[k.to_sym] = v }
+          out
+        end
+      end
+
+      # --- instance API ---
+
+      def errors
+        @errors ||= Funicular::Model::Errors.new
+      end
+
+      def read_attribute_for_validation(attribute)
+        send(attribute)
+      end
+
+      def valid?
+        errors.clear
+        self.class.validators.each { |validator| validator.validate(self) }
+        errors.empty?
+      end
+
+      def invalid?
+        !valid?
+      end
+    end
+  end
+end

--- a/mrblib/1_validators.rb
+++ b/mrblib/1_validators.rb
@@ -1,0 +1,180 @@
+# Concrete validators for Funicular::Model, mirroring the standard Rails set.
+#
+# Named "1_" so the mruby build loads it after 0_validations.rb (which defines
+# EachValidator) but before model.rb. Keep this free of Ruby-only regexp
+# features: on the client, Regexp is a JS RegExp wrapper.
+module Funicular
+  class Model
+    module Validations
+      class PresenceValidator < EachValidator
+        def validate_each(record, attribute, value)
+          record.errors.add(attribute, options[:message] || "can't be blank") if blank?(value)
+        end
+      end
+
+      class AbsenceValidator < EachValidator
+        def validate_each(record, attribute, value)
+          record.errors.add(attribute, options[:message] || "must be blank") if present?(value)
+        end
+      end
+
+      class LengthValidator < EachValidator
+        def validate_each(record, attribute, value)
+          length = value.nil? ? 0 : value.to_s.length
+
+          if (min = options[:minimum]) && length < min
+            record.errors.add(attribute, options[:message] ||
+              "is too short (minimum is #{min} characters)")
+          end
+          if (max = options[:maximum]) && length > max
+            record.errors.add(attribute, options[:message] ||
+              "is too long (maximum is #{max} characters)")
+          end
+          if (exact = options[:is]) && length != exact
+            record.errors.add(attribute, options[:message] ||
+              "is the wrong length (should be #{exact} characters)")
+          end
+          if (range = options[:in] || options[:within]) && !range_include?(range, length)
+            record.errors.add(attribute, options[:message] || "is the wrong length")
+          end
+        end
+
+        private
+
+        def range_include?(range, length)
+          if range.respond_to?(:include?)
+            range.include?(length)
+          else
+            false
+          end
+        end
+      end
+
+      class FormatValidator < EachValidator
+        def validate_each(record, attribute, value)
+          str = value.to_s
+          if (with = options[:with]) && !str.match?(with)
+            record.errors.add(attribute, options[:message] || "is invalid")
+          end
+          if (without = options[:without]) && str.match?(without)
+            record.errors.add(attribute, options[:message] || "is invalid")
+          end
+        end
+      end
+
+      class NumericalityValidator < EachValidator
+        CHECKS = {
+          greater_than: ">",
+          greater_than_or_equal_to: ">=",
+          equal_to: "==",
+          less_than: "<",
+          less_than_or_equal_to: "<=",
+          other_than: "!="
+        }
+
+        def validate_each(record, attribute, value)
+          number = to_number(value)
+          if number.nil?
+            record.errors.add(attribute, options[:message] || "is not a number")
+            return
+          end
+
+          if options[:only_integer] && !number.is_a?(Integer)
+            record.errors.add(attribute, options[:message] || "must be an integer")
+            return
+          end
+
+          CHECKS.each do |option, _operator|
+            next unless options.key?(option)
+            unless compare(number, option, options[option])
+              record.errors.add(attribute, options[:message] || message_for(option, options[option]))
+            end
+          end
+        end
+
+        private
+
+        def compare(number, option, target)
+          case option
+          when :greater_than then number > target
+          when :greater_than_or_equal_to then number >= target
+          when :equal_to then number == target
+          when :less_than then number < target
+          when :less_than_or_equal_to then number <= target
+          when :other_than then number != target
+          else true
+          end
+        end
+
+        def message_for(option, target)
+          case option
+          when :greater_than then "must be greater than #{target}"
+          when :greater_than_or_equal_to then "must be greater than or equal to #{target}"
+          when :equal_to then "must be equal to #{target}"
+          when :less_than then "must be less than #{target}"
+          when :less_than_or_equal_to then "must be less than or equal to #{target}"
+          when :other_than then "must be other than #{target}"
+          else "is invalid"
+          end
+        end
+
+        def to_number(value)
+          return value if value.is_a?(Numeric)
+          str = value.to_s.strip
+          return nil if str.empty?
+          begin
+            Integer(str)
+          rescue
+            begin
+              Float(str)
+            rescue
+              nil
+            end
+          end
+        end
+      end
+
+      class InclusionValidator < EachValidator
+        def validate_each(record, attribute, value)
+          list = options[:in] || options[:within]
+          return unless list.respond_to?(:include?)
+          unless list.include?(value)
+            record.errors.add(attribute, options[:message] || "is not included in the list")
+          end
+        end
+      end
+
+      class ExclusionValidator < EachValidator
+        def validate_each(record, attribute, value)
+          list = options[:in] || options[:within]
+          return unless list.respond_to?(:include?)
+          if list.include?(value)
+            record.errors.add(attribute, options[:message] || "is reserved")
+          end
+        end
+      end
+
+      class AcceptanceValidator < EachValidator
+        def validate_each(record, attribute, value)
+          accepted = options[:accept] || ["1", "true", true]
+          accepted = [accepted] unless accepted.is_a?(Array)
+          unless accepted.include?(value)
+            record.errors.add(attribute, options[:message] || "must be accepted")
+          end
+        end
+      end
+
+      class ConfirmationValidator < EachValidator
+        def validate_each(record, attribute, value)
+          confirmation_attr = "#{attribute}_confirmation"
+          return unless record.respond_to?(confirmation_attr)
+          confirmation = record.send(confirmation_attr)
+          return if confirmation.nil?
+          if value != confirmation
+            record.errors.add(attribute, options[:message] || "doesn't match confirmation")
+          end
+        end
+      end
+    end
+  end
+end

--- a/mrblib/form_builder.rb
+++ b/mrblib/form_builder.rb
@@ -6,8 +6,12 @@ module Funicular
       @component = component
       @model_key = model_key
       @options = options
-      @error_class = options[:error_class] || "text-red-600 text-sm mt-1"
-      @field_error_class = options[:field_error_class] || "border-red-500"
+      @error_class = options[:error_class] || "text-red-600 text-sm mt-1 font-medium"
+      # A light-red fill plus a red ring stay visible regardless of how the
+      # field's own border-color utility is ordered in the stylesheet, giving a
+      # recognizable error highlight without fighting the base border class.
+      @field_error_class = options[:field_error_class] ||
+        "border-red-500 bg-red-50 ring-1 ring-red-500"
     end
 
     # Generic field builder for input elements
@@ -26,7 +30,10 @@ module Funicular
 
       # Check for errors
       error_message = @component.state.errors ? @component.state.errors[field_key.to_sym] : nil
-      has_error = !error_message.nil?
+      # errors may be a single message (legacy) or an array of messages
+      # (Funicular::Model::Errors#messages). Show the first.
+      error_message = error_message.first if error_message.is_a?(Array)
+      has_error = !(error_message.nil? || error_message == "")
 
       # Merge CSS classes (add error class if error exists)
       css_class = field_options[:class]
@@ -89,7 +96,10 @@ module Funicular
       end
 
       error_message = @component.state.errors ? @component.state.errors[field_key.to_sym] : nil
-      has_error = !error_message.nil?
+      # errors may be a single message (legacy) or an array of messages
+      # (Funicular::Model::Errors#messages). Show the first.
+      error_message = error_message.first if error_message.is_a?(Array)
+      has_error = !(error_message.nil? || error_message == "")
 
       css_class = options[:class]
       css_class = css_class.to_s if css_class
@@ -149,7 +159,10 @@ module Funicular
       end
 
       error_message = @component.state.errors ? @component.state.errors[field_key.to_sym] : nil
-      has_error = !error_message.nil?
+      # errors may be a single message (legacy) or an array of messages
+      # (Funicular::Model::Errors#messages). Show the first.
+      error_message = error_message.first if error_message.is_a?(Array)
+      has_error = !(error_message.nil? || error_message == "")
 
       css_class = options[:class]
       css_class = css_class.to_s if css_class

--- a/mrblib/form_builder.rb
+++ b/mrblib/form_builder.rb
@@ -6,12 +6,15 @@ module Funicular
       @component = component
       @model_key = model_key
       @options = options
-      @error_class = options[:error_class] || "text-red-600 text-sm mt-1 font-medium"
-      # A light-red fill plus a red ring stay visible regardless of how the
-      # field's own border-color utility is ordered in the stylesheet, giving a
-      # recognizable error highlight without fighting the base border class.
-      @field_error_class = options[:field_error_class] ||
-        "border-red-500 bg-red-50 ring-1 ring-red-500"
+      # Per-form options win, then the global Funicular.configure_forms config,
+      # then the built-in defaults. The defaults are semantic class names whose
+      # CSS the gem ships and injects via picoruby_include_tag, so error styling
+      # works without depending on the host app's CSS pipeline (e.g. Tailwind,
+      # which never scans the gem and so would not generate utility classes
+      # emitted from here).
+      config = Funicular.form_builder_config || {}
+      @error_class = options[:error_class] || config[:error_class] || "funicular-error"
+      @field_error_class = options[:field_error_class] || config[:field_error_class] || "funicular-field-error"
     end
 
     # Generic field builder for input elements

--- a/mrblib/funicular.rb
+++ b/mrblib/funicular.rb
@@ -66,10 +66,13 @@ module Funicular
   def self.window_state
     return {} if server?
     win = JS.global[:window]
+    # @type var win: JS::Object?
     return {} unless win
     raw = win[:__FUNICULAR_STATE__]
     return {} if raw.nil?
-    json_str = JS.global[:JSON].stringify(raw)
+    json = JS.global[:JSON]
+    # @type var json: untyped
+    json_str = json.stringify(raw)
     JSON.parse(json_str.to_s)
   rescue => e
     puts "[Funicular] Failed to read window state: #{e.message}"
@@ -80,6 +83,7 @@ module Funicular
   def self.has_ssr_state?
     return false if server?
     win = JS.global[:window]
+    # @type var win: JS::Object?
     return false unless win
     !win[:__FUNICULAR_STATE__].nil?
   rescue
@@ -209,7 +213,9 @@ module Funicular
         error_class: "funicular-error",
         field_error_class: "funicular-field-error"
       }
-      yield @form_builder_config if block_given?
+      config = @form_builder_config
+      # @type var config: Hash[Symbol, String]
+      yield config if block_given?
     end
   end
 

--- a/mrblib/funicular.rb
+++ b/mrblib/funicular.rb
@@ -203,9 +203,11 @@ module Funicular
     attr_accessor :form_builder_config
 
     def configure_forms
+      # Defaults are semantic class names whose CSS the gem ships and injects
+      # via picoruby_include_tag (see assets/funicular.css).
       @form_builder_config ||= {
-        error_class: "text-red-600 text-sm mt-1",
-        field_error_class: "border-red-500"
+        error_class: "funicular-error",
+        field_error_class: "funicular-field-error"
       }
       yield @form_builder_config if block_given?
     end

--- a/mrblib/html_serializer.rb
+++ b/mrblib/html_serializer.rb
@@ -25,10 +25,13 @@ module Funicular
       def render(vnode)
         case vnode&.type
         when :element
+          # @type var vnode: Funicular::VDOM::Element
           render_element(vnode)
         when :text
+          # @type var vnode: Funicular::VDOM::Text
           render_text(vnode)
         when :component
+          # @type var vnode: Funicular::VDOM::Component
           render_component(vnode)
         when nil
           ""
@@ -51,7 +54,7 @@ module Funicular
       end
 
       def render_children(children)
-        parts = []
+        parts = [] #: Array[String]
         children.each do |child|
           if child.is_a?(VNode)
             parts << render(child)
@@ -77,7 +80,7 @@ module Funicular
       end
 
       def serialize_props(props)
-        parts = []
+        parts = [] #: Array[String]
         props.each do |key, value|
           key_str = key.to_s
           next if SKIP_PROPS.include?(key)

--- a/mrblib/model.rb
+++ b/mrblib/model.rb
@@ -1,5 +1,7 @@
 module Funicular
   class Model
+    include Validations
+
     attr_reader :id
 
     class << self
@@ -22,6 +24,41 @@ module Funicular
             @changed_attributes[name] = value
           end
         end
+
+        # Validations are inlined per attribute by Funicular::Schema.build.
+        register_schema_validations(name => config["validations"]) if config["validations"]
+      end
+
+      # Backward-compatible: a top-level { attr => rules } block also works.
+      register_schema_validations(schema_data["validations"])
+    end
+
+    # validations: { "attr" => { "presence" => true, "length" => { "maximum" => 30 } } }
+    def self.register_schema_validations(validations)
+      return unless validations.is_a?(Hash)
+      validations.each do |attribute, rules|
+        next unless rules.is_a?(Hash)
+        rules.each do |kind, opts|
+          options = normalize_validation_options(kind, opts)
+          add_schema_validator(attribute, kind, options)
+        end
+      end
+    end
+
+    # Turn JSON-shaped validator options into the Ruby options the client
+    # validators expect (notably rebuilding a Regexp for `format`). Integer
+    # Regexp flags are used so this works the same under CRuby and the client
+    # JS RegExp wrapper.
+    def self.normalize_validation_options(kind, opts)
+      return opts unless opts.is_a?(Hash)
+      if kind.to_s == "format" && opts["with"]
+        flags = opts["flags"].to_s
+        bits = 0
+        bits |= Regexp::IGNORECASE if flags.include?("i")
+        bits |= Regexp::MULTILINE if flags.include?("m")
+        { with: Regexp.new(opts["with"], bits) }
+      else
+        opts
       end
     end
 
@@ -70,6 +107,13 @@ module Funicular
       endpoint = @endpoints["create"]
       return unless endpoint
 
+      # Validate on the client before the request (mirrors ActiveRecord#save).
+      candidate = new(attrs)
+      unless candidate.valid?
+        block.call(nil, candidate.errors) if block
+        return
+      end
+
       HTTP.post(endpoint["path"], attrs) do |response|
         if response.error?
           block.call(nil, response.error_message) if block
@@ -99,6 +143,12 @@ module Funicular
     def update(attrs = nil, &block)
       if attrs
         attrs.each { |k, v| send("#{k}=", v) }
+      end
+
+      # Validate on the client before the request (mirrors ActiveRecord#save).
+      unless valid?
+        block.call(false, errors) if block
+        return
       end
 
       return if @changed_attributes.empty?

--- a/sig/component.rbs
+++ b/sig/component.rbs
@@ -54,6 +54,8 @@ module Funicular
 
     def patch: (Hash[Symbol, untyped] new_state) -> void
     def mount: (JS::Element container) -> void
+    def hydrate: (JS::Element dom_element) -> void
+    def seed_state: (Hash[untyped, untyped]? state_hash) -> self
     def unmount: () -> void
     def render: () -> (VDOM::VNode | String | Integer | Float | Array[untyped] | nil)
     def bind_events: (JS::Element dom_element, VDOM::VNode | VDOM::Text | nil vnode) -> void
@@ -97,6 +99,12 @@ module Funicular
     private def add_child: (untyped child) -> void
     private def collect_child_components: (VDOM::VNode | VDOM::Text | nil vnode) -> void
     private def collect_child_components_recursive: (VDOM::VNode | VDOM::Text | nil vnode, Array[Component] components) -> void
+
+    # Hydration helpers
+    private def hydration_match?: (untyped vnode, untyped dom_element) -> bool
+    private def warn_hydration_mismatch: (untyped vnode, untyped dom_element) -> void
+    private def full_render_fallback: (VDOM::VNode | VDOM::Text | nil new_vdom, untyped server_dom) -> JS::Element
+    private def hydrate_child_components: (untyped vnode, untyped dom_element) -> void
 
     # HTML element methods (DSL)
     def div: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element

--- a/sig/funicular.rbs
+++ b/sig/funicular.rbs
@@ -1,13 +1,26 @@
 module Funicular
   VERSION: String
 
+  self.@server: bool
+  self.@form_builder_config: Hash[Symbol, String]?
+
   def self.version: () -> String
   def self.env: () -> EnvironmentInquirer
   def self.env=: (EnvironmentInquirer | String environment) -> EnvironmentInquirer?
   def self.router: () -> Router?
+
+  # SSR / hydration support
+  def self.server?: () -> bool
+  def self.server=: (untyped value) -> bool
+  def self.window_state: () -> Hash[String, untyped]
+  def self.has_ssr_state?: () -> bool
+  def self.first_element_child: (JS::Element container_element) -> JS::Element?
+
   def self.load_schemas: (Hash[singleton(Model), String] models) ?{ () -> void } -> void
-  def self.start: (?singleton(Component)? component_class, ?container: String | JS::Element, ?props: Hash[Symbol, untyped]) ?{ (Router router) -> void } -> (Component | Router)
+  def self.start: (?singleton(Component)? component_class, ?container: String | JS::Element, ?props: Hash[Symbol, untyped], ?hydrate: bool) ?{ (Router router) -> void } -> (Component | Router | nil)
   def self.configure_forms: () ?{ (Hash[Symbol, String]) -> void } -> void
+  def self.form_builder_config: () -> Hash[Symbol, String]?
+  def self.form_builder_config=: (Hash[Symbol, String] config) -> Hash[Symbol, String]
   def self.configure_debug: () ?{ (self) -> void } -> void
   def self.export_debug_config: () -> void
 

--- a/sig/html_serializer.rbs
+++ b/sig/html_serializer.rbs
@@ -1,0 +1,20 @@
+module Funicular
+  module VDOM
+    class HTMLSerializer
+      VOID_ELEMENTS: Array[String]
+      SKIP_PROPS: Array[Symbol]
+
+      def self.serialize: (VNode? vnode) -> String
+      def render: (VNode? vnode) -> String
+
+      private
+      def render_element: (Element element) -> String
+      def render_children: (Array[child_t] children) -> String
+      def render_text: (Text text) -> String
+      def render_component: (Component component_vnode) -> String
+      def serialize_props: (Hash[Symbol, untyped] props) -> String
+      def escape_html: (untyped str) -> String
+      def escape_attr: (untyped str) -> String
+    end
+  end
+end

--- a/sig/model.rbs
+++ b/sig/model.rbs
@@ -1,5 +1,8 @@
 module Funicular
   class Model
+    include Funicular::Model::Validations
+    extend Funicular::Model::Validations::ClassMethods
+
     attr_reader id: untyped
     @changed_attributes: Hash[String, untyped]
 
@@ -10,10 +13,12 @@ module Funicular
 
     def initialize: (?Hash[untyped, untyped] attributes) -> void
     def self.load_schema: (Hash[String, untyped] schema_data) -> void
+    def self.register_schema_validations: (untyped validations) -> void
+    def self.normalize_validation_options: (Symbol | String kind, untyped opts) -> untyped
 
     def self.all: (?Hash[untyped, untyped] params) ?{ (Array[Model]? instances, String? error) -> void } -> void
     def self.find: (?untyped id, ?endpoint_name: String, ?model_class: singleton(Model)) ?{ (Model? instance, String? error) -> void } -> void
-    def self.create: (Hash[untyped, untyped] attrs, ?model_class: singleton(Model)) ?{ (Model? instance, String? error) -> void } -> void
+    def self.create: (Hash[untyped, untyped] attrs, ?model_class: singleton(Model)) ?{ (Model? instance, untyped error) -> void } -> void
     def self.destroy: (?untyped id) ?{ (bool success, untyped result) -> void } -> void
 
     def update: (?Hash[untyped, untyped]? attrs) ?{ (bool success, untyped result) -> void } -> void

--- a/sig/router.rbs
+++ b/sig/router.rbs
@@ -19,7 +19,7 @@ module Funicular
     attr_reader current_component: Component?
     attr_reader current_path: String?
 
-    def initialize: (JS::Element container) -> void
+    def initialize: (JS::Element? container) -> void
     def get: (String path, to: singleton(Component), ?as: String?, ?constraints: route_constraints_t?) -> void
     def post: (String path, to: singleton(Component), ?as: String?, ?constraints: route_constraints_t?) -> void
     def put: (String path, to: singleton(Component), ?as: String?, ?constraints: route_constraints_t?) -> void
@@ -27,7 +27,8 @@ module Funicular
     def delete: (String path, to: singleton(Component), ?as: String?, ?constraints: route_constraints_t?) -> void
     def add_route: (String path, singleton(Component) component_class, ?as: String?, ?constraints: route_constraints_t?) -> void
     def set_default: (String path) -> void
-    def start: () -> void
+    def match: (String path) -> [singleton(Component)?, Hash[Symbol, untyped]]
+    def start: (?hydrate: bool) -> void
     def stop: () -> void
     def navigate: (String path) -> void
     def current_hash_path: () -> String

--- a/sig/validations.rbs
+++ b/sig/validations.rbs
@@ -1,0 +1,103 @@
+module Funicular
+  class Model
+    # Validation error collection (a small slice of ActiveModel::Errors).
+    class Errors
+      @messages: Hash[Symbol, Array[String]]
+
+      def initialize: () -> void
+      def add: (Symbol | String attribute, String message) -> String
+      def []: (Symbol | String attribute) -> Array[String]
+      def added?: (Symbol | String attribute) -> bool
+      def messages: () -> Hash[Symbol, Array[String]]
+      def full_messages: () -> Array[String]
+      def clear: () -> void
+      def empty?: () -> bool
+      def any?: () -> bool
+
+      private
+      def humanize: (Symbol | String attribute) -> String
+    end
+
+    # ActiveModel-style validation, mixed into Model.
+    module Validations
+      def self.included: (untyped base) -> void
+
+      # Base class for attribute validators.
+      class EachValidator
+        @attributes: Array[Symbol]
+        @options: Hash[Symbol, untyped]
+
+        attr_reader attributes: Array[Symbol]
+        attr_reader options: Hash[Symbol, untyped]
+
+        def initialize: (attributes: Array[Symbol], **untyped options) -> void
+        def kind: () -> Symbol
+        def validate: (untyped record) -> void
+        def validate_each: (untyped record, Symbol attribute, untyped value) -> void
+
+        private
+        def blank?: (untyped value) -> bool
+        def present?: (untyped value) -> bool
+      end
+
+      module ClassMethods
+        @validators: Array[EachValidator]
+
+        SHARED_OPTIONS: Array[Symbol]
+
+        def validators: () -> Array[EachValidator]
+        def validators_on: (Symbol | String attribute) -> Array[EachValidator]
+        def validates: (*Symbol | String attributes, **untyped options) -> void
+        def add_schema_validator: (Symbol | String attribute, Symbol | String kind, untyped opts) -> void
+
+        private
+        def validator_class_for: (Symbol | String key) -> singleton(EachValidator)?
+        def symbolize_keys: (untyped hash) -> Hash[Symbol, untyped]
+      end
+
+      # Instance API (mixed into Model).
+      @errors: Errors
+      def errors: () -> Errors
+      def read_attribute_for_validation: (Symbol attribute) -> untyped
+      def valid?: () -> bool
+      def invalid?: () -> bool
+
+      # --- concrete validators ---
+
+      class PresenceValidator < EachValidator
+      end
+
+      class AbsenceValidator < EachValidator
+      end
+
+      class LengthValidator < EachValidator
+        private
+        def range_include?: (untyped range, Integer length) -> bool
+      end
+
+      class FormatValidator < EachValidator
+      end
+
+      class NumericalityValidator < EachValidator
+        CHECKS: Hash[Symbol, String]
+
+        private
+        def compare: (Numeric number, Symbol option, untyped target) -> bool
+        def message_for: (Symbol option, untyped target) -> String
+        def to_number: (untyped value) -> (Numeric | nil)
+      end
+
+      class InclusionValidator < EachValidator
+      end
+
+      class ExclusionValidator < EachValidator
+      end
+
+      class AcceptanceValidator < EachValidator
+      end
+
+      class ConfirmationValidator < EachValidator
+      end
+    end
+  end
+end

--- a/test/validations_test.rb
+++ b/test/validations_test.rb
@@ -1,0 +1,77 @@
+# Client-side validation framework, mruby/PicoRuby side. The same code is
+# tested under CRuby in minitest/validations_test.rb; this file confirms it
+# runs on the real target VM, including FormatValidator against the JS RegExp
+# engine. Models are built at runtime via Class.new so Funicular::Model is
+# referenced only inside methods (load-time references resolve too early).
+class ValidationsTest < Picotest::Test
+  def model_with
+    k = Class.new(Funicular::Model)
+    k.load_schema(
+      "attributes" => {
+        "name" => { "type" => "string", "readonly" => false },
+        "age" => { "type" => "string", "readonly" => false }
+      },
+      "endpoints" => {}
+    )
+    yield k
+    k
+  end
+
+  def test_presence
+    k = model_with { |c| c.validates :name, presence: true }
+    blank = k.new("name" => "")
+    assert_equal(false, blank.valid?)
+    assert_equal(["can't be blank"], blank.errors[:name])
+    assert_equal(true, k.new("name" => "Alice").valid?)
+  end
+
+  def test_length
+    k = model_with { |c| c.validates :name, length: { minimum: 2, maximum: 5 } }
+    short = k.new("name" => "a")
+    assert_equal(false, short.valid?)
+    assert_equal(["is too short (minimum is 2 characters)"], short.errors[:name])
+    assert_equal(true, k.new("name" => "abc").valid?)
+  end
+
+  # FormatValidator runs the regexp through the JS RegExp engine. Patterns must
+  # be written in JS syntax (^...$, not \A...\z).
+  def test_format_with_js_regexp
+    k = model_with { |c| c.validates :name, format: { with: /^[a-z]+$/ } }
+    assert_equal(true, k.new("name" => "abc").valid?)
+    bad = k.new("name" => "ABC")
+    assert_equal(false, bad.valid?)
+    assert_equal(["is invalid"], bad.errors[:name])
+  end
+
+  def test_numericality
+    k = model_with { |c| c.validates :age, numericality: { only_integer: true, greater_than: 0 } }
+    assert_equal(false, k.new("age" => "abc").valid?)
+    assert_equal(true, k.new("age" => "10").valid?)
+    low = k.new("age" => "0")
+    assert_equal(false, low.valid?)
+    assert_equal(["must be greater than 0"], low.errors[:age])
+  end
+
+  def test_inclusion
+    k = model_with { |c| c.validates :name, inclusion: { in: ["a", "b"] } }
+    assert_equal(true, k.new("name" => "a").valid?)
+    assert_equal(false, k.new("name" => "z").valid?)
+  end
+
+  # Inline shape produced by Funicular::Schema.build: validations nested in
+  # each attribute entry.
+  def test_inline_schema_validations
+    k = Class.new(Funicular::Model)
+    k.load_schema(
+      "attributes" => {
+        "name" => {
+          "type" => "string", "readonly" => false,
+          "validations" => { "presence" => true, "length" => { "maximum" => 3 } }
+        }
+      },
+      "endpoints" => {}
+    )
+    assert_equal(false, k.new("name" => "toolong").valid?)
+    assert_equal(true, k.new("name" => "ok").valid?)
+  end
+end


### PR DESCRIPTION
This pull request introduces client-side model validations and improves error styling for forms in Funicular. It adds a mechanism to derive validation rules from server-side ActiveRecord models, injects a minimal CSS stylesheet for error highlighting, and updates documentation to reflect these features and their usage.

**Model validation and schema derivation:**

* Added the `Funicular::Schema` module (`lib/funicular/schema.rb`) to derive client-side validation rules from ActiveRecord/ActiveModel models, supporting common validator kinds and translating Ruby regexps to JavaScript-compatible forms.
* Added tests for schema derivation, covering allowlists, denylists, conditional and unsupported validators, and regexp translation (`minitest/schema_test.rb`).

**Form error styling and base CSS:**

* Added a minimal, namespaced CSS stylesheet (`lib/funicular/assets/funicular.css`) for error highlighting, injected automatically by `picoruby_include_tag` unless disabled.
* Updated the Picoruby helper to inject the base CSS by default, with an option to skip it (`lib/funicular/helpers/picoruby_helper.rb`). [[1]](diffhunk://#diff-0a96195b9c8d76a0c862890d145e9a05ceb9d9ce5ee05776310ff266e290c6b0R14-R21) [[2]](diffhunk://#diff-0a96195b9c8d76a0c862890d145e9a05ceb9d9ce5ee05776310ff266e290c6b0L23-R42)

**Documentation updates:**

* Added a new "Validations" documentation page explaining client-side model validation, schema derivation, and caveats (`docs/validations.md`).
* Updated the forms documentation to describe the new default error classes, CSS injection, and how to customize or override error styles (`docs/forms.md`). [[1]](diffhunk://#diff-ea812a39d1fa73551fcadfb84a6ec18f559d0c32b5fd7728459353cf4455813cL143-R143) [[2]](diffhunk://#diff-ea812a39d1fa73551fcadfb84a6ec18f559d0c32b5fd7728459353cf4455813cL156-R160) [[3]](diffhunk://#diff-ea812a39d1fa73551fcadfb84a6ec18f559d0c32b5fd7728459353cf4455813cR211-R215) [[4]](diffhunk://#diff-ea812a39d1fa73551fcadfb84a6ec18f559d0c32b5fd7728459353cf4455813cR237-R238)
* Linked the new validations documentation from the main README (`docs/README.md`).

**Other changes:**

* Required the new schema module in the main Funicular entrypoint (`lib/funicular.rb`).
* Registered the new validation runtime modules for SSR (`lib/funicular/ssr/runtime.rb`).