### PR TITLE
Improve form

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    funicular (0.2.0)
+    funicular (0.2.1)
       rails (~> 8.0)
 
 GEM

--- a/funicular.gemspec
+++ b/funicular.gemspec
@@ -65,7 +65,8 @@ Gem::Specification.new do |spec|
       seamless asset pipeline support.
         bin/rails funicular:install
 
-    For more information: https://github.com/picoruby/funicular
+    For Web App Developers: https://picoruby.org/funicular
+    For Funicular Contributors: https://github.com/picoruby/funicular
 
   MSG
 

--- a/lib/funicular/version.rb
+++ b/lib/funicular/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Funicular
-  VERSION = "0.2.0"
+  VERSION = "0.2.1"
 end

--- a/mrblib/form_builder.rb
+++ b/mrblib/form_builder.rb
@@ -117,13 +117,14 @@ module Funicular
       end
 
       attrs = {
+        value: value,
         oninput: on_input
       }.merge(options.reject { |k, _| k == :class })
 
       attrs[:class] = css_class unless css_class.empty?
 
       @component.div do
-        @component.textarea(attrs) { value }
+        @component.textarea(attrs)
         if has_error
           @component.div(class: @error_class) { error_message }
         end

--- a/mrblib/patcher.rb
+++ b/mrblib/patcher.rb
@@ -187,8 +187,10 @@ module Funicular
           if BOOLEAN_ATTRIBUTES.include?(key_str)
             if value.nil? || value.to_s == "false"
               element.removeAttribute(key_str)
+              element[key_str] = false
             else
               element.setAttribute(key_str, key_str)
+              element[key_str] = true
             end
           elsif value.nil?
             element.removeAttribute(key_str)
@@ -232,8 +234,10 @@ module Funicular
               element[:value] = value.to_s
             elsif BOOLEAN_ATTRIBUTES.include?(key_str)
               if value.nil? || value.to_s == "false"
+                element[key_str] = false
               else
                 element.setAttribute(key_str, key_str)
+                element[key_str] = true
               end
             else
               element.setAttribute(key_str, value.to_s)

--- a/mrblib/vdom.rb
+++ b/mrblib/vdom.rb
@@ -132,8 +132,10 @@ module Funicular
             # Handle boolean attributes
             if value.nil? || value.to_s == "false"
               # Do not set attribute (leave it absent)
+              dom_node[key_str] = false
             else
               dom_node.setAttribute(key_str, key_str)
+              dom_node[key_str] = true
             end
           else
             # Attribute

--- a/test/vdom_patcher_test.rb
+++ b/test/vdom_patcher_test.rb
@@ -171,6 +171,38 @@ class VDOMPatcherTest < Picotest::Test
     assert_nil(element.attributes['class'])
   end
 
+  def test_update_props_sets_boolean_property
+    element = @doc.createElement('button')
+    patches = [[:props, {disabled: true}]]
+
+    @patcher.apply(element, patches)
+
+    assert_equal('disabled', element.attributes['disabled'])
+    assert_equal(true, element.properties['disabled'])
+  end
+
+  def test_update_props_clears_boolean_property
+    element = @doc.createElement('button')
+    element.setAttribute('disabled', 'disabled')
+    element[:disabled] = true
+    patches = [[:props, {disabled: false}]]
+
+    @patcher.apply(element, patches)
+
+    assert_nil(element.attributes['disabled'])
+    assert_equal(false, element.properties['disabled'])
+  end
+
+  def test_update_props_sets_textarea_value_property
+    element = @doc.createElement('textarea')
+    patches = [[:props, {value: 'hello'}]]
+
+    @patcher.apply(element, patches)
+
+    assert_equal('hello', element.properties['value'])
+    assert_nil(element.attributes['value'])
+  end
+
   def test_update_props_skip_event_handlers
     element = @doc.createElement('div')
     patches = [[:props, {onclick: 'handler', class: 'foo'}]]
@@ -200,6 +232,23 @@ class VDOMPatcherTest < Picotest::Test
     assert(element.is_a?(MockElement))
     assert_equal('div', element.tag_name)
     assert_equal('foo', element.attributes['class'])
+    assert_equal(0, element.children.length)
+  end
+
+  def test_create_element_sets_boolean_property
+    vnode = Funicular::VDOM::Element.new('button', {disabled: true})
+    element = @patcher.send(:create_element, vnode)
+
+    assert_equal('disabled', element.attributes['disabled'])
+    assert_equal(true, element.properties['disabled'])
+  end
+
+  def test_create_element_sets_textarea_value_property
+    vnode = Funicular::VDOM::Element.new('textarea', {value: 'hello'})
+    element = @patcher.send(:create_element, vnode)
+
+    assert_equal('hello', element.properties['value'])
+    assert_nil(element.attributes['value'])
     assert_equal(0, element.children.length)
   end
 


### PR DESCRIPTION
## mrblib/form_builder.rb
- Amend managing textarea by `value: prop`, not children

## mrblib/patcher.rb
- Sync DOM property to the actual true/false value when updating boolan attibutes

## mrblib/vdom.rb
- Sync boolean DOM property even in initial render

## test/vdom_patcher_test.rb
- Add tests for boolean property and textarea value property