### PR TITLE
[Feature] Add Funicular plugin gem support

### DIFF
--- a/lib/funicular.rb
+++ b/lib/funicular.rb
@@ -3,6 +3,7 @@
 require_relative "funicular/version"
 require_relative "funicular/configuration"
 require_relative "funicular/compiler"
+require_relative "funicular/plugin"
 require_relative "funicular/schema"
 require_relative "funicular/ssr"
 

--- a/lib/funicular/compiler.rb
+++ b/lib/funicular/compiler.rb
@@ -25,13 +25,14 @@ module Funicular
       models_files + stores_files + components_files + initializer_files
     end
 
-    attr_reader :source_dir, :output_file, :debug_mode, :logger
+    attr_reader :source_dir, :output_file, :debug_mode, :logger, :prepend_source_files
 
-    def initialize(source_dir:, output_file:, debug_mode: false, logger: nil)
+    def initialize(source_dir:, output_file:, debug_mode: false, logger: nil, prepend_source_files: [])
       @source_dir = source_dir
       @output_file = output_file
       @debug_mode = debug_mode
       @logger = logger
+      @prepend_source_files = prepend_source_files.map(&:to_s)
     end
 
     def compile
@@ -92,7 +93,7 @@ module Funicular
         f.puts "ENV['FUNICULAR_ENV'] = '#{Rails.env}'"
       end
 
-      @source_files = all_files
+      @source_files = prepend_source_files + all_files
       @env_file = env_file
     end
 
@@ -108,14 +109,15 @@ module Funicular
       output_dir = File.dirname(output_file)
       FileUtils.mkdir_p(output_dir) unless Dir.exist?(output_dir)
 
-      all_files = @source_files + [@env_file]
+      all_files = @source_files.dup
+      all_files << @env_file if @env_file
       argv = [node_command, PICORBC_JS]
       argv << "-g" if debug_mode
       argv += ["-o", output_file.to_s]
       argv += all_files.map(&:to_s)
 
-      log "Compiling Funicular application..."
-      log "  Source: #{source_dir}"
+      log "Compiling Funicular Ruby..."
+      log "  Source: #{source_dir}" if source_dir
       log "  Input files:"
       all_files.each do |file|
         log "    - #{file}"

--- a/lib/funicular/helpers/picoruby_helper.rb
+++ b/lib/funicular/helpers/picoruby_helper.rb
@@ -67,6 +67,28 @@ module Funicular
         raw("<script>window.__FUNICULAR_STATE__ = #{safe};</script>")
       end
 
+      # Renders registered Funicular plugin browser assets.
+      #
+      # Plugins are gems in the Gemfile :funicular group. Their Ruby sources
+      # are compiled into app.mrb before the application sources; this helper
+      # emits browser assets such as CSS.
+      def funicular_plugin_include_tags
+        registry = Funicular::Plugin::Registry.new(Rails.root)
+        tags = registry.asset_entries.map do |entry|
+          logical_path = entry.fetch("logical_path")
+          if entry["type"] == "css"
+            stylesheet_link_tag(logical_path, "data-turbo-track": "reload")
+          else
+            tag.script("", type: "application/x-mrb", src: asset_path(logical_path), data: { funicular_plugin: true })
+          end
+        end
+        safe_join(tags)
+      rescue Funicular::Plugin::Error => e
+        raise e if Rails.env.production?
+
+        tag.comment("Funicular plugin assets skipped: #{e.message}")
+      end
+
       private
 
       def picoruby_src_for(source)

--- a/lib/funicular/middleware.rb
+++ b/lib/funicular/middleware.rb
@@ -49,13 +49,17 @@ module Funicular
 
       begin
         Rails.logger.info "Funicular: Source files changed, recompiling..."
-        compiler = Compiler.new(
-          source_dir: @source_dir,
-          output_file: @output_file,
-          debug_mode: true,
-          logger: Rails.logger
-        )
-        compiler.compile
+        plugin_registry = build_plugins
+        if Dir.exist?(@source_dir)
+          compiler = Compiler.new(
+            source_dir: @source_dir,
+            output_file: @output_file,
+            debug_mode: true,
+            logger: Rails.logger,
+            prepend_source_files: plugin_registry.local_source_files
+          )
+          compiler.compile
+        end
         self.class.last_mtime = current_mtime
         invalidate_asset_pipeline_cache
       rescue => e
@@ -90,9 +94,30 @@ module Funicular
 
     def latest_source_mtime
       source_files = Dir.glob(File.join(@source_dir, "**", "*.rb"))
-      return Time.at(0) if source_files.empty?
+      plugin_files = plugin_source_files
+      all_files = source_files + plugin_files
+      return Time.at(0) if all_files.empty?
 
-      source_files.map { |f| File.mtime(f) }.max
+      all_files.map { |f| File.mtime(f) }.max
+    end
+
+    def build_plugins
+      registry = Plugin::Registry.new(Rails.root)
+      return registry if registry.specs.empty?
+
+      registry.validate!
+      registry.sync_assets
+      registry
+    rescue Plugin::Error => e
+      Rails.logger.error "Funicular plugin compilation failed: #{e.message}"
+      Plugin::Registry.new(Rails.root)
+    end
+
+    def plugin_source_files
+      registry = Plugin::Registry.new(Rails.root)
+      registry.local_source_files + registry.specs.flat_map { |spec| spec.css_paths.map(&:to_s) }
+    rescue Plugin::Error
+      []
     end
   end
 end

--- a/lib/funicular/plugin.rb
+++ b/lib/funicular/plugin.rb
@@ -1,0 +1,147 @@
+# frozen_string_literal: true
+
+require "fileutils"
+require "pathname"
+
+module Funicular
+  module Plugin
+    BUILD_DIR = "app/assets/builds/funicular/plugins"
+    GROUP = :funicular
+
+    class Error < StandardError; end
+
+    class Project
+      attr_reader :root
+
+      def initialize(root)
+        @root = Pathname(root).expand_path
+      end
+
+      def assets_dir
+        root.join("assets")
+      end
+
+      def source_dir
+        root.join("lib")
+      end
+
+      def source_files
+        nested = Dir.glob(source_dir.join("*", "**", "*.rb").to_s).sort
+        top_level = Dir.glob(source_dir.join("*.rb").to_s).sort
+        nested + top_level
+      end
+
+      def css_paths
+        Dir.glob(assets_dir.join("*.css").to_s).sort.map { |path| Pathname(path) }
+      end
+    end
+
+    class Spec
+      attr_reader :bundler_spec
+
+      def initialize(bundler_spec)
+        @bundler_spec = bundler_spec
+      end
+
+      def root
+        @root ||= Pathname(bundler_spec.full_gem_path).expand_path
+      end
+
+      def project
+        @project ||= Project.new(root)
+      end
+
+      def name
+        bundler_spec.name
+      end
+
+      def css_paths
+        project.css_paths
+      end
+
+      def validate!
+        raise Error, "Missing Funicular plugin gem: #{root}" unless root.exist?
+        raise Error, "No Ruby source files found in #{project.source_dir}" if project.source_files.empty?
+
+        self
+      end
+    end
+
+    class Registry
+      attr_reader :rails_root
+
+      def initialize(rails_root)
+        @rails_root = Pathname(rails_root).expand_path
+      end
+
+      def specs
+        @specs ||= funicular_specs.map { |spec| Spec.new(spec) }
+      end
+
+      def sync_assets
+        build_root = rails_root.join(BUILD_DIR)
+        FileUtils.mkdir_p(build_root)
+
+        validated_specs.each do |spec|
+          target_dir = build_root.join(Plugin.safe_name(spec.name))
+          FileUtils.rm_rf(target_dir)
+          FileUtils.mkdir_p(target_dir)
+          spec.css_paths.each do |path|
+            FileUtils.cp(path, target_dir.join(File.basename(path))) if path.exist?
+          end
+        end
+      end
+
+      def local_source_files
+        validated_specs.flat_map { |spec| spec.project.source_files }
+      end
+
+      def asset_entries
+        validated_specs.flat_map do |spec|
+          safe_name = Plugin.safe_name(spec.name)
+          css = spec.css_paths.map { |path| File.basename(path) }
+          css.map { |file| { "type" => "css", "logical_path" => "funicular/plugins/#{safe_name}/#{file}" } }
+        end
+      end
+
+      def validate!
+        specs.each(&:validate!)
+      end
+
+      private
+
+      def funicular_specs
+        names = bundler_dependencies
+                .select { |dependency| dependency.groups.include?(GROUP) }
+                .map(&:name)
+        return [] if names.empty?
+
+        bundler_specs.select { |spec| names.include?(spec.name) }
+      end
+
+      def bundler_dependencies
+        require "bundler"
+
+        Bundler.definition.dependencies
+      rescue LoadError
+        raise Error, "Bundler is required to resolve Funicular plugin gems"
+      end
+
+      def bundler_specs
+        require "bundler"
+
+        Bundler.load.specs
+      rescue LoadError
+        raise Error, "Bundler is required to resolve Funicular plugin gems"
+      end
+
+      def validated_specs
+        specs.map(&:validate!)
+      end
+    end
+
+    def self.safe_name(name)
+      name.to_s.split("/").last.gsub(/[^a-zA-Z0-9]+/, "_").gsub(/\A_+|_+\z/, "").downcase
+    end
+  end
+end

--- a/lib/funicular/testing/node_runner.rb
+++ b/lib/funicular/testing/node_runner.rb
@@ -84,12 +84,31 @@ module Funicular
       def source_files
         return [] unless Dir.exist?(source_dir)
 
-        files = if defined?(Funicular::Compiler)
+        files = if rails_app_source_dir? && defined?(Funicular::Compiler)
                   Funicular::Compiler.source_files(source_dir)
                 else
-                  Dir.glob(File.join(source_dir, "**", "*.rb")).sort
+                  generic_source_files
                 end
-        files.reject { |path| File.basename(path) == "initializer.rb" || path.end_with?("_initializer.rb") }
+        app_files = files.reject { |path| File.basename(path) == "initializer.rb" || path.end_with?("_initializer.rb") }
+        plugin_source_files + app_files
+      end
+
+      def rails_app_source_dir?
+        source_dir == File.expand_path(File.join(app_root, "app", "funicular"))
+      end
+
+      def generic_source_files
+        nested = Dir.glob(File.join(source_dir, "*", "**", "*.rb")).sort
+        top_level = Dir.glob(File.join(source_dir, "*.rb")).sort
+        nested + top_level
+      end
+
+      def plugin_source_files
+        return [] unless defined?(Funicular::Plugin::Registry)
+
+        Funicular::Plugin::Registry.new(app_root).local_source_files
+      rescue Funicular::Plugin::Error
+        []
       end
 
       def test_files

--- a/lib/tasks/funicular.rake
+++ b/lib/tasks/funicular.rake
@@ -4,6 +4,7 @@ namespace :funicular do
   desc "Compile Funicular Ruby files to .mrb format"
   task compile: :environment do
     require "funicular/compiler"
+    require "funicular/plugin"
 
     source_dir = Rails.root.join("app", "funicular")
     output_file = Rails.root.join("app", "assets", "builds", "app.mrb")
@@ -15,12 +16,19 @@ namespace :funicular do
     end
 
     begin
+      plugin_registry = Funicular::Plugin::Registry.new(Rails.root)
+      plugin_registry.validate!
+      plugin_registry.sync_assets
       compiler = Funicular::Compiler.new(
         source_dir: source_dir,
         output_file: output_file,
-        debug_mode: debug_mode
+        debug_mode: debug_mode,
+        prepend_source_files: plugin_registry.local_source_files
       )
       compiler.compile
+    rescue Funicular::Plugin::Error => e
+      puts "ERROR: #{e.message}"
+      exit 1
     rescue Funicular::Compiler::PicorbcMissingError => e
       puts "ERROR: #{e.message}"
       exit 1

--- a/minitest/plugin_test.rb
+++ b/minitest/plugin_test.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "fileutils"
+require "tmpdir"
+
+require_relative "test_helper"
+
+class PluginTest < Minitest::Test
+  def test_registry_resolves_funicular_group_gems_and_syncs_assets
+    Dir.mktmpdir do |dir|
+      rails_root = File.join(dir, "app")
+      gem_root = File.join(dir, "funicular-datepicker")
+      FileUtils.mkdir_p(File.join(gem_root, "lib", "components"))
+      FileUtils.mkdir_p(File.join(gem_root, "assets"))
+      File.write(File.join(gem_root, "lib", "date_picker.rb"), "# plugin entry\n")
+      File.write(File.join(gem_root, "lib", "components", "date_picker_component.rb"), "# component\n")
+      File.write(File.join(gem_root, "assets", "date_picker.css"), "/* css */\n")
+
+      spec = Gem::Specification.new do |s|
+        s.name = "funicular-datepicker"
+        s.version = "0.1.0"
+        s.full_gem_path = gem_root
+      end
+
+      registry = Funicular::Plugin::Registry.new(rails_root)
+      registry.define_singleton_method(:funicular_specs) { [spec] }
+      registry.sync_assets
+
+      synced_css = File.join(
+        rails_root,
+        "app",
+        "assets",
+        "builds",
+        "funicular",
+        "plugins",
+        "funicular_datepicker",
+        "date_picker.css"
+      )
+      assert File.exist?(synced_css)
+
+      entries = registry.asset_entries
+      assert_equal 1, entries.size
+      assert_equal "css", entries.first["type"]
+      assert_equal "funicular/plugins/funicular_datepicker/date_picker.css", entries.first["logical_path"]
+      assert_equal [
+        File.join(gem_root, "lib", "components", "date_picker_component.rb"),
+        File.join(gem_root, "lib", "date_picker.rb")
+      ], registry.local_source_files
+    end
+  end
+end

--- a/mrblib/component.rb
+++ b/mrblib/component.rb
@@ -192,10 +192,14 @@ module Funicular
     #     div { user.name }
     #   end
     def suspense(fallback:, error: nil, &block)
+      current_children = @current_children
+      child_count_before = current_children&.size
+      result = nil
+
       # Check for any rejected suspense
       rejected_name = self.class.suspense_definitions.keys.find { |name| @suspense_states[name] == :rejected }
       if rejected_name
-        if error
+        result = if error
           error.call(@suspense_errors[rejected_name])
         else
           fallback.call
@@ -203,13 +207,17 @@ module Funicular
       elsif suspense_loading?
         # Check if any suspense is still loading
         # Note: Loading is started in mount(), not here
-        fallback.call
+        result = fallback.call
       else
         # All suspense data loaded, render content
-        block.call
+        result = block.call
       end
-      # Note: We don't add result to @current_children because
-      # the DSL methods inside fallback/block already do that
+
+      if current_children && current_children.size == child_count_before
+        add_child(result)
+      end
+
+      result
     end
 
     # Class methods for styles DSL


### PR DESCRIPTION
Resolve Funicular plugins from gems in the Bundler `:funicular` group and prepend
their lib/**/*.rb sources before app/funicular sources during compilation.

Also copy plugin CSS assets into app/assets/builds/funicular/plugins, expose
`funicular_plugin_include_tags` for layouts, and include plugin sources in the
development recompile watcher and client-side test runner.

Plugin source discovery uses nested files before top-level files so a gem can
define components under lib/components/ and expose them from a top-level entry
file.

Add registry coverage for resolving plugin gems, syncing assets, and preserving
source order.