### PR TITLE
Harden VDOM rendering against HTML injection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@
   picorbc, has become the default compiler for mruby, we changed the name
   from picorbc to mrbc.
 
+### Fixed
+
+- Harden VDOM rendering against HTML and script injection in both SSR and
+  browser rendering: validate tag and attribute names, reject `script`
+  elements, and consistently block case-obfuscated event handlers, `srcdoc`,
+  and unsafe URL schemes including control-character variants.
+
 ## [0.2.1] - 2026-06-15
 
 ### Added

--- a/minitest/ssr_test.rb
+++ b/minitest/ssr_test.rb
@@ -59,6 +59,36 @@ class SSRTest < Minitest::Test
                  serialize(el("a", { href: "javascript:alert(1)" }, ["x"]))
   end
 
+  def test_security_checks_are_case_insensitive
+    assert_equal "<button>Go</button>",
+                 serialize(el("button", { "ONCLICK" => "alert(1)" }, ["Go"]))
+    assert_equal "<a>x</a>",
+                 serialize(el("a", { "HREF" => "JAVASCRIPT:alert(1)" }, ["x"]))
+  end
+
+  def test_blocks_obfuscated_javascript_uri
+    assert_equal "<a>x</a>",
+                 serialize(el("a", { href: "java\nscript:alert(1)" }, ["x"]))
+    assert_equal "<a>x</a>",
+                 serialize(el("a", { href: "\x01javascript:alert(1)" }, ["x"]))
+  end
+
+  def test_blocks_srcdoc
+    assert_equal "<div></div>",
+                 serialize(el("div", { srcdoc: "<script>alert(1)</script>" }))
+  end
+
+  def test_rejects_invalid_attribute_name
+    assert_raises(ArgumentError) do
+      el("div", { 'x" autofocus onfocus' => "alert(1)" })
+    end
+  end
+
+  def test_rejects_invalid_and_active_tag_names
+    assert_raises(ArgumentError) { el('div><script>alert(1)</script><div') }
+    assert_raises(ArgumentError) { el("script", {}, ["alert(1)"]) }
+  end
+
   # --- Full SSR render (runtime + fixture app) --------------------------
 
   def test_render_injects_server_state

--- a/mrblib/component.rb
+++ b/mrblib/component.rb
@@ -452,7 +452,7 @@ module Funicular
 
       vnode.props.each do |key, value|
         key_str = key.to_s
-        next unless key_str.start_with?('on')
+        next unless VDOM.event_attribute?(key_str)
 
         event_name = key_str[2..-1]&.downcase || ""
         event_types << event_name

--- a/mrblib/html_serializer.rb
+++ b/mrblib/html_serializer.rb
@@ -46,7 +46,7 @@ module Funicular
         tag = element.tag
         attrs = serialize_props(element.props)
 
-        if VOID_ELEMENTS.include?(tag)
+        if VOID_ELEMENTS.include?(tag.downcase)
           "<#{tag}#{attrs}>"
         else
           "<#{tag}#{attrs}>#{render_children(element.children)}</#{tag}>"
@@ -83,17 +83,12 @@ module Funicular
         parts = [] #: Array[String]
         props.each do |key, value|
           key_str = key.to_s
-          next if SKIP_PROPS.include?(key)
+          normalized_key = key_str.downcase
+          next if SKIP_PROPS.include?(key) || SKIP_PROPS.include?(normalized_key.to_sym)
           # Event handlers are bound on the client, never serialized.
-          next if key_str.start_with?("on")
+          next if VDOM.blocked_attribute?(normalized_key, value)
 
-          if URL_ATTRIBUTES.include?(key_str) &&
-             value.to_s.strip.downcase.start_with?("javascript:")
-            # Prevent XSS via javascript: URIs (mirrors Renderer#render_element).
-            next
-          end
-
-          if BOOLEAN_ATTRIBUTES.include?(key_str)
+          if BOOLEAN_ATTRIBUTES.include?(normalized_key)
             # Boolean attributes are absent when false/nil, otherwise present.
             next if value.nil? || value.to_s == "false"
             parts << " #{key_str}=\"#{key_str}\""

--- a/mrblib/patcher.rb
+++ b/mrblib/patcher.rb
@@ -159,9 +159,10 @@ module Funicular
 
         props_patch.each do |key, value|
           key_str = key.to_s
+          normalized_key = key_str.downcase
 
           # Skip event handlers (handled by bind_events)
-          next if key_str.start_with?('on')
+          next if VDOM.event_attribute?(normalized_key)
 
           # Skip updating value for focused input/textarea elements
           if key_str == "value"
@@ -178,13 +179,13 @@ module Funicular
           end
 
           # Block javascript: URIs in URL attributes
-          if URL_ATTRIBUTES.include?(key_str) && value.to_s.strip.downcase.start_with?('javascript:')
+          if VDOM.blocked_attribute?(normalized_key, value)
             puts "[WARN] Funicular: Blocked potentially malicious value for attribute '#{key_str}'."
             next
           end
 
           # Handle boolean attributes
-          if BOOLEAN_ATTRIBUTES.include?(key_str)
+          if BOOLEAN_ATTRIBUTES.include?(normalized_key)
             if value.nil? || value.to_s == "false"
               element.removeAttribute(key_str)
               element[key_str] = false
@@ -225,14 +226,15 @@ module Funicular
           element = @doc.createElement(vnode.tag)
           vnode.props.each do |key, value|
             key_str = key.to_s
-            next if key_str.start_with?('on')
-            if URL_ATTRIBUTES.include?(key_str) && value.to_s.strip.downcase.start_with?('javascript:')
+            normalized_key = key_str.downcase
+            next if VDOM.event_attribute?(normalized_key)
+            if VDOM.blocked_attribute?(normalized_key, value)
               puts "[WARN] Funicular: Blocked potentially malicious value for attribute '#{key_str}'."
               next
             end
             if key_str == "value" && (vnode.tag == "input" || vnode.tag == "textarea")
               element[:value] = value.to_s
-            elsif BOOLEAN_ATTRIBUTES.include?(key_str)
+            elsif BOOLEAN_ATTRIBUTES.include?(normalized_key)
               if value.nil? || value.to_s == "false"
                 element[key_str] = false
               else

--- a/mrblib/vdom.rb
+++ b/mrblib/vdom.rb
@@ -6,6 +6,69 @@ module Funicular
 
     URL_ATTRIBUTES = %w[href src action formaction data poster xlink:href]
 
+    # VDOM input is normally authored by application code, but props and tags
+    # can also be assembled from hashes. Validate names before either the DOM
+    # renderer or the SSR serializer sees them so an attacker-controlled key
+    # cannot become HTML syntax.
+    SCRIPTING_ELEMENTS = %w[script]
+
+    def self.valid_tag_name?(name)
+      str = name.to_s
+      return false if str.empty?
+
+      index = 0
+      str.each_byte do |byte|
+        alpha = (byte >= 65 && byte <= 90) || (byte >= 97 && byte <= 122)
+        digit = byte >= 48 && byte <= 57
+        return false unless alpha || (index > 0 && (digit || byte == 45))
+        index += 1
+      end
+      true
+    end
+
+    def self.valid_attribute_name?(name)
+      str = name.to_s
+      return false if str.empty?
+
+      str.each_byte do |byte|
+        alpha = (byte >= 65 && byte <= 90) || (byte >= 97 && byte <= 122)
+        digit = byte >= 48 && byte <= 57
+        punctuation = byte == 45 || byte == 46 || byte == 58 || byte == 95
+        return false unless alpha || digit || punctuation
+      end
+      true
+    end
+
+    def self.event_attribute?(name)
+      name.to_s.downcase.start_with?('on')
+    end
+
+    def self.unsafe_url?(name, value)
+      return false unless URL_ATTRIBUTES.include?(name.to_s.downcase)
+
+      # Browsers discard ASCII tabs and newlines while parsing URLs, so test
+      # the same canonical form rather than only a literal "javascript:".
+      raw = value.to_s
+      start = 0
+      start += 1 while (byte = raw.getbyte(start)) && byte <= 32
+
+      normalized = (raw[start..-1] || "")
+                        .gsub("\t", "")
+                        .gsub("\n", "")
+                        .gsub("\r", "")
+                        .gsub("\f", "")
+                        .strip
+                        .downcase
+      normalized.start_with?('javascript:') || normalized.start_with?('vbscript:')
+    end
+
+    def self.blocked_attribute?(name, value)
+      normalized_name = name.to_s.downcase
+      event_attribute?(normalized_name) ||
+        normalized_name == 'srcdoc' ||
+        unsafe_url?(normalized_name, value)
+    end
+
     class VNode
       attr_reader :type, :key
 
@@ -20,8 +83,20 @@ module Funicular
       def initialize(tag, props = {}, children = [])
         super(:element)
         @tag = tag.to_s
+        unless VDOM.valid_tag_name?(@tag)
+          raise ArgumentError, "Invalid VDOM tag name: #{@tag.inspect}"
+        end
+        if SCRIPTING_ELEMENTS.include?(@tag.downcase)
+          raise ArgumentError, "Unsafe VDOM tag: #{@tag.inspect}"
+        end
+
         @key = props.delete(:key)
         @props = props || {}
+        @props.each_key do |name|
+          unless VDOM.valid_attribute_name?(name)
+            raise ArgumentError, "Invalid VDOM attribute name: #{name.inspect}"
+          end
+        end
         @children = normalize_children(children || [])
       end
 
@@ -122,13 +197,14 @@ module Funicular
 
         element.props.each do |key, value|
           key_str = key.to_s
-          if key_str.start_with?('on')
+          normalized_key = key_str.downcase
+          if VDOM.event_attribute?(normalized_key)
             # Event handlers are handled by Funicular::Component and should not be set as attributes.
             # warn "Funicular: Attempted to set event handler '#{key_str}' as an attribute. This will be ignored."
-          elsif URL_ATTRIBUTES.include?(key_str) && value.to_s.strip.downcase.start_with?('javascript:')
-            # Prevent XSS attacks by blocking javascript: URIs in URL attributes
+          elsif VDOM.blocked_attribute?(normalized_key, value)
+            # Prevent active HTML content and unsafe URL schemes.
             puts "[WARN] Funicular: Blocked potentially malicious value for attribute '#{key_str}'."
-          elsif BOOLEAN_ATTRIBUTES.include?(key_str)
+          elsif BOOLEAN_ATTRIBUTES.include?(normalized_key)
             # Handle boolean attributes
             if value.nil? || value.to_s == "false"
               # Do not set attribute (leave it absent)

--- a/sig/vdom.rbs
+++ b/sig/vdom.rbs
@@ -4,6 +4,13 @@ module Funicular
     type child_t = Element | Text | Component | String | Array[Element | Text | Component | String]
 
     URL_ATTRIBUTES: Array[String]
+    SCRIPTING_ELEMENTS: Array[String]
+
+    def self.valid_tag_name?: (untyped name) -> bool
+    def self.valid_attribute_name?: (untyped name) -> bool
+    def self.event_attribute?: (untyped name) -> bool
+    def self.unsafe_url?: (untyped name, untyped value) -> bool
+    def self.blocked_attribute?: (untyped name, untyped value) -> bool
 
     class VNode
       attr_reader type: Symbol

--- a/test/html_serializer_test.rb
+++ b/test/html_serializer_test.rb
@@ -58,6 +58,36 @@ class HTMLSerializerTest < Picotest::Test
                  serialize(el('a', {href: 'javascript:alert(1)'}, ['x'])))
   end
 
+  def test_security_checks_are_case_insensitive
+    assert_equal('<button>Go</button>',
+                 serialize(el('button', {'ONCLICK' => 'alert(1)'}, ['Go'])))
+    assert_equal('<a>x</a>',
+                 serialize(el('a', {'HREF' => 'JAVASCRIPT:alert(1)'}, ['x'])))
+  end
+
+  def test_blocks_obfuscated_javascript_uri
+    assert_equal('<a>x</a>',
+                 serialize(el('a', {href: "java\nscript:alert(1)"}, ['x'])))
+    assert_equal('<a>x</a>',
+                 serialize(el('a', {href: "\x01javascript:alert(1)"}, ['x'])))
+  end
+
+  def test_blocks_srcdoc
+    assert_equal('<div></div>',
+                 serialize(el('div', {srcdoc: '<script>alert(1)</script>'})))
+  end
+
+  def test_rejects_invalid_attribute_name
+    assert_raise(ArgumentError) do
+      el('div', {'x" autofocus onfocus' => 'alert(1)'})
+    end
+  end
+
+  def test_rejects_invalid_and_active_tag_names
+    assert_raise(ArgumentError) { el('div><script>alert(1)</script><div') }
+    assert_raise(ArgumentError) { el('script', {}, ['alert(1)']) }
+  end
+
   def test_text_vnode_is_escaped
     assert_equal('&lt;b&gt;',
                  serialize(Funicular::VDOM::Text.new('<b>')))

--- a/test/vdom_patcher_test.rb
+++ b/test/vdom_patcher_test.rb
@@ -215,6 +215,39 @@ class VDOMPatcherTest < Picotest::Test
     assert_equal('foo', element.attributes['class'])
   end
 
+  def test_update_props_security_checks_are_case_insensitive
+    element = @doc.createElement('a')
+    patches = [[:props, {'ONCLICK' => 'alert(1)', 'HREF' => 'javascript:alert(2)'}]]
+
+    @patcher.apply(element, patches)
+
+    assert_nil(element.attributes['ONCLICK'])
+    assert_nil(element.attributes['HREF'])
+  end
+
+  def test_update_props_blocks_obfuscated_javascript_and_srcdoc
+    element = @doc.createElement('div')
+    patches = [[:props, {href: "java\nscript:alert(1)", srcdoc: '<script>alert(2)</script>'}]]
+
+    @patcher.apply(element, patches)
+
+    assert_nil(element.attributes['href'])
+    assert_nil(element.attributes['srcdoc'])
+  end
+
+  def test_renderer_blocks_active_attributes
+    vnode = Funicular::VDOM::Element.new(
+      'a',
+      {'ONCLICK' => 'alert(1)', 'HREF' => "java\nscript:alert(2)", 'SRCDOC' => '<script>alert(3)</script>'}
+    )
+
+    element = Funicular::VDOM::Renderer.new(@doc).render(vnode)
+
+    assert_nil(element.attributes['ONCLICK'])
+    assert_nil(element.attributes['HREF'])
+    assert_nil(element.attributes['SRCDOC'])
+  end
+
   # Test element creation from VDOM
   def test_create_text_element
     text_vnode = Funicular::VDOM::Text.new('hello')


### PR DESCRIPTION
Validate tag and attribute names, reject script elements, and consistently block unsafe event, srcdoc, and URL attributes across SSR and browser rendering.

ref #11