### PR TITLE
Update picorbc file names for mrbc-prism rename

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -66,7 +66,7 @@ task :copy_wasm do
   abort "Missing #{picorbc_src}" unless Dir.exist?(picorbc_src)
 
   picorbc_version = JSON.parse(File.read(File.join(npm_root, "picorbc", "package.json"))).fetch("version")
-  picorbc_files = %w[picorbc.js picorbc.wasm]
+  picorbc_files = %w[mrbc-prism.js mrbc-prism.wasm]
 
   FileUtils.rm_rf(picorbc_dest)
   FileUtils.mkdir_p(picorbc_dest)
@@ -75,7 +75,7 @@ task :copy_wasm do
     abort "Missing file: #{src_file}" unless File.exist?(src_file)
     FileUtils.copy_file(src_file, File.join(picorbc_dest, fname))
   end
-  File.chmod(0755, File.join(picorbc_dest, "picorbc.js"))
+  File.chmod(0755, File.join(picorbc_dest, "mrbc-prism.js"))
   File.write(File.join(picorbc_dest, "VERSION"), "#{picorbc_version}\n")
   puts "  copied picorbc (#{picorbc_version})"
 

--- a/lib/funicular/compiler.rb
+++ b/lib/funicular/compiler.rb
@@ -7,9 +7,9 @@ module Funicular
     class NodeNotFoundError < StandardError; end
     class PicorbcMissingError < StandardError; end
 
-    # picorbc.js + picorbc.wasm bundled into the gem at build time by `rake copy_wasm`.
+    # mrbc-prism.js + picorbc.wasm bundled into the gem at build time by `rake copy_wasm`.
     PICORBC_DIR = File.expand_path("vendor/picorbc", __dir__)
-    PICORBC_JS  = File.join(PICORBC_DIR, "picorbc.js")
+    PICORBC_JS  = File.join(PICORBC_DIR, "mrbc-prism.js")
 
     # Ordered list of application source files under app/funicular/.
     # Order matters: models -> stores -> components -> initializer, so that
@@ -48,7 +48,7 @@ module Funicular
         raise PicorbcMissingError, <<~ERROR
           Vendored picorbc not found at #{PICORBC_JS}.
 
-          The funicular gem ships picorbc.js + picorbc.wasm inside the gem
+          The funicular gem ships mrbc-prism.js + picorbc.wasm inside the gem
           package. This file is missing, which likely means the gem was not
           installed correctly. Try reinstalling:
 


### PR DESCRIPTION
With the rename of picorbc to mrbc-prism in picoruby/picoruby#437, the corresponding filenames from the picorbc-wasm build have changed. Use the new names when building the gem and in `Funicular::Compiler`.

I tried this with a clean install of https://github.com/hasumikin/funicular-demo alongside picoruby/picoruby#442 and it seemed to work.

This PR assumes you would like to keep the new file names - in case you would rather keep the old JS and WASM file names instead, this PR can be closed. Thanks!