### PR TITLE
Add generic tag method and expand HTML element coverage

### DIFF
--- a/minitest/ssr_test.rb
+++ b/minitest/ssr_test.rb
@@ -54,6 +54,12 @@ class SSRTest < Minitest::Test
     assert_equal '<img src="/a.png">', serialize(el("img", { src: "/a.png" }))
   end
 
+  def test_serializes_custom_element
+    component = Class.new(Funicular::Component).new
+    vnode = component.tag(:"custom-element", { id: "x" }) { "hi" }
+    assert_equal '<custom-element id="x">hi</custom-element>', serialize(vnode)
+  end
+
   def test_blocks_javascript_uri
     assert_equal "<a>x</a>",
                  serialize(el("a", { href: "javascript:alert(1)" }, ["x"]))

--- a/minitest/ssr_test.rb
+++ b/minitest/ssr_test.rb
@@ -60,6 +60,12 @@ class SSRTest < Minitest::Test
     assert_equal '<custom-element id="x">hi</custom-element>', serialize(vnode)
   end
 
+  def test_tag_rejects_invalid_and_active_tag_names
+    component = Class.new(Funicular::Component).new
+    assert_raises(ArgumentError) { component.tag("div><script>alert(1)</script><div") }
+    assert_raises(ArgumentError) { component.tag(:script) }
+  end
+
   def test_blocks_javascript_uri
     assert_equal "<a>x</a>",
                  serialize(el("a", { href: "javascript:alert(1)" }, ["x"]))

--- a/mrblib/component.rb
+++ b/mrblib/component.rb
@@ -809,7 +809,7 @@ module Funicular
       a em strong small cite q dfn abbr ruby rt rp data time code var samp kbd
       sub sup i b u mark bdi bdo span br wbr
       ins del
-      picture source img iframe embed object video audio track map area svg
+      picture source img iframe embed object video audio track map area
       table caption colgroup col tbody thead tfoot tr td th
       form label input button select datalist optgroup option textarea output
       progress meter fieldset legend

--- a/mrblib/component.rb
+++ b/mrblib/component.rb
@@ -750,18 +750,6 @@ module Funicular
       end
     end
 
-    # DSL methods for HTML elements
-    HTML_TAGS = %w[
-      div span p a
-      h1 h2 h3 h4 h5 h6
-      ul ol li
-      table thead tbody tr th td
-      form input textarea button select option label
-      header footer nav section article aside
-      img video audio canvas
-      br hr
-    ]
-
     # The HTML tag DSL methods are public: besides being called inside render
     # (implicit self), they are invoked by collaborators such as FormBuilder
     # with an explicit receiver (@component.div). A private method would forbid
@@ -769,45 +757,70 @@ module Funicular
     # any component using form_for. Keep them public on both VMs.
     public
 
-    HTML_TAGS.each do |tag|
-      define_method(tag) do |props = {}, &block|
+    # Generic element DSL. Builds a VDOM::Element for any tag name, so custom
+    # elements / Web Components (e.g. tag(:"custom-element")) and any HTML tag
+    # not listed in HTML_TAGS can be rendered. The named tag methods generated
+    # below are thin wrappers that delegate here with a fixed name.
+    def tag(name, props = {}, &block)
+      # @type self: Component
+      children = [] #: Array[Funicular::VDOM::child_t]
+
+      if block
+        prev_children = @current_children
+        @current_children = children
+        # @type var block: Proc
+        result = block.call
+        @current_children = prev_children
+
+        # Add block result to children if not already added via add_child
+        if result && !result.equal?(children) && children.empty?
+          normalized = normalize_vnode(result)
+          children << normalized if normalized
+        end
+      end
+
+      # Normalize props (convert StyleValue to String for :class)
+      normalized_props = {}
+      # @type var props: Hash[Symbol, String]
+      props.each do |key, value|
+        if key == :class && value.is_a?(StyleValue)
+          normalized_props[key] = value.to_s
+        else
+          normalized_props[key] = value
+        end
+      end
+
+      # @type var normalized_props: Hash[Symbol, String]
+      element = VDOM::Element.new(name.to_s, normalized_props, children)
+
+      # If we're inside another element's block, add this element to parent's children
+      if @rendering && @current_children
+        @current_children << element
+      end
+
+      element
+    end
+
+    # DSL methods for the HTML elements defined in the HTML Living Standard.
+    # `s` collides with the styles accessor, so it is excluded. Use tag instead.
+    HTML_TAGS = %w[
+      article section nav aside h1 h2 h3 h4 h5 h6 hgroup header footer address
+      p hr pre blockquote ol ul menu li dl dt dd figure figcaption main div
+      a em strong small cite q dfn abbr ruby rt rp data time code var samp kbd
+      sub sup i b u mark bdi bdo span br wbr
+      ins del
+      picture source img iframe embed object video audio track map area svg
+      table caption colgroup col tbody thead tfoot tr td th
+      form label input button select datalist optgroup option textarea output
+      progress meter fieldset legend
+      details summary dialog
+      canvas
+    ]
+
+    HTML_TAGS.each do |html_tag|
+      define_method(html_tag) do |props = {}, &block|
         # @type self: Component
-        children = [] #: Array[Funicular::VDOM::child_t]
-
-        if block
-          prev_children = @current_children
-          @current_children = children
-          # @type var block: Proc
-          result = block.call
-          @current_children = prev_children
-
-          # Add block result to children if not already added via add_child
-          if result && !result.equal?(children) && children.empty?
-            normalized = normalize_vnode(result)
-            children << normalized if normalized
-          end
-        end
-
-        # Normalize props (convert StyleValue to String for :class)
-        normalized_props = {}
-        # @type var props: Hash[Symbol, String]
-        props.each do |key, value|
-          if key == :class && value.is_a?(StyleValue)
-            normalized_props[key] = value.to_s
-          else
-            normalized_props[key] = value
-          end
-        end
-
-        # @type var normalized_props: Hash[Symbol, String]
-        element = VDOM::Element.new(tag, normalized_props, children)
-
-        # If we're inside another element's block, add this element to parent's children
-        if @rendering && @current_children
-          @current_children << element
-        end
-
-        element
+        tag(html_tag, props, &block)
       end
     end
 

--- a/mrblib/component.rb
+++ b/mrblib/component.rb
@@ -805,7 +805,8 @@ module Funicular
     # `s` collides with the styles accessor, so it is excluded. Use tag instead.
     HTML_TAGS = %w[
       article section nav aside h1 h2 h3 h4 h5 h6 hgroup header footer address
-      p hr pre blockquote ol ul menu li dl dt dd figure figcaption main div
+      p hr pre blockquote ol ul menu li dl dt dd figure figcaption main search
+      div
       a em strong small cite q dfn abbr ruby rt rp data time code var samp kbd
       sub sup i b u mark bdi bdo span br wbr
       ins del

--- a/mrblib/component.rb
+++ b/mrblib/component.rb
@@ -801,7 +801,9 @@ module Funicular
       element
     end
 
-    # DSL methods for the HTML elements defined in the HTML Living Standard.
+    # DSL methods for HTML elements defined in the HTML Living Standard,
+    # ordered by spec category. Named methods are generated for body content
+    # elements that the VDOM and HTMLSerializer render as-is.
     # `s` collides with the styles accessor, so it is excluded. Use tag instead.
     HTML_TAGS = %w[
       article section nav aside h1 h2 h3 h4 h5 h6 hgroup header footer address

--- a/sig/component.rbs
+++ b/sig/component.rbs
@@ -146,6 +146,7 @@ module Funicular
     def figure: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
     def figcaption: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
     def main: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
+    def search: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
     def div: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
 
     # text-level

--- a/sig/component.rbs
+++ b/sig/component.rbs
@@ -194,7 +194,6 @@ module Funicular
     def track: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
     def map: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
     def area: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
-    def svg: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
 
     # tabular
     def table: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element

--- a/sig/component.rbs
+++ b/sig/component.rbs
@@ -112,44 +112,124 @@ module Funicular
     private def full_render_fallback: (VDOM::VNode | VDOM::Text | nil new_vdom, untyped server_dom) -> JS::Element
     private def hydrate_child_components: (untyped vnode, untyped dom_element) -> void
 
-    # HTML element methods (DSL)
-    def div: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
-    def span: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
-    def p: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
-    def a: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
+    # DSL methods for the HTML elements defined in the HTML Living Standard.
+    def tag: (Symbol | String name, ?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
+
+    # sections
+    def article: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
+    def section: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
+    def nav: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
+    def aside: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
     def h1: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
     def h2: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
     def h3: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
     def h4: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
     def h5: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
     def h6: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
-    def ul: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
-    def ol: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
-    def li: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
-    def table: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
-    def thead: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
-    def tbody: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
-    def tr: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
-    def th: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
-    def td: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
-    def form: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
-    def input: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
-    def textarea: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
-    def button: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
-    def select: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
-    def option: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
-    def label: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
+    def hgroup: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
     def header: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
     def footer: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
-    def nav: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
-    def section: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
-    def article: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
-    def aside: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
+    def address: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
+
+    # grouping
+    def p: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
+    def hr: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
+    def pre: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
+    def blockquote: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
+    def ol: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
+    def ul: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
+    def menu: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
+    def li: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
+    def dl: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
+    def dt: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
+    def dd: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
+    def figure: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
+    def figcaption: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
+    def main: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
+    def div: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
+
+    # text-level
+    def a: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
+    def em: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
+    def strong: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
+    def small: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
+    def cite: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
+    def q: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
+    def dfn: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
+    def abbr: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
+    def ruby: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
+    def rt: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
+    def rp: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
+    def data: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
+    def time: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
+    def code: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
+    def var: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
+    def samp: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
+    def kbd: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
+    def sub: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
+    def sup: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
+    def i: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
+    def b: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
+    def u: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
+    def mark: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
+    def bdi: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
+    def bdo: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
+    def span: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
+    def br: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
+    def wbr: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
+
+    # edits
+    def ins: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
+    def del: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
+
+    # embedded
+    def picture: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
+    def source: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
     def img: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
+    def iframe: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
+    def embed: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
+    def object: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
     def video: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
     def audio: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
+    def track: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
+    def map: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
+    def area: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
+    def svg: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
+
+    # tabular
+    def table: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
+    def caption: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
+    def colgroup: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
+    def col: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
+    def tbody: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
+    def thead: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
+    def tfoot: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
+    def tr: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
+    def td: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
+    def th: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
+
+    # forms
+    def form: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
+    def label: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
+    def input: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
+    def button: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
+    def select: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
+    def datalist: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
+    def optgroup: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
+    def option: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
+    def textarea: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
+    def output: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
+    def progress: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
+    def meter: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
+    def fieldset: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
+    def legend: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
+
+    # interactive
+    def details: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
+    def summary: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
+    def dialog: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
+
+    # scripting
     def canvas: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
-    def br: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
-    def hr: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
   end
 end

--- a/test/html_serializer_test.rb
+++ b/test/html_serializer_test.rb
@@ -59,6 +59,12 @@ class HTMLSerializerTest < Picotest::Test
     assert_equal('<custom-element id="x">hi</custom-element>', serialize(vnode))
   end
 
+  def test_tag_rejects_invalid_and_active_tag_names
+    component = Class.new(Funicular::Component).new
+    assert_raise(ArgumentError) { component.tag('div><script>alert(1)</script><div') }
+    assert_raise(ArgumentError) { component.tag(:script) }
+  end
+
   def test_blocks_javascript_uri
     assert_equal('<a>x</a>',
                  serialize(el('a', {href: 'javascript:alert(1)'}, ['x'])))

--- a/test/html_serializer_test.rb
+++ b/test/html_serializer_test.rb
@@ -53,6 +53,12 @@ class HTMLSerializerTest < Picotest::Test
     assert_equal('<img src="/a.png">', serialize(el('img', {src: '/a.png'})))
   end
 
+  def test_serializes_custom_element
+    component = Class.new(Funicular::Component).new
+    vnode = component.tag(:'custom-element', {id: 'x'}) { 'hi' }
+    assert_equal('<custom-element id="x">hi</custom-element>', serialize(vnode))
+  end
+
   def test_blocks_javascript_uri
     assert_equal('<a>x</a>',
                  serialize(el('a', {href: 'javascript:alert(1)'}, ['x'])))


### PR DESCRIPTION
I added an HTML tag DSL based on the HTML Living Standard.
And I also introduce a `tag` method for adding an element with any name, including custom elements.
The named element methods now delegate to it.

The `s` tag collides with an existing method name, so `tag(:s)` needs to be used instead.
