### PR TITLE
Fix form

### DIFF
--- a/minitest/form_for_test.rb
+++ b/minitest/form_for_test.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class FormForTest < Minitest::Test
+  def setup
+    Funicular::SSR::Runtime.load_framework!
+  end
+
+  def component_class
+    Class.new(Funicular::Component) do
+      attr_reader :submitted
+
+      def initialize_state
+        { comment: { body: "" } }
+      end
+
+      def handle_submit(data)
+        @submitted = data
+      end
+
+      def render
+        form_for(:comment, on_submit: :handle_submit) do |f|
+          f.textarea(:body)
+          f.submit("Post")
+        end
+      end
+    end
+  end
+
+  class SubmitEvent
+    attr_reader :target
+
+    def initialize(target)
+      @target = target
+      @prevented = false
+    end
+
+    def preventDefault
+      @prevented = true
+    end
+
+    def prevented?
+      @prevented
+    end
+
+    def [](key)
+      key == :target ? @target : nil
+    end
+  end
+
+  class FormElement
+    def initialize(elements)
+      @elements = Elements.new(elements)
+    end
+
+    def [](key)
+      key == :elements ? @elements : nil
+    end
+  end
+
+  class Elements
+    def initialize(elements)
+      @elements = elements
+    end
+
+    def [](key)
+      return @elements.length if key == :length
+
+      @elements[key]
+    end
+  end
+
+  class Field
+    def initialize(attrs)
+      @attrs = attrs
+    end
+
+    def [](key)
+      @attrs[key]
+    end
+  end
+
+  def test_form_for_submits_current_dom_values
+    component = component_class.new
+    vnode = component.build_vdom
+    event = SubmitEvent.new(
+      FormElement.new([
+        Field.new(name: "body", type: "textarea", value: "fresh")
+      ])
+    )
+
+    vnode.props[:onsubmit].call(event)
+
+    assert_predicate event, :prevented?
+    assert_equal({ body: "fresh" }, component.submitted)
+  end
+
+  def test_form_builder_fields_include_names
+    component = component_class.new
+    vnode = component.build_vdom
+    textarea = vnode.children[0].children[0]
+
+    assert_equal "body", textarea.props[:name]
+  end
+end

--- a/mrblib/component.rb
+++ b/mrblib/component.rb
@@ -854,20 +854,7 @@ module Funicular
         ->(event) do
           event.preventDefault
 
-          # Collect form data from state
-          model_data = state.send(model_key)
-          form_data = if model_data.is_a?(Hash)
-            model_data
-          elsif model_data.respond_to?(:instance_variables)
-            data = {} #: Hash[Symbol, untyped]
-            model_data.instance_variables.each do |var|
-              key = var.to_s.sub('@', '').to_sym
-              data[key] = model_data.instance_variable_get(var)
-            end
-            data
-          else
-            {} #: Hash[Symbol, untyped]
-          end
+          form_data = collect_form_data(event, model_key)
 
           # Call the submit handler (Symbol, Method, or Proc)
           case on_submit
@@ -889,6 +876,79 @@ module Funicular
       form({ onsubmit: submit_handler, class: form_class }.merge(options)) do
         builder = Funicular::FormBuilder.new(self, model_key, options)
         block.call(builder)
+      end
+    end
+
+    def collect_form_data(event, model_key)
+      form_data = collect_dom_form_data(event)
+      return form_data unless form_data.empty?
+
+      collect_state_form_data(model_key)
+    end
+
+    def collect_dom_form_data(event)
+      form = event_target(event)
+      return {} unless form
+
+      elements = form[:elements]
+      return {} unless elements
+
+      data = {} #: Hash[Symbol, untyped]
+      length_value = elements[:length]
+      length = length_value ? length_value.to_i : 0
+      i = 0
+      while i < length
+        field = elements[i]
+        add_form_field_value(data, field) if field
+        i += 1
+      end
+      data
+    end
+
+    def event_target(event)
+      target = nil
+      begin
+        target = event[:target]
+      rescue
+        target = nil
+      end
+      return target if target
+
+      event.target if event.respond_to?(:target)
+    end
+
+    def add_form_field_value(data, field)
+      name = field[:name].to_s
+      return if name.empty?
+
+      type = field[:type].to_s.downcase
+      return if %w[submit button reset].include?(type)
+      return if type == "radio" && !field[:checked]
+
+      value = if type == "checkbox"
+        field[:checked]
+      elsif type == "file"
+        field[:files]
+      else
+        field[:value]
+      end
+
+      data[name.to_sym] = value
+    end
+
+    def collect_state_form_data(model_key)
+      model_data = state.send(model_key)
+      if model_data.is_a?(Hash)
+        model_data
+      elsif model_data.respond_to?(:instance_variables)
+        data = {} #: Hash[Symbol, untyped]
+        model_data.instance_variables.each do |var|
+          key = var.to_s.sub('@', '').to_sym
+          data[key] = model_data.instance_variable_get(var)
+        end
+        data
+      else
+        {} #: Hash[Symbol, untyped]
       end
     end
 

--- a/mrblib/form_builder.rb
+++ b/mrblib/form_builder.rb
@@ -53,6 +53,7 @@ module Funicular
 
       # Build field attributes
       attrs = {
+        name: field_options[:name] || field_key,
         type: field_type,
         value: value,
         oninput: on_input
@@ -117,6 +118,7 @@ module Funicular
       end
 
       attrs = {
+        name: options[:name] || field_key,
         value: value,
         oninput: on_input
       }.merge(options.reject { |k, _| k == :class })
@@ -143,6 +145,7 @@ module Funicular
       end
 
       attrs = {
+        name: options[:name] || field_key,
         type: "checkbox",
         checked: value,
         onchange: on_change
@@ -181,6 +184,7 @@ module Funicular
       end
 
       attrs = {
+        name: options[:name] || field_key,
         onchange: on_change
       }.merge(options.reject { |k, _| k == :class })
 
@@ -223,6 +227,7 @@ module Funicular
       on_change = custom_handler || default_handler
 
       attrs = {
+        name: options[:name] || field_key,
         type: "file",
         onchange: on_change
       }.merge(options)

--- a/test/form_for_test.rb
+++ b/test/form_for_test.rb
@@ -1,0 +1,96 @@
+class FormForTest < Picotest::Test
+  class FormComponent < Funicular::Component
+    attr_reader :submitted
+
+    def initialize_state
+      { comment: { body: "" } }
+    end
+
+    def handle_submit(data)
+      @submitted = data
+    end
+
+    def render
+      form_for(:comment, on_submit: :handle_submit) do |f|
+        f.textarea(:body)
+        f.submit("Post")
+      end
+    end
+  end
+
+  class SubmitEvent
+    attr_reader :target
+
+    def initialize(target)
+      @target = target
+      @prevented = false
+    end
+
+    def preventDefault
+      @prevented = true
+    end
+
+    def prevented?
+      @prevented
+    end
+
+    def [](key)
+      key == :target ? @target : nil
+    end
+  end
+
+  class FormElement
+    def initialize(elements)
+      @elements = Elements.new(elements)
+    end
+
+    def [](key)
+      key == :elements ? @elements : nil
+    end
+  end
+
+  class Elements
+    def initialize(elements)
+      @elements = elements
+    end
+
+    def [](key)
+      return @elements.length if key == :length
+
+      @elements[key]
+    end
+  end
+
+  class Field
+    def initialize(attrs)
+      @attrs = attrs
+    end
+
+    def [](key)
+      @attrs[key]
+    end
+  end
+
+  def test_form_for_submits_current_dom_values
+    component = FormComponent.new
+    vnode = component.build_vdom
+    event = SubmitEvent.new(
+      FormElement.new([
+        Field.new(name: "body", type: "textarea", value: "fresh")
+      ])
+    )
+
+    vnode.props[:onsubmit].call(event)
+
+    assert_equal(true, event.prevented?)
+    assert_equal({ body: "fresh" }, component.submitted)
+  end
+
+  def test_form_builder_fields_include_names
+    component = FormComponent.new
+    vnode = component.build_vdom
+    textarea = vnode.children[0].children[0]
+
+    assert_equal("body", textarea.props[:name])
+  end
+end


### PR DESCRIPTION
## mrblib/component.rb
- The submit handler for `form_for` has been changed to collect form values from `event.target.elements` at the time of submission, instead of using `state`
- The `state` method is still used as a fallback only when the DOM cannot be retrieved

## mrblib/form_builder.rb
- Add `name` prop to text_field / textarea / checkbox / select / file_field

## minitest/form_for_test.rb
- Tests to confirm if presend DOM reaches to submit handler when state is old/stale