### PR TITLE
Redesign component DSL for 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,37 @@
 
 ### Added
 
+- 0.3.0 rendering architecture: `render(h)` now receives a `ViewContext`
+  facade for elements, components, forms, styles, resources, and routes.
+- Per-app `Runtime` context for route helpers and renderer/serializer
+  propagation, enabling isolated route helper sets across multiple apps.
+
+### Breaking Changes
+
+- **0.3.0 is a deliberate breaking DSL redesign. Existing Funicular
+  components written for 0.2.x require source changes.**
+- Component render methods must now accept a view context:
+  `def render(h)`. The former implicit component-level DSL methods for HTML
+  tags, `component`, `form_for`, `link_to`, `button_to`, `suspense`, styles,
+  resources, and route helpers have been removed.
+- HTML and framework helpers are now called through `h`, for example
+  `h.div`, `h.component(...)`, `h.form_for(...)`, `h.link_to(...)`,
+  `h.suspense(...)`, `h.styles[...]`, `h.resources[...]`, and `h.routes`.
+- Component state reads are explicit: use `state[:key]`, `state.fetch(:key)`,
+  or `h.state[:key]`. The old `state.key_name` method-style access has been
+  removed.
+- Style definitions are explicit: use `styles { |css| css.define(...) }`.
+  The old dynamic style definition DSL has been removed.
+- Component children are stored as `VDOM::Component#children`. The old
+  `children_block` prop path has been removed and no compatibility shim is
+  provided.
+- Route helpers are scoped by `Funicular::Runtime`; global
+  `Funicular::RouteHelpers` injection has been removed. Code that depends on
+  route helpers should use `h.routes`.
+- `FormBuilder`, `ErrorBoundary`, SSR, hydration, renderer, patcher, and HTML
+  serialization now operate through the same `ViewContext` / `Runtime`
+  architecture.
+
 ### Changed
 
 - Since mruby-compiler-prism, which used to be mruby-compiler2 producing

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    funicular (0.2.2)
+    funicular (0.3.0)
       rails (~> 8.0)
 
 GEM

--- a/demo/test_chartjs.html
+++ b/demo/test_chartjs.html
@@ -44,7 +44,7 @@
           return
         end
 
-        current_data = state.data_sets[state.month_index]
+        current_data = state[:data_sets][state[:month_index]]
 
         config = {
           type: 'line',
@@ -69,7 +69,7 @@
       end
 
       def component_updated
-        puts "component_updated: Updating Chart.js with data index #{state.month_index}"
+        puts "component_updated: Updating Chart.js with data index #{state[:month_index]}"
         update_chart
       end
 
@@ -80,22 +80,22 @@
 
       def next_data_set(event)
         event.preventDefault if event
-        new_index = (state.month_index + 1) % state.data_sets.size
-        puts "next_data_set: Changing index from #{state.month_index} to #{new_index}"
+        new_index = (state[:month_index] + 1) % state[:data_sets].size
+        puts "next_data_set: Changing index from #{state[:month_index]} to #{new_index}"
         patch(month_index: new_index)
       end
 
       def prev_data_set(event)
         event.preventDefault if event
-        new_index = (state.month_index - 1) % state.data_sets.size
-        puts "prev_data_set: Changing index from #{state.month_index} to #{new_index}"
+        new_index = (state[:month_index] - 1) % state[:data_sets].size
+        puts "prev_data_set: Changing index from #{state[:month_index]} to #{new_index}"
         patch(month_index: new_index)
       end
 
       def update_chart
         return unless @chart
 
-        current_data = state.data_sets[state.month_index]
+        current_data = state[:data_sets][state[:month_index]]
         puts "update_chart: Setting data to #{current_data[:labels].join(', ')}"
 
         # Convert to JS objects
@@ -118,18 +118,18 @@
         puts "update_chart: Chart.js update('active') called"
       end
 
-      def render
-        div(id: "dashboard") do
-          h2 { "Sales Dashboard" }
-          div(id: "chart-container") do
-            canvas(ref: :chart_canvas, id: "chart")
+      def render(h)
+        h.div(id: "dashboard") do |hh|
+          hh.h2 { "Sales Dashboard" }
+          hh.div(id: "chart-container") do |hhh|
+            hhh.canvas(ref: :chart_canvas, id: "chart")
           end
-          div do
-            button(id: "prev-btn", onclick: :prev_data_set) { "Previous Quarter" }
-            button(id: "next-btn", onclick: :next_data_set) { "Next Quarter" }
+          hh.div do |hhh|
+            hhh.button(id: "prev-btn", onclick: :prev_data_set) { "Previous Quarter" }
+            hhh.button(id: "next-btn", onclick: :next_data_set) { "Next Quarter" }
           end
-          div(id: "info") do
-            current = state.data_sets[state.month_index]
+          hh.div(id: "info") do
+            current = state[:data_sets][state[:month_index]]
             "Current data: #{current[:labels].join(', ')}"
           end
         end

--- a/demo/test_component.html
+++ b/demo/test_component.html
@@ -40,26 +40,26 @@
 
       def increment(event)
         event.preventDefault if event
-        patch(count: state.count + 1)
+        patch(count: state[:count] + 1)
       end
 
       def decrement(event)
         event.preventDefault if event
-        patch(count: state.count - 1)
+        patch(count: state[:count] - 1)
       end
 
-      def render
-        div(id: "counter-app") do
-          h2 { "Counter: #{state.count}" }
-          div(id: "status") do
-            "Mounted: #{state.mounted}"
+      def render(h)
+        h.div(id: "counter-app") do |hh|
+          hh.h2 { "Counter: #{state[:count]}" }
+          hh.div(id: "status") do
+            "Mounted: #{state[:mounted]}"
           end
-          div do
-            button(id: "increment-btn", onclick: :increment) { "+1" }
-            button(id: "decrement-btn", onclick: :decrement) { "-1" }
+          hh.div do |hhh|
+            hhh.button(id: "increment-btn", onclick: :increment) { "+1" }
+            hhh.button(id: "decrement-btn", onclick: :decrement) { "-1" }
           end
-          div(ref: :display, id: "display") do
-            "Current value: #{state.count}"
+          hh.div(ref: :display, id: "display") do
+            "Current value: #{state[:count]}"
           end
         end
       end
@@ -89,7 +89,7 @@
       # Test 2: Initial state
       begin
         counter = TestCounter.new
-        initial_state = counter.state.count == 0
+        initial_state = counter.state[:count] == 0
         log_test("Initial state", initial_state)
       rescue => e
         log_test("Initial state", false)
@@ -139,13 +139,13 @@
         has_button = btn != nil
 
         # Test handler logic by calling it directly (standard testing approach)
-        initial_count = counter.state.count
+        initial_count = counter.state[:count]
         counter.increment(nil)
         sleep 0.05
 
         h2_element = JS.document.querySelector('#counter-app h2')
         text = h2_element.textContent.to_s
-        handler_works = counter.state.count == initial_count + 1 && text.include?("#{initial_count + 1}")
+        handler_works = counter.state[:count] == initial_count + 1 && text.include?("#{initial_count + 1}")
 
         log_test("Event handler (click)", has_button && handler_works)
       rescue => e

--- a/demo/test_error_boundary.html
+++ b/demo/test_error_boundary.html
@@ -91,7 +91,7 @@
   <script type="text/ruby">
     # A component that always throws an error during render
     class BrokenComponent < Funicular::Component
-      def render
+      def render(h)
         raise "BrokenComponent intentionally threw this error!"
       end
     end
@@ -107,80 +107,80 @@
         patch(count: state[:count] + 1)
       end
 
-      def render
-        div(class: 'demo-card') do
-          h3 { "Working Component" }
-          p { "Count: #{state[:count]}" }
-          button(onclick: :increment) { "Increment" }
+      def render(h)
+        h.div(class: 'demo-card') do |hh|
+          hh.h3 { "Working Component" }
+          hh.p { "Count: #{state[:count]}" }
+          hh.button(onclick: :increment) { "Increment" }
         end
       end
     end
 
     # Main demo application
     class ErrorBoundaryDemo < Funicular::Component
-      def render
+      def render(h)
         error_handler = ->(error, info) {
           puts "[Demo] Error caught by ErrorBoundary:"
           puts "  Error: #{error.message}"
           puts "  Component: #{info&.dig(:component_class)}"
         }
 
-        custom_fallback = ->(error) {
-          div(style: 'background: linear-gradient(135deg, #ff6b6b, #ee5a5a); color: white; padding: 20px; border-radius: 8px;') do
-            h3(style: 'margin-top: 0;') { "Custom Error Handler" }
-            p { "Caught: #{error.message}" }
-            p(style: 'font-size: 12px; opacity: 0.8;') { "This is a custom fallback provided via props." }
+        custom_fallback = ->(hh, error) {
+          hh.div(style: 'background: linear-gradient(135deg, #ff6b6b, #ee5a5a); color: white; padding: 20px; border-radius: 8px;') do |hhh|
+            hhh.h3(style: 'margin-top: 0;') { "Custom Error Handler" }
+            hhh.p { "Caught: #{error.message}" }
+            hhh.p(style: 'font-size: 12px; opacity: 0.8;') { "This is a custom fallback provided via props." }
           end
         }
 
-        div do
-          h2 { "Error Boundary Demonstrations" }
+        h.div do |hh|
+          hh.h2 { "Error Boundary Demonstrations" }
 
           # Demo 1: Default fallback
-          div(class: 'demo-card') do
-            h3 { "Demo 1: Default Fallback UI" }
-            p { "ErrorBoundary wraps a component that always throws. Default fallback is shown." }
-            component(Funicular::ErrorBoundary, on_error: error_handler) do
-              component(BrokenComponent)
+          hh.div(class: 'demo-card') do |card|
+            card.h3 { "Demo 1: Default Fallback UI" }
+            card.p { "ErrorBoundary wraps a component that always throws. Default fallback is shown." }
+            card.component(Funicular::ErrorBoundary, on_error: error_handler) do |boundary|
+              boundary.component(BrokenComponent)
             end
           end
 
           # Demo 2: Custom fallback
-          div(class: 'demo-card') do
-            h3 { "Demo 2: Custom Fallback UI" }
-            p { "ErrorBoundary with a custom fallback prop." }
-            component(Funicular::ErrorBoundary,
+          hh.div(class: 'demo-card') do |card|
+            card.h3 { "Demo 2: Custom Fallback UI" }
+            card.p { "ErrorBoundary with a custom fallback prop." }
+            card.component(Funicular::ErrorBoundary,
               fallback: custom_fallback,
               on_error: error_handler
-            ) do
-              component(BrokenComponent)
+            ) do |boundary|
+              boundary.component(BrokenComponent)
             end
           end
 
           # Demo 3: Mixed content - some work, some fail
-          div(class: 'demo-card') do
-            h3 { "Demo 3: Isolated Error Boundaries" }
-            p { "Each component has its own ErrorBoundary. One failure doesn't affect others." }
+          hh.div(class: 'demo-card') do |card|
+            card.h3 { "Demo 3: Isolated Error Boundaries" }
+            card.p { "Each component has its own ErrorBoundary. One failure doesn't affect others." }
 
-            div(style: 'display: flex; gap: 15px; flex-wrap: wrap;') do
-              div(style: 'flex: 1; min-width: 200px;') do
-                h4 { "Working:" }
-                component(Funicular::ErrorBoundary) do
-                  component(WorkingComponent)
+            card.div(style: 'display: flex; gap: 15px; flex-wrap: wrap;') do |row|
+              row.div(style: 'flex: 1; min-width: 200px;') do |col|
+                col.h4 { "Working:" }
+                col.component(Funicular::ErrorBoundary) do |boundary|
+                  boundary.component(WorkingComponent)
                 end
               end
 
-              div(style: 'flex: 1; min-width: 200px;') do
-                h4 { "Broken:" }
-                component(Funicular::ErrorBoundary) do
-                  component(BrokenComponent)
+              row.div(style: 'flex: 1; min-width: 200px;') do |col|
+                col.h4 { "Broken:" }
+                col.component(Funicular::ErrorBoundary) do |boundary|
+                  boundary.component(BrokenComponent)
                 end
               end
 
-              div(style: 'flex: 1; min-width: 200px;') do
-                h4 { "Also Working:" }
-                component(Funicular::ErrorBoundary) do
-                  component(WorkingComponent)
+              row.div(style: 'flex: 1; min-width: 200px;') do |col|
+                col.h4 { "Also Working:" }
+                col.component(Funicular::ErrorBoundary) do |boundary|
+                  boundary.component(WorkingComponent)
                 end
               end
             end

--- a/demo/test_router.html
+++ b/demo/test_router.html
@@ -39,12 +39,12 @@
         }
       end
 
-      def render
-        nav do
-          a(href: '/login', onclick: go_to('/login')) { 'Login' }
-          a(href: '/home', onclick: go_to('/home')) { 'Home' }
-          a(href: '/settings', onclick: go_to('/settings')) { 'Settings' }
-          a(href: '/users', onclick: go_to('/users')) { 'Users' }
+      def render(h)
+        h.nav do |hh|
+          hh.a(href: '/login', onclick: go_to('/login')) { 'Login' }
+          hh.a(href: '/home', onclick: go_to('/home')) { 'Home' }
+          hh.a(href: '/settings', onclick: go_to('/settings')) { 'Settings' }
+          hh.a(href: '/users', onclick: go_to('/users')) { 'Users' }
         end
       end
     end
@@ -63,25 +63,25 @@
         Funicular.router.navigate('/home')
       end
 
-      def render
-        div(class: 'login-page') do
-          h2(class: 'page-title') { 'Login Page' }
+      def render(h)
+        h.div(class: 'login-page') do |hh|
+          hh.h2(class: 'page-title') { 'Login Page' }
 
-          div do
-            input(
+          hh.div do |hhh|
+            hhh.input(
               type: 'text',
               placeholder: 'Username',
-              value: state.username,
+              value: state[:username],
               oninput: :on_username_input
             )
           end
 
-          div do
-            button(onclick: :on_login_click) { 'Login' }
+          hh.div do |hhh|
+            hhh.button(onclick: :on_login_click) { 'Login' }
           end
 
-          div(class: 'status') do
-            "Username: #{state.username}"
+          hh.div(class: 'status') do
+            "Username: #{state[:username]}"
           end
         end
       end
@@ -94,7 +94,7 @@
 
       def increment(event)
         event.preventDefault
-        patch(count: state.count + 1)
+        patch(count: state[:count] + 1)
       end
 
       def go_to_settings(event)
@@ -102,20 +102,20 @@
         Funicular.router.navigate('/settings')
       end
 
-      def render
-        div(class: 'home-page') do
-          h2(class: 'page-title') { 'Home Page' }
+      def render(h)
+        h.div(class: 'home-page') do |hh|
+          hh.h2(class: 'page-title') { 'Home Page' }
 
-          div do
-            "Counter: #{state.count}"
+          hh.div do
+            "Counter: #{state[:count]}"
           end
 
-          div do
-            button(onclick: :increment) { 'Increment' }
-            button(onclick: :go_to_settings) { 'Go to Settings' }
+          hh.div do |hhh|
+            hhh.button(onclick: :increment) { 'Increment' }
+            hhh.button(onclick: :go_to_settings) { 'Go to Settings' }
           end
 
-          div(class: 'status') do
+          hh.div(class: 'status') do
             "You are on the home page. Click around to test routing!"
           end
         end
@@ -129,13 +129,13 @@
 
       def toggle_theme(event)
         event.preventDefault
-        new_theme = state.theme == 'light' ? 'dark' : 'light'
+        new_theme = state[:theme] == 'light' ? 'dark' : 'light'
         patch(theme: new_theme)
       end
 
       def toggle_notifications(event)
         event.preventDefault
-        patch(notifications: !state.notifications)
+        patch(notifications: !state[:notifications])
       end
 
       def go_to_home(event)
@@ -143,25 +143,25 @@
         Funicular.router.navigate('/home')
       end
 
-      def render
-        div(class: 'settings-page') do
-          h2(class: 'page-title') { 'Settings Page' }
+      def render(h)
+        h.div(class: 'settings-page') do |hh|
+          hh.h2(class: 'page-title') { 'Settings Page' }
 
-          div do
-            span { "Theme: #{state.theme}" }
-            button(onclick: :toggle_theme) { 'Toggle Theme' }
+          hh.div do |hhh|
+            hhh.span { "Theme: #{state[:theme]}" }
+            hhh.button(onclick: :toggle_theme) { 'Toggle Theme' }
           end
 
-          div do
-            span { "Notifications: #{state.notifications ? 'ON' : 'OFF'}" }
-            button(onclick: :toggle_notifications) { 'Toggle Notifications' }
+          hh.div do |hhh|
+            hhh.span { "Notifications: #{state[:notifications] ? 'ON' : 'OFF'}" }
+            hhh.button(onclick: :toggle_notifications) { 'Toggle Notifications' }
           end
 
-          div do
-            button(onclick: :go_to_home) { 'Back to Home' }
+          hh.div do |hhh|
+            hhh.button(onclick: :go_to_home) { 'Back to Home' }
           end
 
-          div(class: 'status') do
+          hh.div(class: 'status') do
             "Configure your settings here"
           end
         end
@@ -185,21 +185,21 @@
         }
       end
 
-      def render
-        div(class: 'users-page') do
-          h2(class: 'page-title') { 'Users List' }
+      def render(h)
+        h.div(class: 'users-page') do |hh|
+          hh.h2(class: 'page-title') { 'Users List' }
 
-          ul do
-            state.users.each do |user|
-              li do
-                a(href: "/users/#{user[:id]}", onclick: go_to_user(user[:id])) do
+          hh.ul do |hhh|
+            state[:users].each do |user|
+              hhh.li do |item|
+                item.a(href: "/users/#{user[:id]}", onclick: go_to_user(user[:id])) do
                   user[:name]
                 end
               end
             end
           end
 
-          div(class: 'status') do
+          hh.div(class: 'status') do
             "Click a user to see dynamic route with :id parameter"
           end
         end
@@ -216,20 +216,20 @@
         Funicular.router.navigate('/users')
       end
 
-      def render
-        div(class: 'user-detail-page') do
-          h2(class: 'page-title') { "User Detail" }
+      def render(h)
+        h.div(class: 'user-detail-page') do |hh|
+          hh.h2(class: 'page-title') { "User Detail" }
 
-          div do
-            "Viewing user ID: #{state.user_id}"
+          hh.div do
+            "Viewing user ID: #{state[:user_id]}"
           end
 
-          div do
-            button(onclick: :go_back) { 'Back to Users' }
+          hh.div do |hhh|
+            hhh.button(onclick: :go_back) { 'Back to Users' }
           end
 
-          div(class: 'status') do
-            "This page demonstrates dynamic routing with params[:id] = #{state.user_id}"
+          hh.div(class: 'status') do
+            "This page demonstrates dynamic routing with params[:id] = #{state[:user_id]}"
           end
         end
       end

--- a/demo/tic-tac-toe.html
+++ b/demo/tic-tac-toe.html
@@ -38,8 +38,8 @@
         on_click.call if on_click
       end
 
-      def render
-        button(class: 'square', onclick: :handle_click) do
+      def render(h)
+        h.button(class: 'square', onclick: :handle_click) do
           props[:value] || ''
         end
       end
@@ -55,7 +55,7 @@
         }
       end
 
-      def render
+      def render(h)
         squares = props[:squares]
         x_is_next = props[:x_is_next]
 
@@ -66,22 +66,22 @@
           "Next player: #{x_is_next ? 'X' : 'O'}"
         end
 
-        div do
-          div(class: 'status') { status }
-          div(class: 'board-row') do
-            component(Square, value: squares[0], on_click: handle_click(0))
-            component(Square, value: squares[1], on_click: handle_click(1))
-            component(Square, value: squares[2], on_click: handle_click(2))
+        h.div do |hh|
+          hh.div(class: 'status') { status }
+          hh.div(class: 'board-row') do |hhh|
+            hhh.component(Square, value: squares[0], on_click: handle_click(0))
+            hhh.component(Square, value: squares[1], on_click: handle_click(1))
+            hhh.component(Square, value: squares[2], on_click: handle_click(2))
           end
-          div(class: 'board-row') do
-            component(Square, value: squares[3], on_click: handle_click(3))
-            component(Square, value: squares[4], on_click: handle_click(4))
-            component(Square, value: squares[5], on_click: handle_click(5))
+          hh.div(class: 'board-row') do |hhh|
+            hhh.component(Square, value: squares[3], on_click: handle_click(3))
+            hhh.component(Square, value: squares[4], on_click: handle_click(4))
+            hhh.component(Square, value: squares[5], on_click: handle_click(5))
           end
-          div(class: 'board-row') do
-            component(Square, value: squares[6], on_click: handle_click(6))
-            component(Square, value: squares[7], on_click: handle_click(7))
-            component(Square, value: squares[8], on_click: handle_click(8))
+          hh.div(class: 'board-row') do |hhh|
+            hhh.component(Square, value: squares[6], on_click: handle_click(6))
+            hhh.component(Square, value: squares[7], on_click: handle_click(7))
+            hhh.component(Square, value: squares[8], on_click: handle_click(8))
           end
         end
       end
@@ -96,8 +96,8 @@
       end
 
       def handle_play(i)
-        history = state.history
-        current_move = state.current_move
+        history = state[:history]
+        current_move = state[:current_move]
         current_squares = history[current_move].dup
 
         current_squares[i] = (current_move % 2 == 0) ? 'X' : 'O'
@@ -115,30 +115,30 @@
         }
       end
 
-      def render
-        history = state.history
-        current_move = state.current_move
+      def render(h)
+        history = state[:history]
+        current_move = state[:current_move]
         x_is_next = (current_move % 2 == 0)
         current_squares = history[current_move]
 
-        div(class: 'game') do
-          div(class: 'game-board') do
-            component(Board,
+        h.div(class: 'game') do |hh|
+          hh.div(class: 'game-board') do |hhh|
+            hhh.component(Board,
               x_is_next: x_is_next,
               squares: current_squares,
               on_play: ->(i) { handle_play(i) }
             )
           end
-          div(class: 'game-info') do
-            ol do
+          hh.div(class: 'game-info') do |hhh|
+            hhh.ol do |hhhh|
               history.each_with_index do |_squares, move|
                 description = if move > 0
                   "Go to move ##{move}"
                 else
                   'Go to game start'
                 end
-                li(key: move) do
-                  button(onclick: jump_to(move)) { description }
+                hhhh.li(key: move) do |item|
+                  item.button(onclick: jump_to(move)) { description }
                 end
               end
             end

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -26,30 +26,43 @@ stay free of browser-only calls on any server code path
 
 ## `mrblib/` runtime: responsibilities
 
-| File(s)                                          | Responsibility                                                            |
-|--------------------------------------------------|---------------------------------------------------------------------------|
-| `funicular.rb`                                   | Top-level module: `start`, `router`, `server?`, `debug_color` export      |
-| `component.rb`                                   | `Funicular::Component` base: state, props, lifecycle, suspense, refs, styles |
-| `vdom.rb`                                         | Virtual DOM nodes and the element-factory DSL (`div`, `button`, ...)      |
-| `differ.rb`                                       | `Differ.diff(old, new)` -- minimal patch set, key-based list reconciliation |
-| `patcher.rb`                                      | `Patcher.apply(dom, patches)` -- apply patches to the real DOM            |
-| `html_serializer.rb`                             | `VDOM::HTMLSerializer` -- VDOM to HTML string (used by SSR)               |
-| `router.rb`                                       | Client-side router, route DSL, `RouteHelpers` generation, History API     |
-| `model.rb`                                        | Object-REST Mapper (`all`/`find`/`create`/`update`/`destroy`)            |
-| `http.rb`                                         | Low-level fetch wrapper, CSRF, IndexedDB response cache                    |
-| `cable.rb`                                        | ActionCable-compatible consumer/subscription client                       |
-| `store.rb`, `store_singleton.rb`, `store_collection.rb` | IndexedDB-backed stores, scope API, `subscribes_to`, event dispatch |
-| `form_builder.rb`                                | `form_for` and field helpers with inline error rendering                  |
-| `0_validations.rb`, `1_validators.rb`            | ActiveModel-style validators and `errors`                                 |
-| `styles.rb`                                       | CSS-in-Ruby `styles` DSL and the `s` helper                              |
-| `error_boundary.rb`                              | `ErrorBoundary` component                                                 |
-| `file_upload.rb`                                 | File / FormData upload helper                                              |
-| `debug.rb`                                        | Development-only component/error registry for the DevTools extension      |
-| `environment_inquirer.rb`                        | Environment detection (`server?`, `development?`)                         |
+| File(s)                                                 | Responsibility                                                                                  |
+|---------------------------------------------------------|-------------------------------------------------------------------------------------------------|
+| `funicular.rb`                                          | Top-level module: `start`, `router`, `server?`, `debug_color` export                            |
+| `runtime.rb`                                            | Per-app runtime context propagated through render/SSR/hydration                                 |
+| `view_context.rb`                                       | Thin render facade passed as `render(h)`: elements, components, forms, routes, styles, suspense |
+| `component.rb`                                          | `Funicular::Component` base: state, props, lifecycle, suspense loading, refs                    |
+| `vdom.rb`                                               | Virtual DOM nodes, including component vnodes with ordinary `children`                          |
+| `differ.rb`                                             | `Differ.diff(old, new)` -- minimal patch set, key-based list reconciliation                     |
+| `patcher.rb`                                            | `Patcher.apply(dom, patches)` -- apply patches to the real DOM                                  |
+| `html_serializer.rb`                                    | `VDOM::HTMLSerializer` -- VDOM to HTML string (used by SSR)                                     |
+| `router.rb`                                             | Client-side router, route DSL, per-runtime route helper object, History API                     |
+| `model.rb`                                              | Object-REST Mapper (`all`/`find`/`create`/`update`/`destroy`)                                   |
+| `http.rb`                                               | Low-level fetch wrapper, CSRF, IndexedDB response cache                                         |
+| `cable.rb`                                              | ActionCable-compatible consumer/subscription client                                             |
+| `store.rb`, `store_singleton.rb`, `store_collection.rb` | IndexedDB-backed stores, scope API, `subscribes_to`, event dispatch                             |
+| `form_builder.rb`                                       | `h.form_for` field helpers with inline error rendering                                          |
+| `0_validations.rb`, `1_validators.rb`                   | ActiveModel-style validators and `errors`                                                       |
+| `styles.rb`                                             | CSS-in-Ruby `styles { |css| css.define ... }` and `h.styles[...]` access                        |
+| `error_boundary.rb`                                     | `ErrorBoundary` component                                                                       |
+| `file_upload.rb`                                        | File / FormData upload helper                                                                   |
+| `debug.rb`                                              | Development-only component/error registry for the DevTools extension                            |
+| `environment_inquirer.rb`                               | Environment detection (`server?`, `development?`)                                               |
 
 The render cycle: a state change calls `patch()`, which rebuilds the component's
-VDOM, diffs it against the previous VDOM with `Differ`, and applies the result
-with `Patcher`. Event handlers are native DOM listeners, re-bound on each render.
+VDOM by calling `render(h)`, diffs it against the previous VDOM with `Differ`,
+and applies the result with `Patcher`. Event handlers are native DOM listeners,
+re-bound on each render.
+
+Application code receives all render helpers through `h`. HTML is authored as
+`h.div`, custom elements as `h.tag(:custom_element)`, child components as
+`h.component`, forms as `h.form_for`, styles as `h.styles[:name]`, resources as
+`h.resources[:name]`, and routes as `h.routes.user_path(id)`. Component state is
+explicitly read with `state[:name]` or `state.fetch(:name)`.
+
+Component children are ordinary VDOM children stored on
+`VDOM::Component#children`; there is no delayed `children_block` prop. This keeps
+SSR, diffing, ErrorBoundary rendering, and hydration on the same data model.
 
 ## `lib/` Rails integration
 
@@ -87,11 +100,11 @@ only works from within that checkout -- see Development below.
 
 For SSR the `mrblib/` framework is loaded into the Rails process under CRuby.
 `Funicular::SSR.render(path:, state:)` resolves the path against the routes in
-`app/funicular/initializer.rb`, builds the component's VDOM, and serializes it
-with `HTMLSerializer`. The state is also embedded as `window.__FUNICULAR_STATE__`
-so the browser can hydrate the markup rather than rebuild it. Keep `render`
-deterministic and free of browser-only calls so the same code is safe on both
-sides.
+`app/funicular/initializer.rb`, builds a `Runtime` around that router, builds the
+component's VDOM, and serializes it with `HTMLSerializer`. The state is also
+embedded as `window.__FUNICULAR_STATE__` so the browser can hydrate the markup
+rather than rebuild it. Keep `render(h)` deterministic and free of browser-only
+calls so the same code is safe on both sides.
 
 ## Development
 

--- a/lib/funicular/helpers/picoruby_helper.rb
+++ b/lib/funicular/helpers/picoruby_helper.rb
@@ -11,6 +11,11 @@ module Funicular
         local_dist:  "/picoruby/dist/init.iife.js"
       }.freeze
 
+      LOCAL_VARIANTS = {
+        local_debug: "debug",
+        local_dist:  "dist"
+      }.freeze
+
       # Minimal CSS the gem ships for class names it emits itself (e.g.
       # FormBuilder error states). Read once; see assets/funicular.css.
       BASE_CSS_PATH = File.expand_path("../assets/funicular.css", __dir__)
@@ -101,11 +106,29 @@ module Funicular
           end
           format(CDN_URL_TEMPLATE, version: version)
         elsif (path = LOCAL_PATHS[source])
-          path
+          local_picoruby_src(path, source)
         else
           raise ArgumentError,
                 "Unknown picoruby source: #{source.inspect}. Expected one of #{Funicular::Configuration::SOURCES.inspect}"
         end
+      end
+
+      def local_picoruby_src(path, source)
+        cache_key = local_picoruby_cache_key(source)
+        return path if cache_key.nil?
+
+        "#{path}?v=#{cache_key}"
+      end
+
+      def local_picoruby_cache_key(source)
+        variant = LOCAL_VARIANTS.fetch(source)
+        version = Funicular.vendored_wasm_version
+        wasm = File.join(Funicular::VENDOR_PICORUBY_DIR, variant, "picoruby.wasm")
+        mtime = File.mtime(wasm).to_i
+
+        [version, mtime].compact.join("-")
+      rescue Errno::ENOENT
+        Funicular.vendored_wasm_version
       end
     end
   end

--- a/lib/funicular/helpers/picoruby_helper.rb
+++ b/lib/funicular/helpers/picoruby_helper.rb
@@ -126,9 +126,9 @@ module Funicular
         wasm = File.join(Funicular::VENDOR_PICORUBY_DIR, variant, "picoruby.wasm")
         mtime = File.mtime(wasm).to_i
 
-        [version, mtime].compact.join("-")
+        [version || Funicular::VERSION, mtime].join("-")
       rescue Errno::ENOENT
-        Funicular.vendored_wasm_version
+        Funicular.vendored_wasm_version || Funicular::VERSION
       end
     end
   end

--- a/lib/funicular/ssr.rb
+++ b/lib/funicular/ssr.rb
@@ -30,8 +30,9 @@ module Funicular
       return { html: "", state: {}, component: nil } unless component_class
 
       instance = component_class.new(symbolize_keys(params).merge(props))
+      instance.runtime = Funicular::Runtime.new(router)
       instance.seed_state(state)
-      html = Funicular::VDOM::HTMLSerializer.serialize(instance.build_vdom)
+      html = Funicular::VDOM::HTMLSerializer.serialize(instance.build_vdom, instance.runtime)
 
       { html: html, state: state, component: component_class }
     end

--- a/lib/funicular/ssr/runtime.rb
+++ b/lib/funicular/ssr/runtime.rb
@@ -27,6 +27,8 @@ module Funicular
         differ
         patcher
         styles
+        runtime
+        view_context
         debug
         component
         error_boundary

--- a/lib/funicular/testing/node_runner.rb
+++ b/lib/funicular/testing/node_runner.rb
@@ -117,9 +117,9 @@ module Funicular
 
       def default_runtime_dir
         ENV["FUNICULAR_TEST_PICORUBY_DIR"] ||
-          existing_path(File.join(gem_root, "lib", "funicular", "vendor", "picoruby-test-node")) ||
           existing_path(File.expand_path("../picoruby/build/picoruby-wasm-test/bin", gem_root)) ||
           existing_path(File.expand_path("../../build/picoruby-wasm-test/bin", gem_root)) ||
+          existing_path(File.join(gem_root, "lib", "funicular", "vendor", "picoruby-test-node")) ||
           File.join(gem_root, "lib", "funicular", "vendor", "picoruby-test-node")
       end
 

--- a/lib/funicular/version.rb
+++ b/lib/funicular/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Funicular
-  VERSION = "0.2.2"
+  VERSION = "0.3.0"
 end

--- a/lib/generators/funicular/chat/templates/funicular_chat_component.rb.tt
+++ b/lib/generators/funicular/chat/templates/funicular_chat_component.rb.tt
@@ -1,24 +1,25 @@
 class FunicularChatComponent < Funicular::Component
-  styles do
-    shell "funicular-chat"
-    panel "funicular-chat__panel"
-    header "funicular-chat__header"
-    title "funicular-chat__title"
-    subtitle "funicular-chat__subtitle"
-    messages "funicular-chat__messages"
-    empty "funicular-chat__empty"
-    message "funicular-chat__message"
-    name "funicular-chat__message-name"
-    body "funicular-chat__message-body"
-    form "funicular-chat__form"
-    row "funicular-chat__form-row"
-    input "funicular-chat__input"
-    button base: "funicular-chat__button",
-           variants: {
-             enabled: "funicular-chat__button--enabled",
-             disabled: "funicular-chat__button--disabled"
-           }
-    error "funicular-chat__error"
+  styles do |css|
+    css.define :shell, "funicular-chat"
+    css.define :panel, "funicular-chat__panel"
+    css.define :header, "funicular-chat__header"
+    css.define :title, "funicular-chat__title"
+    css.define :subtitle, "funicular-chat__subtitle"
+    css.define :messages, "funicular-chat__messages"
+    css.define :empty, "funicular-chat__empty"
+    css.define :message, "funicular-chat__message"
+    css.define :name, "funicular-chat__message-name"
+    css.define :body, "funicular-chat__message-body"
+    css.define :form, "funicular-chat__form"
+    css.define :row, "funicular-chat__form-row"
+    css.define :input, "funicular-chat__input"
+    css.define :button,
+               base: "funicular-chat__button",
+               variants: {
+                 enabled: "funicular-chat__button--enabled",
+                 disabled: "funicular-chat__button--disabled"
+               }
+    css.define :error, "funicular-chat__error"
   end
 
   def initialize_state
@@ -55,7 +56,7 @@ class FunicularChatComponent < Funicular::Component
   def subscribe
     @consumer = Funicular::Cable.create_consumer("/cable")
     @subscription = @consumer.subscriptions.create(channel: "FunicularChatChannel") do |message|
-      patch(messages: state.messages + [message])
+      patch(messages: state[:messages] + [message])
     end
     @subscription.on_connected do
       patch(connected: true)
@@ -72,10 +73,10 @@ class FunicularChatComponent < Funicular::Component
 
   def send_message(event = nil)
     event.preventDefault if event
-    return if state.sending
+    return if state[:sending]
 
-    name = state.name.to_s.strip
-    body = state.body.to_s.strip
+    name = state[:name].to_s.strip
+    body = state[:body].to_s.strip
     if name == "" || body == ""
       patch(error: "Name and message are required")
       return
@@ -94,38 +95,38 @@ class FunicularChatComponent < Funicular::Component
     end
   end
 
-  def render
-    div(class: s.shell) do
-      div(class: s.panel) do
-        div(class: s.header) do
-          h1(class: s.title) { "Funicular Chat" }
-          p(class: s.subtitle) do
-            state.connected ? "Realtime Ruby chat over ActionCable" : "Connecting..."
+  def render(h)
+    h.div(class: h.styles[:shell]) do |hh|
+      hh.div(class: h.styles[:panel]) do |panel|
+        panel.div(class: h.styles[:header]) do |header|
+          header.h1(class: h.styles[:title]) { "Funicular Chat" }
+          header.p(class: h.styles[:subtitle]) do
+            state[:connected] ? "Realtime Ruby chat over ActionCable" : "Connecting..."
           end
         end
 
-        div(class: s.messages) do
-          if state.messages.empty?
-            p(class: s.empty) { "No messages yet." }
+        panel.div(class: h.styles[:messages]) do |messages|
+          if state[:messages].empty?
+            messages.p(class: h.styles[:empty]) { "No messages yet." }
           else
-            state.messages.each do |message|
-              div(class: s.message, key: message["id"]) do
-                div(class: s.name) { message["name"] }
-                div(class: s.body) { message["body"] }
+            state[:messages].each do |message|
+              messages.div(class: h.styles[:message], key: message["id"]) do |item|
+                item.div(class: h.styles[:name]) { message["name"] }
+                item.div(class: h.styles[:body]) { message["body"] }
               end
             end
           end
         end
 
-        form(onsubmit: :send_message, class: s.form) do
-          if state.error
-            div(class: s.error) { state.error }
+        panel.form(onsubmit: :send_message, class: h.styles[:form]) do |form|
+          if state[:error]
+            form.div(class: h.styles[:error]) { state[:error] }
           end
-          div(class: s.row) do
-            input(type: "text", value: state.name, placeholder: "Name", oninput: :update_name, class: s.input)
-            input(type: "text", value: state.body, placeholder: "Message", oninput: :update_body, class: s.input)
-            button(type: "submit", class: s.button(state.sending ? :disabled : :enabled), disabled: state.sending) do
-              state.sending ? "Sending..." : "Send"
+          form.div(class: h.styles[:row]) do |row|
+            row.input(type: "text", value: state[:name], placeholder: "Name", oninput: :update_name, class: h.styles[:input])
+            row.input(type: "text", value: state[:body], placeholder: "Message", oninput: :update_body, class: h.styles[:input])
+            row.button(type: "submit", class: h.styles[:button, state[:sending] ? :disabled : :enabled], disabled: state[:sending]) do
+              state[:sending] ? "Sending..." : "Send"
             end
           end
         end

--- a/minitest/fixtures/funicular_app/components/greeting_component.rb
+++ b/minitest/fixtures/funicular_app/components/greeting_component.rb
@@ -3,12 +3,12 @@ class GreetingComponent < Funicular::Component
     { title: "Default Title", items: [] }
   end
 
-  def render
-    div(class: "greeting") do
-      h1 { state.title }
-      ul do
-        state.items.each do |item|
-          li(key: item["id"]) { item["name"] }
+  def render(h)
+    h.div(class: "greeting") do |hh|
+      hh.h1 { state[:title] }
+      hh.ul do |hhh|
+        state[:items].each do |item|
+          hhh.li(key: item["id"]) { item["name"] }
         end
       end
     end

--- a/minitest/form_for_test.rb
+++ b/minitest/form_for_test.rb
@@ -19,8 +19,8 @@ class FormForTest < Minitest::Test
         @submitted = data
       end
 
-      def render
-        form_for(:comment, on_submit: :handle_submit) do |f|
+      def render(h)
+        h.form_for(:comment, on_submit: :handle_submit) do |f|
           f.textarea(:body)
           f.submit("Post")
         end

--- a/minitest/hydration_test.rb
+++ b/minitest/hydration_test.rb
@@ -25,8 +25,8 @@ class HydrationMatchTest < Minitest::Test
   # invoked here (we feed vnodes directly); it only satisfies the abstract API.
   def probe
     klass = Class.new(Funicular::Component) do
-      def render
-        div { "x" }
+      def render(h)
+        h.div { "x" }
       end
 
       def match?(vnode, dom)

--- a/minitest/picoruby_helper_test.rb
+++ b/minitest/picoruby_helper_test.rb
@@ -35,14 +35,14 @@ class PicorubyHelperTest < Minitest::Test
 
   def test_local_dist_source_emits_script_and_base_style
     html = @view.picoruby_include_tag(source: :local_dist)
-    assert_includes html, '<script src="/picoruby/dist/init.iife.js">'
+    assert_includes html, '<script src="/picoruby/dist/init.iife.js?v='
     assert_includes html, "<style"
     assert_includes html, "data-funicular-base"
   end
 
   def test_local_debug_source_path
     html = @view.picoruby_include_tag(source: :local_debug)
-    assert_includes html, '<script src="/picoruby/debug/init.iife.js">'
+    assert_includes html, '<script src="/picoruby/debug/init.iife.js?v='
   end
 
   def test_base_styles_can_be_skipped
@@ -71,14 +71,11 @@ class PicorubyHelperTest < Minitest::Test
   end
 
   def test_cdn_source_without_version_raises
-    @config.cdn_version = nil
-    Funicular.instance_variable_set(:@vendored_wasm_version, nil)
+    @config.define_singleton_method(:cdn_version) { nil }
     error = assert_raises(ArgumentError) do
       @view.picoruby_include_tag(source: :cdn)
     end
     assert_includes error.message, ":cdn requires a version"
-  ensure
-    Funicular.instance_variable_set(:@vendored_wasm_version, nil)
   end
 
   def test_unknown_source_raises

--- a/minitest/view_context_test.rb
+++ b/minitest/view_context_test.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ViewContextTest < Minitest::Test
+  def setup
+    Funicular::SSR::Runtime.load_framework!
+  end
+
+  def test_explicit_state_styles_and_resources_do_not_collide_with_html_methods
+    klass = Class.new(Funicular::Component) do
+      styles { |css| css.define :hash, "hash-class" }
+
+      use_suspense :data, ->(resolve, _reject) { resolve.call("loaded") }
+
+      def initialize_state
+        { class: "state-class", hash: "state-hash" }
+      end
+
+      def render(h)
+        h.data(class: h.styles[:hash]) do
+          "#{state[:class]} #{state[:hash]} #{h.resources[:data]}"
+        end
+      end
+    end
+
+    component = klass.new
+    component.instance_variable_get(:@suspense_data)[:data] = "loaded"
+    component.instance_variable_get(:@suspense_states)[:data] = :resolved
+
+    vnode = component.build_vdom
+
+    assert_equal "data", vnode.tag
+    assert_equal "hash-class", vnode.props[:class]
+    assert_equal ["state-class state-hash loaded"], vnode.children
+  end
+
+  def test_component_children_are_vdom_children_not_props
+    child = Class.new(Funicular::Component) do
+      def render(h)
+        h.div { children }
+      end
+    end
+
+    parent = Class.new(Funicular::Component) do
+      define_method(:render) do |h|
+        h.component(child, title: "x") do |hh|
+          hh.span { "inside" }
+        end
+      end
+    end
+
+    vnode = parent.new.build_vdom
+
+    assert_instance_of Funicular::VDOM::Component, vnode
+    assert_equal({ title: "x" }, vnode.props)
+    refute_includes vnode.props.keys, :children_block
+    assert_equal 1, vnode.children.length
+    assert_equal "span", vnode.children.first.tag
+  end
+
+  def test_route_helpers_are_runtime_scoped
+    router_a = Funicular::Router.new(nil)
+    router_b = Funicular::Router.new(nil)
+    router_a.get("/users/:id", to: Class.new(Funicular::Component), as: "user")
+    router_b.get("/accounts/:id", to: Class.new(Funicular::Component), as: "user")
+
+    component_a = Class.new(Funicular::Component).new
+    component_b = Class.new(Funicular::Component).new
+    component_a.runtime = Funicular::Runtime.new(router_a)
+    component_b.runtime = Funicular::Runtime.new(router_b)
+
+    assert_equal "/users/7", Funicular::ViewContext.new(component_a).routes.user_path(7)
+    assert_equal "/accounts/7", Funicular::ViewContext.new(component_b).routes.user_path(7)
+  end
+
+  def test_child_collector_is_restored_when_render_raises
+    klass = Class.new(Funicular::Component) do
+      attr_reader :captured
+
+      def render(h)
+        begin
+          h.div do |hh|
+            hh.span { "before" }
+            raise "boom"
+          end
+        rescue
+          @captured = current_children
+          h.div { "after" }
+        end
+      end
+    end
+
+    instance = klass.new
+    vnode = instance.build_vdom
+
+    assert_nil instance.current_children
+    assert_equal "div", vnode.tag
+    assert_equal ["after"], vnode.children
+  end
+end

--- a/mrblib/component.rb
+++ b/mrblib/component.rb
@@ -5,46 +5,77 @@ module Funicular
         @state = state_hash
       end
 
-      # Support dynamic key access: state[:key] or state[variable_key]
       def [](key)
         @state[key]
       end
-      def method_missing(method, *args)
-        if method.to_s.end_with?('=')
-          key = method.to_s[0..-2] || method
-          raise "Use patch(#{key}: value) to update state"
-        else
-          @state[method]
-        end
+
+      def fetch(key, default = nil)
+        return @state.fetch(key) if default.nil? && @state.key?(key)
+        @state.fetch(key, default)
       end
 
-      def respond_to_missing?(method, include_private = false)
-        return false if method.to_s.end_with?('=')
-        @state.key?(method) || super
+      def key?(key)
+        @state.key?(key)
+      end
+
+      def to_h
+        @state
       end
     end
 
-    attr_accessor :props, :vdom, :dom_element, :mounted
+    class ResourceAccessor
+      def initialize(data, states, errors)
+        @data = data
+        @states = states
+        @errors = errors
+      end
+
+      def [](key)
+        @data[key]
+      end
+
+      def fetch(key, default = nil)
+        return @data.fetch(key) if default.nil? && @data.key?(key)
+        @data.fetch(key, default)
+      end
+
+      def loading?(key)
+        @states[key] == :pending || @states[key] == :loading
+      end
+
+      def error?(key)
+        @states[key] == :rejected
+      end
+
+      def error(key)
+        @errors[key]
+      end
+    end
+
+    attr_accessor :props, :vdom, :dom_element, :mounted, :runtime, :children, :current_children
     attr_reader :refs
 
     def initialize(props = {})
       @props = props
       @state = initialize_state || {}
       @state_accessor = nil
+      @resource_accessor = nil
       @style_accessor = nil
+      @runtime = Funicular::Runtime.new
+      @children = [] #: Array[Funicular::VDOM::child_t]
       @vdom = nil
       @dom_element = nil
-      @refs = {}
-      @event_listeners = []
+      @refs = {} #: Hash[Symbol, JS::Element]
+      @event_listeners = [] #: Array[untyped]
       @mounted = false
       @updating = false
-      @child_components = []
+      @child_components = [] #: Array[Funicular::Component]
 
       # Initialize suspense state
-      @suspense_data = {}
-      @suspense_states = {}   # :pending, :loading, :resolved, :rejected
-      @suspense_errors = {}
-      @suspense_pending_timers = []  # Track pending setTimeout IDs for cleanup
+      @suspense_data = {} #: Hash[Symbol, untyped]
+      @suspense_states = {} #: Hash[Symbol, Symbol]
+      @suspense_errors = {} #: Hash[Symbol, untyped]
+      @suspense_pending_timers = [] #: Array[untyped]
       self.class.suspense_definitions.each_key do |name|
         @suspense_states[name] = :pending
       end
@@ -57,6 +88,14 @@ module Funicular
       @state_accessor ||= StateAccessor.new(@state)
     end
 
+    def resources
+      @resource_accessor ||= ResourceAccessor.new(@suspense_data, @suspense_states, @suspense_errors)
+    end
+
+    def styles
+      @style_accessor ||= StyleAccessor.new(self.class.styles_definitions)
+    end
+
     # Override this method in subclasses to define initial state
     def initialize_state
       {}
@@ -66,7 +105,7 @@ module Funicular
     # Used by SSR to inject server data, and by client hydration to restore
     # the same state from window.__FUNICULAR_STATE__ so the first client
     # render matches the server HTML. Top-level keys are symbolized so they
-    # are reachable via state.foo (StateAccessor uses symbol keys); nested
+    # are reachable via state[:foo] (StateAccessor uses symbol keys); nested
     # values are left untouched (components read them with string keys).
     def seed_state(state_hash)
       return self if state_hash.nil?
@@ -191,30 +230,25 @@ module Funicular
     #   ) do
     #     div { user.name }
     #   end
-    def suspense(fallback:, error: nil, &block)
+    def render_suspense(h, name, fallback:, error: nil, &block)
       current_children = @current_children
       child_count_before = current_children&.size
       result = nil
 
-      # Check for any rejected suspense
-      rejected_name = self.class.suspense_definitions.keys.find { |name| @suspense_states[name] == :rejected }
-      if rejected_name
+      if @suspense_states[name] == :rejected
         result = if error
-          error.call(@suspense_errors[rejected_name])
+          error.call(h, @suspense_errors[name])
         else
-          fallback.call
+          fallback.call(h)
         end
-      elsif suspense_loading?
-        # Check if any suspense is still loading
-        # Note: Loading is started in mount(), not here
-        result = fallback.call
+      elsif suspense_loading?(name)
+        result = fallback.call(h)
       else
-        # All suspense data loaded, render content
-        result = block.call
+        result = block.call(h, resources)
       end
 
       if current_children && current_children.size == child_count_before
-        add_child(result)
+        add_child_from_view(result)
       end
 
       result
@@ -223,7 +257,7 @@ module Funicular
     # Class methods for styles DSL
     def self.styles(&block)
       builder = StyleBuilder.new
-      builder.instance_eval(&block)
+      block.call(builder)
       @styles_definitions = builder.to_definitions
     end
 
@@ -257,11 +291,6 @@ module Funicular
 
     def self.suspense_definitions
       @suspense_definitions ||= {}
-    end
-
-    # Instance method to access styles
-    def s
-      @style_accessor ||= StyleAccessor.new(self.class.styles_definitions)
     end
 
     # Update state and trigger re-render
@@ -301,7 +330,7 @@ module Funicular
 
         @container = container
         new_vdom = build_vdom
-        @dom_element = VDOM::Renderer.new.render(new_vdom)
+        @dom_element = VDOM::Renderer.new(nil, @runtime).render(new_vdom)
         bind_events(@dom_element, new_vdom)
         collect_refs(@dom_element, new_vdom)
         collect_child_components(new_vdom)
@@ -397,7 +426,7 @@ module Funicular
         @child_components.each do |child|
           child.unmount if child.respond_to?(:unmount)
         end
-        @child_components = []
+        @child_components = [] #: Array[Funicular::Component]
 
         cleanup_events
         cleanup_suspense_timers
@@ -418,17 +447,23 @@ module Funicular
     end
 
     # Override this method in subclasses to define render logic
-    def render
-      raise "Subclasses must implement the render method"
+    def render(h)
+      raise "Subclasses must implement render(h)"
     end
 
     # Build VDOM tree from render method
     # Called by VDOM::Renderer, Differ, and Patcher
     def build_vdom
+      previous_rendering = @rendering
+      previous_children = @current_children
       @rendering = true
       @current_children = nil
-      result = render
-      @rendering = false
+      begin
+        result = render(ViewContext.new(self))
+      ensure
+        @rendering = previous_rendering
+        @current_children = previous_children
+      end
 
       # Convert render result to VNode
       vnode = normalize_vnode(result)
@@ -563,7 +598,7 @@ module Funicular
       @event_listeners.each do |callback_id|
         JS::Object.removeEventListener(callback_id)
       end
-      @event_listeners = []
+      @event_listeners = [] #: Array[untyped]
 
       # NOTE: Do NOT cleanup child component events here!
       # Child components manage their own events and will cleanup
@@ -576,7 +611,74 @@ module Funicular
       @suspense_pending_timers.each do |timer_id|
         JS.global.clearTimeout(timer_id)
       end
-      @suspense_pending_timers = []
+      @suspense_pending_timers = [] #: Array[untyped]
+    end
+
+    private
+
+    public
+
+    def normalize_vnode_for_view(value)
+      normalize_vnode(value)
+    end
+
+    def add_child_from_view(child)
+      current_children = @current_children
+      return unless @rendering && current_children
+
+      normalized = normalize_vnode(child)
+      current_children << normalized if normalized
+    end
+
+    def build_form_for(h, model_key, options = {}, &block)
+      on_submit = options.delete(:on_submit)
+      form_class = options.delete(:class)
+
+      submit_handler = if on_submit
+        ->(event) do
+          event.preventDefault
+          form_data = collect_form_data(event, model_key)
+
+          case on_submit
+          when Symbol
+            send(on_submit, form_data)
+          when Method
+            on_submit.call(form_data)
+          when Proc
+            on_submit.call(form_data)
+          else
+            raise "on_submit must be Symbol, Method, or Proc, got #{on_submit.class}"
+          end
+        end
+      else
+        ->(event) { event.preventDefault }
+      end
+
+      h.form({ onsubmit: submit_handler, class: form_class }.merge(options)) do |hh|
+        builder = Funicular::FormBuilder.new(self, hh, model_key, options)
+        block.call(builder)
+      end
+    end
+
+    def build_link_to(h, path, method: :get, **options, &block)
+      merged_options = options.merge(href: path)
+      merged_options[:onclick] = ->(event) {
+        event.preventDefault
+        if method.to_s.downcase.to_sym == :get
+          handle_link_click(path)
+        else
+          handle_link_with_method(path, method)
+        end
+      }
+      h.a(merged_options, &block)
+    end
+
+    def build_button_to(h, path, method: :post, **options, &block)
+      merged_options = options.merge(
+        type: options[:type] || "button",
+        onclick: -> { handle_link_with_method(path, method) }
+      )
+      h.button(merged_options, &block)
     end
 
     private
@@ -615,7 +717,7 @@ module Funicular
       cleanup_events
 
       unless patches.empty?
-        new_dom_element = VDOM::Patcher.new.apply(@dom_element, patches)
+        new_dom_element = VDOM::Patcher.new(nil, @runtime).apply(@dom_element, patches)
         # apply returns JS::Object (it must accept text-node patches), but
         # the component's root is always an Element. Narrow to JS::Element.
         @dom_element = new_dom_element if new_dom_element.is_a?(JS::Element)
@@ -698,7 +800,7 @@ module Funicular
     # appendChild: the stale node already has a place in the document, so we
     # replaceChild instead.
     def full_render_fallback(new_vdom, server_dom)
-      fresh = VDOM::Renderer.new.render(new_vdom)
+      fresh = VDOM::Renderer.new(nil, @runtime).render(new_vdom)
       parent = server_dom.parentNode
       parent.replaceChild(fresh, server_dom) if parent
       bind_events(fresh, new_vdom)
@@ -721,6 +823,8 @@ module Funicular
 
         if child.is_a?(VDOM::Component)
           instance = child.component_class.new(child.props)
+          instance.runtime = child.runtime || @runtime
+          instance.children = child.children
           child.instance = instance
           instance.hydrate(child_dom)
         elsif child.is_a?(VDOM::Element)
@@ -731,7 +835,7 @@ module Funicular
 
     # Collect child component instances from VDOM tree
     def collect_child_components(vnode)
-      @child_components = []
+      @child_components = [] #: Array[Funicular::Component]
       collect_child_components_recursive(vnode, @child_components)
     end
 
@@ -747,135 +851,6 @@ module Funicular
           # @type var child: VDOM::VNode
           collect_child_components_recursive(child, components)
         end
-      end
-    end
-
-    # DSL methods for HTML elements
-    HTML_TAGS = %w[
-      div span p a
-      h1 h2 h3 h4 h5 h6
-      ul ol li
-      table thead tbody tr th td
-      form input textarea button select option label
-      header footer nav section article aside
-      img video audio canvas
-      br hr
-    ]
-
-    # The HTML tag DSL methods are public: besides being called inside render
-    # (implicit self), they are invoked by collaborators such as FormBuilder
-    # with an explicit receiver (@component.div). A private method would forbid
-    # that under CRuby (it is tolerated under mruby), which would break SSR of
-    # any component using form_for. Keep them public on both VMs.
-    public
-
-    HTML_TAGS.each do |tag|
-      define_method(tag) do |props = {}, &block|
-        # @type self: Component
-        children = [] #: Array[Funicular::VDOM::child_t]
-
-        if block
-          prev_children = @current_children
-          @current_children = children
-          # @type var block: Proc
-          result = block.call
-          @current_children = prev_children
-
-          # Add block result to children if not already added via add_child
-          if result && !result.equal?(children) && children.empty?
-            normalized = normalize_vnode(result)
-            children << normalized if normalized
-          end
-        end
-
-        # Normalize props (convert StyleValue to String for :class)
-        normalized_props = {}
-        # @type var props: Hash[Symbol, String]
-        props.each do |key, value|
-          if key == :class && value.is_a?(StyleValue)
-            normalized_props[key] = value.to_s
-          else
-            normalized_props[key] = value
-          end
-        end
-
-        # @type var normalized_props: Hash[Symbol, String]
-        element = VDOM::Element.new(tag, normalized_props, children)
-
-        # If we're inside another element's block, add this element to parent's children
-        if @rendering && @current_children
-          @current_children << element
-        end
-
-        element
-      end
-    end
-
-    private
-
-    # Helper to add children in DSL blocks
-    def add_child(child)
-      return unless @rendering && @current_children
-
-      normalized = normalize_vnode(child)
-      @current_children << normalized if normalized
-    end
-
-    # Helper method to render child components in DSL
-    # Accepts optional block for passing children to the component
-    def component(component_class, props = {}, &block)
-      unless component_class.is_a?(Class) && component_class.ancestors.include?(Funicular::Component)
-        raise "component() expects a Funicular::Component class"
-      end
-
-      # If a block is provided, store the children builder in props
-      # This allows components like ErrorBoundary to control child rendering
-      if block
-        props = props.merge(children_block: block)
-      end
-
-      vnode = VDOM::Component.new(component_class, props)
-
-      # If we're inside another element's block, add this component to parent's children
-      if @rendering && @current_children
-        @current_children << vnode
-      end
-
-      vnode
-    end
-
-    # Rails-style form_for helper
-    def form_for(model_key, options = {}, &block)
-      on_submit = options.delete(:on_submit)
-      form_class = options.delete(:class)
-
-      # Build submit handler
-      submit_handler = if on_submit
-        ->(event) do
-          event.preventDefault
-
-          form_data = collect_form_data(event, model_key)
-
-          # Call the submit handler (Symbol, Method, or Proc)
-          case on_submit
-          when Symbol
-            send(on_submit, form_data)
-          when Method
-            on_submit.call(form_data)
-          when Proc
-            on_submit.call(form_data)
-          else
-            raise "on_submit must be Symbol, Method, or Proc, got #{on_submit.class}"
-          end
-        end
-      else
-        ->(event) { event.preventDefault }
-      end
-
-      # Render form
-      form({ onsubmit: submit_handler, class: form_class }.merge(options)) do
-        builder = Funicular::FormBuilder.new(self, model_key, options)
-        block.call(builder)
       end
     end
 
@@ -937,7 +912,7 @@ module Funicular
     end
 
     def collect_state_form_data(model_key)
-      model_data = state.send(model_key)
+      model_data = state[model_key]
       if model_data.is_a?(Hash)
         model_data
       elsif model_data.respond_to?(:instance_variables)
@@ -952,34 +927,9 @@ module Funicular
       end
     end
 
-    # Rails-style link_to helper
-    # Default behavior: Fetch API for same-page actions (SPA-friendly)
-    # Use navigate: true for router navigation (different component tree)
-    def link_to(path, method: :get, navigate: false, **options, &block)
-      if navigate
-        # Navigation: Use <a> tag with real href for browser features
-        # (right-click -> open in new tab, link preview, etc.)
-        # Note: preventDefault is automatically called by js_add_event_listener
-        # for <a> tags to enable SPA navigation
-        merged_options = options.merge(href: path)
-        merged_options[:onclick] = ->(event) {
-          event.preventDefault  # Called for clarity, but already handled by JS layer
-          handle_link_click(path)
-        }
-        a(merged_options, &block)
-      else
-        # Action: Use <div> tag (semantically more appropriate for actions)
-        # No href needed, purely onclick-driven
-        merged_options = options.merge(
-          onclick: -> { handle_link_with_method(path, method) }
-        )
-        div(merged_options, &block)
-      end
-    end
-
     # Handle router navigation (navigate using History API)
     def handle_link_click(path)
-      Funicular.router&.navigate(path)
+      @runtime.router&.navigate(path)
     end
 
     # Handle link action via Fetch API
@@ -1005,35 +955,6 @@ module Funicular
     def handle_link_response(response, path, method)
       if response.error?
         puts "Link action failed (#{method.to_s.upcase} #{path}): #{response.error_message}"
-      end
-    end
-
-    # Enable URL helpers from RouteHelpers module and suspense data accessors
-    def method_missing(method, *args)
-      # Check for suspense data accessor
-      if self.class.suspense_definitions.key?(method)
-        return @suspense_data[method]
-      end
-
-      if Funicular.const_defined?(:RouteHelpers)
-        helpers = Funicular::RouteHelpers
-        if helpers.instance_methods.include?(method)
-          # Include helpers module and retry
-          self.class.include(helpers) unless self.class.include?(helpers)
-          return send(method, *args)
-        end
-      end
-      super
-    end
-
-    def respond_to_missing?(method, include_private = false)
-      # Check for suspense data accessor
-      return true if self.class.suspense_definitions.key?(method)
-
-      if Funicular.const_defined?(:RouteHelpers)
-        Funicular::RouteHelpers.instance_methods.include?(method) || super
-      else
-        super
       end
     end
 

--- a/mrblib/differ.rb
+++ b/mrblib/differ.rb
@@ -213,11 +213,13 @@ module Funicular
           # If only Proc props changed, update props but skip VDOM rebuild
           unless data_props_changed
             instance.props = new_node.props
+            instance.children = new_node.children
             return []
           end
 
           old_internal_vdom = instance.vdom
           instance.props = new_node.props
+          instance.children = new_node.children
           new_internal_vdom = instance.build_vdom
           internal_patches = diff(old_internal_vdom, new_internal_vdom)
 
@@ -227,7 +229,7 @@ module Funicular
         end
 
         # Original logic: If props changed, replace the entire component
-        if old_node.props != new_node.props
+        if old_node.props != new_node.props || old_node.children != new_node.children
           return [[:replace, new_node, old_node]]
         end
 

--- a/mrblib/error_boundary.rb
+++ b/mrblib/error_boundary.rb
@@ -3,13 +3,13 @@ module Funicular
   # a fallback UI instead of crashing the entire application.
   #
   # Usage:
-  #   component(ErrorBoundary) do
-  #     component(RiskyComponent)
+  #   h.component(ErrorBoundary) do |hh|
+  #     hh.component(RiskyComponent)
   #   end
   #
   # With custom fallback:
-  #   component(ErrorBoundary, fallback: ->(error) { div { "Error: #{error.message}" } }) do
-  #     component(RiskyComponent)
+  #   h.component(ErrorBoundary, fallback: ->(h, error) { h.div { "Error: #{error.message}" } }) do |hh|
+  #     hh.component(RiskyComponent)
   #   end
   #
   # Props:
@@ -60,56 +60,48 @@ module Funicular
       end
     end
 
-    def render
+    def render(h)
       if state[:has_error]
-        render_fallback
+        render_fallback(h)
       else
-        render_children
+        render_children(h)
       end
     end
 
     private
 
-    def render_fallback
+    def render_fallback(h)
       if props[:fallback]
-        result = props[:fallback].call(state[:error])
+        result = props[:fallback].call(h, state[:error])
         if result.is_a?(VDOM::VNode)
           result
         else
-          div { result.to_s }
+          h.div { result.to_s }
         end
       else
-        default_fallback
+        default_fallback(h)
       end
     end
 
-    def default_fallback
-      div(class: 'error-boundary-fallback', style: 'padding: 20px; background: #fee; border: 1px solid #f00; border-radius: 4px;') do
-        h3(style: 'color: #c00; margin: 0 0 10px 0;') { "Something went wrong" }
+    def default_fallback(h)
+      h.div(class: 'error-boundary-fallback', style: 'padding: 20px; background: #fee; border: 1px solid #f00; border-radius: 4px;') do |hh|
+        hh.h3(style: 'color: #c00; margin: 0 0 10px 0;') { "Something went wrong" }
         if state[:error]
-          div(style: 'font-family: monospace; white-space: pre-wrap; font-size: 12px; color: #600;') do
+          hh.div(style: 'font-family: monospace; white-space: pre-wrap; font-size: 12px; color: #600;') do
             "#{state[:error].class}: #{state[:error].message}"
           end
         end
         if Funicular.env.development? && state[:error_info]
-          div(style: 'margin-top: 10px; font-size: 11px; color: #666;') do
+          hh.div(style: 'margin-top: 10px; font-size: 11px; color: #666;') do
             "Component: #{state[:error_info][:component_class]}"
           end
         end
       end
     end
 
-    def render_children
-      # Children are passed via children_block prop from the component() DSL
-      # Errors are caught by VDOM::Renderer.render_component
-      if props[:children_block]
-        div(class: 'error-boundary-content') do
-          props[:children_block].call
-        end
-      elsif props[:children]
-        props[:children]
-      else
-        div { "" }
+    def render_children(h)
+      h.div(class: 'error-boundary-content') do
+        children
       end
     end
   end

--- a/mrblib/form_builder.rb
+++ b/mrblib/form_builder.rb
@@ -1,9 +1,10 @@
 module Funicular
   class FormBuilder
-    attr_reader :component, :model_key, :options
+    attr_reader :component, :view_context, :model_key, :options
 
-    def initialize(component, model_key, options = {})
+    def initialize(component, view_context, model_key, options = {})
       @component = component
+      @view_context = view_context
       @model_key = model_key
       @options = options
       # Per-form options win, then the global Funicular.configure_forms config,
@@ -32,7 +33,8 @@ module Funicular
       end
 
       # Check for errors
-      error_message = @component.state.errors ? @component.state.errors[field_key.to_sym] : nil
+      errors = @component.state[:errors]
+      error_message = errors ? errors[field_key.to_sym] : nil
       # errors may be a single message (legacy) or an array of messages
       # (Funicular::Model::Errors#messages). Show the first.
       error_message = error_message.first if error_message.is_a?(Array)
@@ -63,10 +65,10 @@ module Funicular
       attrs[:class] = css_class unless css_class.empty?
 
       # Render field + error message
-      @component.div do
-        @component.input(attrs)
+      @view_context.div do |h|
+        h.input(attrs)
         if has_error
-          @component.div(class: @error_class) { error_message }
+          h.div(class: @error_class) { error_message }
         end
       end
     end
@@ -99,7 +101,8 @@ module Funicular
         set_nested_value(@model_key, field_key, new_value)
       end
 
-      error_message = @component.state.errors ? @component.state.errors[field_key.to_sym] : nil
+      errors = @component.state[:errors]
+      error_message = errors ? errors[field_key.to_sym] : nil
       # errors may be a single message (legacy) or an array of messages
       # (Funicular::Model::Errors#messages). Show the first.
       error_message = error_message.first if error_message.is_a?(Array)
@@ -125,10 +128,10 @@ module Funicular
 
       attrs[:class] = css_class unless css_class.empty?
 
-      @component.div do
-        @component.textarea(attrs)
+      @view_context.div do |h|
+        h.textarea(attrs)
         if has_error
-          @component.div(class: @error_class) { error_message }
+          h.div(class: @error_class) { error_message }
         end
       end
     end
@@ -151,7 +154,7 @@ module Funicular
         onchange: on_change
       }.merge(options)
 
-      @component.input(attrs)
+      @view_context.input(attrs)
     end
 
     def select(field_name, choices, options = {})
@@ -165,7 +168,8 @@ module Funicular
         set_nested_value(@model_key, field_key, new_value)
       end
 
-      error_message = @component.state.errors ? @component.state.errors[field_key.to_sym] : nil
+      errors = @component.state[:errors]
+      error_message = errors ? errors[field_key.to_sym] : nil
       # errors may be a single message (legacy) or an array of messages
       # (Funicular::Model::Errors#messages). Show the first.
       error_message = error_message.first if error_message.is_a?(Array)
@@ -190,18 +194,18 @@ module Funicular
 
       attrs[:class] = css_class unless css_class.empty?
 
-      @component.div do
-        @component.select(attrs) do
+      @view_context.div do |h|
+        h.select(attrs) do |hh|
           choices.each do |choice|
             option_value, option_text = choice.is_a?(Array) ? choice : [choice, choice]
             selected = value.to_s == option_value.to_s
-            @component.option(value: option_value, selected: selected) do
+            hh.option(value: option_value, selected: selected) do
               option_text
             end
           end
         end
         if has_error
-          @component.div(class: @error_class) { error_message }
+          h.div(class: @error_class) { error_message }
         end
       end
     end
@@ -232,17 +236,17 @@ module Funicular
         onchange: on_change
       }.merge(options)
 
-      @component.input(attrs)
+      @view_context.input(attrs)
     end
 
     def submit(label = "Submit", options = {})
       attrs = { type: "submit" }.merge(options)
-      @component.button(attrs) { label }
+      @view_context.button(attrs) { label }
     end
 
     def label(field_name, text = nil, options = {})
       text ||= field_name.to_s.split('_').map { |word| word.capitalize }.join(' ')
-      @component.label(options) { text }
+      @view_context.label(options) { text }
     end
 
     private
@@ -252,10 +256,10 @@ module Funicular
       keys = key_path.split('.')
       value = state
       keys.each do |key|
-        if value.respond_to?(key.to_sym)
-          value = value.send(key.to_sym)
-        elsif value.is_a?(Hash)
+        if value.is_a?(Hash)
           value = value[key.to_sym] || value[key]
+        elsif value.respond_to?(:[])
+          value = value[key.to_sym]
         else
           value = nil
         end
@@ -270,12 +274,12 @@ module Funicular
       if field_key.include?('.')
         # Complex nested update
         keys = field_key.split('.')
-        current_model = @component.state.send(model_key.to_sym)
+        current_model = @component.state[model_key.to_sym]
         updated_model = deep_merge_value(current_model, keys, new_value)
         @component.patch(model_key.to_sym => updated_model)
       else
         # Simple update
-        current_model = @component.state.send(model_key.to_sym)
+        current_model = @component.state[model_key.to_sym]
         if current_model.nil?
           @component.patch(model_key.to_sym => { field_key.to_sym => new_value })
         elsif current_model.is_a?(Hash)

--- a/mrblib/funicular.rb
+++ b/mrblib/funicular.rb
@@ -18,7 +18,7 @@ module Funicular
   # Guard against redefinition: when the mrblib runtime is loaded into a
   # CRuby/Rails process for SSR, lib/funicular/version.rb has already defined
   # VERSION for the CRuby gem. In the wasm build VERSION is undefined here.
-  VERSION = '0.1.0' unless Funicular.const_defined?(:VERSION)
+  VERSION = '0.3.0' unless Funicular.const_defined?(:VERSION)
 
   def self.version
     VERSION
@@ -185,6 +185,7 @@ module Funicular
     # Otherwise, mount single component (backward compatible)
     if component_class
       instance = component_class.new(props)
+      instance.runtime = Funicular::Runtime.new(nil)
       server_root = hydrate ? first_element_child(container_element) : nil
       if server_root
         instance.seed_state(window_state)

--- a/mrblib/html_serializer.rb
+++ b/mrblib/html_serializer.rb
@@ -16,10 +16,14 @@ module Funicular
       ]
 
       # Props that must never be emitted as HTML attributes.
-      SKIP_PROPS = %i[ref key children_block]
+      SKIP_PROPS = %i[ref key]
 
-      def self.serialize(vnode)
-        new.render(vnode)
+      def self.serialize(vnode, runtime = nil)
+        new(runtime).render(vnode)
+      end
+
+      def initialize(runtime = nil)
+        @runtime = runtime
       end
 
       def render(vnode)
@@ -75,6 +79,8 @@ module Funicular
 
       def render_component(component_vnode)
         instance = component_vnode.component_class.new(component_vnode.props)
+        instance.runtime = component_vnode.runtime || @runtime || Funicular::Runtime.new
+        instance.children = component_vnode.children
         component_vnode.instance = instance
         render(instance.build_vdom)
       end

--- a/mrblib/http.rb
+++ b/mrblib/http.rb
@@ -134,6 +134,17 @@ module Funicular
         block.call(Response.new(status, data)) if block
       end
 
+      def parse_response_body(text)
+        return nil if text.nil?
+
+        body = text.to_s
+        return nil if body.empty?
+
+        JSON.parse(body)
+      rescue
+        body
+      end
+
       def request(method, url, body, cache: nil, &block)
         if method == "GET" && cache.is_a?(Integer) && cache > 0
           entry = cache_lookup(url)
@@ -163,7 +174,7 @@ module Funicular
         JS.global.fetch(url, options) do |response|
           status = response.status.to_i
           json_text = response.to_binary
-          data = JSON.parse(json_text)
+          data = parse_response_body(json_text)
           # @type var status: Integer
           http_response = Response.new(status, data)
 

--- a/mrblib/patcher.rb
+++ b/mrblib/patcher.rb
@@ -1,8 +1,9 @@
 module Funicular
   module VDOM
     class Patcher
-      def initialize(doc = nil)
+      def initialize(doc = nil, runtime = nil)
         @doc = doc || JS.document
+        @runtime = runtime
       end
 
       def apply(element, patches)
@@ -28,7 +29,7 @@ module Funicular
             old_dom_element = instance.dom_element
 
             # Apply internal patches and get the potentially new root element
-            new_dom_element = Patcher.new(@doc).apply(old_dom_element, internal_patches)
+            new_dom_element = Patcher.new(@doc, instance.runtime).apply(old_dom_element, internal_patches)
 
             # Update the instance's reference to its root DOM element if it changed
             if new_dom_element != old_dom_element && new_dom_element.is_a?(JS::Element)
@@ -265,7 +266,7 @@ module Funicular
           element
         when :component
           raise "Expected Component vnode" unless vnode.is_a?(Component)
-          Renderer.new(@doc).render(vnode, nil)
+          Renderer.new(@doc, vnode.runtime || @runtime).render(vnode, nil)
         else
           raise "Unknown vnode type: #{vnode.type}"
         end

--- a/mrblib/router.rb
+++ b/mrblib/router.rb
@@ -1,6 +1,6 @@
 module Funicular
   class Router
-    attr_reader :routes, :current_component, :current_path
+    attr_reader :routes, :current_component, :current_path, :url_helpers, :route_helpers
 
     def initialize(container)
       @container = container
@@ -10,7 +10,9 @@ module Funicular
       @current_path = nil
       @popstate_callback_id = nil
       @url_helpers = Module.new
-      Funicular.const_set(:RouteHelpers, @url_helpers) unless Funicular.const_defined?(:RouteHelpers)
+      @route_helpers = Object.new
+      @route_helpers.extend(@url_helpers)
+      @runtime = Funicular::Runtime.new(self)
     end
 
     # Rails-style DSL methods
@@ -133,6 +135,7 @@ module Funicular
       # Mount new component
       @current_path = path
       @current_component = component_class.new(params)
+      @current_component.runtime = @runtime
       # @type ivar @current_component: Funicular::Component
 
       server_root = hydrate_now ? Funicular.first_element_child(@container) : nil
@@ -147,6 +150,7 @@ module Funicular
           puts "[Funicular] Hydration failed, falling back to full render: #{e.message}"
           @container[:innerHTML] = ''
           @current_component = component_class.new(params)
+          @current_component.runtime = @runtime
         end
       end
 
@@ -194,19 +198,19 @@ module Funicular
       if param_names.empty?
         # No parameters - return static path
         @url_helpers.module_eval do
-          define_method(helper_method_name) do # steep:ignore
+          define_method(helper_method_name) do
             path_pattern
           end
         end
       else
         # With parameters
         @url_helpers.module_eval do
-          define_method(helper_method_name) do |*args| # steep:ignore
+          define_method(helper_method_name) do |*args|
             # Handle model objects with id method
             if args.length == 1 && args[0].respond_to?(:id) && param_names.length == 1
               args = [args[0].id]
             elsif args.length != param_names.length
-              raise ArgumentError, "#{helper_method_name} expects #{param_names.length} argument(s), got #{args.length}"
+              Kernel.raise ArgumentError, "#{helper_method_name} expects #{param_names.length} argument(s), got #{args.length}"
             end
 
             result = path_pattern.dup

--- a/mrblib/runtime.rb
+++ b/mrblib/runtime.rb
@@ -1,0 +1,28 @@
+module Funicular
+  class Runtime
+    attr_accessor :router
+
+    def initialize(router = nil)
+      @router = router
+    end
+
+    def routes
+      router = @router
+      if router
+        router.route_helpers
+      else
+        EmptyRoutes
+      end
+    end
+  end
+
+  module EmptyRoutes
+    def self.method_missing(name, *args)
+      raise NoMethodError, "undefined route helper #{name}"
+    end
+
+    def self.respond_to_missing?(name, include_private = false)
+      false
+    end
+  end
+end

--- a/mrblib/styles.rb
+++ b/mrblib/styles.rb
@@ -30,32 +30,28 @@ module Funicular
       @definitions = definitions
     end
 
-    def method_missing(name, *args)
+    def [](name, variant = nil)
       style = @definitions[name]
       return StyleValue.new("") unless style
 
-      if args.empty?
+      if variant.nil?
         # No arguments: return base or value
         StyleValue.new(style[:base] || style[:value] || "")
-      elsif args[0] == true || args[0] == false
+      elsif variant == true || variant == false
         # Boolean argument: base + active (if true)
         # JS::Object#== now supports direct comparison with Ruby true/false
         base = style[:base] || ""
-        active_class = (args[0] == true) ? (style[:active] || "") : ""
+        active_class = (variant == true) ? (style[:active] || "") : ""
         StyleValue.new("#{base} #{active_class}".strip)
-      elsif args[0].is_a?(Symbol)
+      elsif variant.is_a?(Symbol)
         # Symbol argument: base + variants[symbol]
         base = style[:base] || ""
-        variant_class = style[:variants] ? (style[:variants][args[0]] || "") : ""
+        variant_class = style[:variants] ? (style[:variants][variant] || "") : ""
         StyleValue.new("#{base} #{variant_class}".strip)
       else
         # Other types: just return base
         StyleValue.new(style[:base] || style[:value] || "")
       end
-    end
-
-    def respond_to_missing?(name, include_private = false)
-      @definitions.key?(name) || super
     end
   end
 
@@ -64,13 +60,13 @@ module Funicular
       @definitions = {}
     end
 
-    def method_missing(name, *args)
-      if args.size == 1 && args[0].is_a?(String)
-        # Simple style: name "class-string"
-        @definitions[name] = { value: args[0] }
-      elsif args.size == 1 && args[0].is_a?(Hash)
-        # Complex style with base/active/variants
-        @definitions[name] = args[0]
+    def define(name, value = nil, **options)
+      if value.is_a?(String)
+        @definitions[name] = { value: value }
+      elsif value.is_a?(Hash)
+        @definitions[name] = value
+      elsif !options.empty?
+        @definitions[name] = options
       else
         raise ArgumentError, "Invalid style definition for #{name}"
       end

--- a/mrblib/vdom.rb
+++ b/mrblib/vdom.rb
@@ -146,26 +146,29 @@ module Funicular
     end
 
     class Component < VNode
-      attr_reader :component_class, :props
-      attr_accessor :instance
+      attr_reader :component_class, :props, :children
+      attr_accessor :instance, :runtime
 
-      def initialize(component_class, props = {})
+      def initialize(component_class, props = {}, children = [])
         super(:component)
         @component_class = component_class
         @key = props.delete(:key)
         @props = props
+        @children = children || []
         @instance = nil
+        @runtime = nil
       end
 
       def ==(other)
         return false unless other.is_a?(Component)
-        @component_class == other.component_class && @props == other.props
+        @component_class == other.component_class && @props == other.props && @children == other.children
       end
     end
 
     class Renderer
-      def initialize(doc = nil)
+      def initialize(doc = nil, runtime = nil)
         @doc = doc || JS.document
+        @runtime = runtime
         @error_boundary_stack = []
       end
 
@@ -252,6 +255,8 @@ module Funicular
 
       def render_component(component_vnode, parent)
         instance = component_vnode.component_class.new(component_vnode.props)
+        instance.runtime = component_vnode.runtime || @runtime || Funicular::Runtime.new
+        instance.children = component_vnode.children
         component_vnode.instance = instance
 
         is_error_boundary = instance.is_a?(Funicular::ErrorBoundary)

--- a/mrblib/view_context.rb
+++ b/mrblib/view_context.rb
@@ -1,0 +1,135 @@
+module Funicular
+  class ViewContext
+    HTML_TAGS = %w[
+      div span p a data
+      h1 h2 h3 h4 h5 h6
+      ul ol li
+      table thead tbody tr th td
+      form input textarea button select option label
+      header footer nav section article aside
+      img video audio canvas
+      br hr
+    ]
+
+    def initialize(component)
+      @component = component
+    end
+
+    def state
+      @component.state
+    end
+
+    def props
+      @component.props
+    end
+
+    def resources
+      @component.resources
+    end
+
+    def styles
+      @component.styles
+    end
+
+    def routes
+      @component.runtime.routes
+    end
+
+    def tag(name, props = {}, &block)
+      build_element(name, props, &block)
+    end
+
+    HTML_TAGS.each do |tag_name|
+      define_method(tag_name) do |props = {}, &block|
+        tag(tag_name, props, &block) # steep:ignore
+      end
+    end
+
+    def component(component_class, props = {}, &block)
+      unless component_class.is_a?(Class) && component_class.ancestors.include?(Funicular::Component)
+        raise "h.component expects a Funicular::Component class"
+      end
+
+      children = if block
+        capture(&block)
+      else
+        [] #: Array[Funicular::VDOM::child_t]
+      end
+      vnode = VDOM::Component.new(component_class, props, children)
+      vnode.runtime = @component.runtime
+      add_child(vnode)
+      vnode
+    end
+
+    def form_for(model_key, options = {}, &block)
+      @component.build_form_for(self, model_key, options, &block)
+    end
+
+    def suspense(name, fallback:, error: nil, &block)
+      @component.render_suspense(self, name, fallback: fallback, error: error, &block)
+    end
+
+    def link_to(path, **options, &block)
+      @component.build_link_to(self, path, **options, &block)
+    end
+
+    def button_to(path, method: :post, **options, &block)
+      @component.build_button_to(self, path, method: method, **options, &block)
+    end
+
+    def capture(&block)
+      children = [] #: Array[Funicular::VDOM::child_t]
+      previous = @component.current_children
+      @component.current_children = children
+      result = block.call(self)
+      @component.current_children = previous
+
+      if result && !result.equal?(children) && children.empty?
+        if result.is_a?(Array)
+          result.each do |item|
+            if item.is_a?(String)
+              children << item
+            else
+              normalized = @component.normalize_vnode_for_view(item)
+              children << normalized if normalized
+            end
+          end
+        elsif result.is_a?(String)
+          children << result
+        else
+          normalized = @component.normalize_vnode_for_view(result)
+          children << normalized if normalized
+        end
+      end
+      children
+    ensure
+      @component.current_children = previous
+    end
+
+    def add_child(child)
+      @component.add_child_from_view(child)
+    end
+
+    private
+
+    def build_element(tag_name, props = {}, &block)
+      children = if block
+        capture(&block)
+      else
+        [] #: Array[Funicular::VDOM::child_t]
+      end
+      normalized_props = normalize_props(props || {})
+      element = VDOM::Element.new(tag_name.to_s, normalized_props, children)
+      add_child(element)
+      element
+    end
+
+    def normalize_props(props)
+      normalized = {} #: Hash[Symbol, untyped]
+      props.each do |key, value|
+        normalized[key] = key == :class && value.is_a?(StyleValue) ? value.to_s : value
+      end
+      normalized
+    end
+  end
+end

--- a/sig/component.rbs
+++ b/sig/component.rbs
@@ -3,65 +3,66 @@ module Funicular
     class StateAccessor
       def initialize: (Hash[Symbol, untyped] state_hash) -> void
       def []: (Symbol key) -> untyped
-      def method_missing: (Symbol method, *untyped args) -> untyped
-      def respond_to_missing?: (Symbol method, ?bool include_private) -> bool
-      def errors: () -> Hash[Symbol, String]
+      def fetch: (Symbol key, ?untyped default) -> untyped
+      def key?: (Symbol key) -> bool
+      def to_h: () -> Hash[Symbol, untyped]
     end
 
-    HTML_TAGS: Array[String]
+    class ResourceAccessor
+      def initialize: (Hash[Symbol, untyped] data, Hash[Symbol, Symbol] states, Hash[Symbol, untyped] errors) -> void
+      def []: (Symbol key) -> untyped
+      def fetch: (Symbol key, ?untyped default) -> untyped
+      def loading?: (Symbol key) -> bool
+      def error?: (Symbol key) -> bool
+      def error: (Symbol key) -> untyped
+    end
 
     attr_accessor props: Hash[Symbol, untyped]
     attr_accessor vdom: VDOM::VNode | VDOM::Text | nil
     attr_accessor dom_element: JS::Element
     attr_accessor mounted: bool
+    attr_accessor runtime: Runtime
+    attr_accessor children: Array[VDOM::child_t]
+    attr_accessor current_children: Array[VDOM::child_t]?
     attr_reader refs: Hash[Symbol, JS::Element]
-    @event_listeners: Array[Integer]
-    @child_components: Array[Component]
-    @suspense_data: Hash[Symbol, untyped]
-    @suspense_states: Hash[Symbol, Symbol]
-    @suspense_errors: Hash[Symbol, untyped]
-    @suspense_pending_timers: Array[Integer]
-    self.@suspense_definitions: Hash[Symbol, suspense_definition]
+
+    type suspense_definition = { loader: untyped, on_resolve: untyped, min_delay: Integer? }
 
     def initialize: (?Hash[Symbol, untyped] props) -> void
-
-    # Styles DSL class methods
     def self.styles: () { (StyleBuilder) -> void } -> void
     def self.styles_definitions: () -> Hash[Symbol, Hash[Symbol, untyped]]
-
-    # Suspense DSL class methods
-    # Note: Using untyped for Proc types to avoid instance_exec block type mismatch warnings
-    type suspense_definition = { loader: untyped, on_resolve: untyped, min_delay: Integer? }
     def self.use_suspense: (Symbol name, untyped loader, ?on_resolve: untyped, ?min_delay: Integer) -> void
     def self.suspense_definitions: () -> Hash[Symbol, suspense_definition]
 
     def state: () -> StateAccessor
-
-    # Styles DSL instance method
-    def s: () -> StyleAccessor
-
-    # Public API
+    def resources: () -> ResourceAccessor
+    def styles: () -> StyleAccessor
     def initialize_state: () -> Hash[Symbol, untyped]
+    def seed_state: (Hash[untyped, untyped]? state_hash) -> self
 
-    # Suspense instance methods
     def load_suspense_data: () -> void
     def load_single_suspense: (Symbol name, ?suspense_definition? definition) -> void
     def reload_suspense: (Symbol name) -> void
     def suspense_loading?: (*Symbol names) -> bool
     def suspense_error?: (Symbol name) -> bool
     def suspense_error: (Symbol name) -> untyped
-    def suspense: (fallback: ^() -> void, ?error: ^(untyped) -> void) { () -> void } -> void
+    def render_suspense: (ViewContext h, Symbol name, fallback: untyped, ?error: untyped) { (ViewContext, ResourceAccessor) -> untyped } -> untyped
 
     def patch: (Hash[Symbol, untyped] new_state) -> void
     def mount: (JS::Element container) -> void
     def hydrate: (JS::Element dom_element) -> void
-    def seed_state: (Hash[untyped, untyped]? state_hash) -> self
     def unmount: () -> void
-    def render: () -> (VDOM::VNode | String | Integer | Float | Array[untyped] | nil)
-    def bind_events: (JS::Element dom_element, VDOM::VNode | VDOM::Text | nil vnode) -> void
+    def render: (ViewContext h) -> (VDOM::VNode | String | Integer | Float | Array[untyped] | nil)
     def build_vdom: () -> (VDOM::VNode | VDOM::Text | nil)
 
-    # Lifecycle hooks (public, can be overridden in subclasses)
+    def bind_events: (JS::Element dom_element, VDOM::VNode | VDOM::Text | nil vnode) -> void
+    def collect_refs: (JS::Element dom_element, VDOM::VNode | VDOM::Text | nil vnode, ?Hash[Symbol, JS::Element] refs_map) -> Hash[Symbol, JS::Element]
+    def normalize_vnode_for_view: (untyped value) -> (VDOM::Element | VDOM::Text | VDOM::Component | nil)
+    def add_child_from_view: (untyped child) -> void
+    def build_form_for: (ViewContext h, Symbol model_key, ?Hash[Symbol, untyped] options) { (FormBuilder) -> void } -> VDOM::Element
+    def build_link_to: (ViewContext h, String path, **untyped options) { (ViewContext) -> untyped } -> VDOM::Element
+    def build_button_to: (ViewContext h, String path, ?method: Symbol, **untyped options) { (ViewContext) -> untyped } -> VDOM::Element
+
     def component_will_mount: () -> void
     def component_mounted: () -> void
     def component_will_update: () -> void
@@ -70,22 +71,9 @@ module Funicular
     def component_unmounted: () -> void
     def component_raised: (Exception e) -> void
 
-    # Child component helper
-    def component: (Class component_class, ?Hash[Symbol, untyped] props) ?{ () -> untyped } -> VDOM::Component
-
-    # Rails-style form helper
-    def form_for: (Symbol model_key, ?Hash[Symbol, untyped] options) { (FormBuilder) -> void } -> VDOM::Element
-
-    # Rails-style routing helpers
-    def link_to: (String path, ?method: Symbol, ?navigate: bool, **untyped options) { -> untyped } -> VDOM::Element
-    def method_missing: (Symbol method, *untyped args) -> untyped
-    def respond_to_missing?: (Symbol method, ?bool include_private) -> bool
-
-    # Transition helpers
     def remove_via: (String element_id, String from, String to, ?duration: Integer) ?{ () -> void } -> void
     def add_via: (String element_id, String from, String to, ?duration: Integer) ?{ () -> void } -> void
 
-    # Private methods
     private def handle_link_click: (String path) -> void
     private def handle_link_with_method: (String path, Symbol method) -> void
     private def handle_link_response: (HTTP::Response response, String path, Symbol method) -> void
@@ -93,63 +81,18 @@ module Funicular
     private def re_render: () -> void
     private def normalize_vnode: (untyped value) -> (VDOM::Element | VDOM::Text | VDOM::Component | nil)
     private def add_data_component_attribute: (VDOM::VNode vnode) -> void
-    private def collect_refs: (JS::Element dom_element, VDOM::VNode | VDOM::Text | nil vnode, ?Hash[Symbol, JS::Element] refs_map) -> Hash[Symbol, JS::Element]
     private def cleanup_events: () -> void
     private def cleanup_suspense_timers: () -> void
-    private def add_child: (untyped child) -> void
     private def collect_child_components: (VDOM::VNode | VDOM::Text | nil vnode) -> void
     private def collect_child_components_recursive: (VDOM::VNode | VDOM::Text | nil vnode, Array[Component] components) -> void
-
-    private def collect_form_data: (JS::Event event, Symbol model_key) -> Hash[Symbol, untyped]
-    private def collect_dom_form_data: (JS::Event event) -> Hash[Symbol, untyped]
+    private def collect_form_data: (untyped event, Symbol model_key) -> Hash[Symbol, untyped]
+    private def collect_dom_form_data: (untyped event) -> Hash[Symbol, untyped]
     private def collect_state_form_data: (Symbol model_key) -> Hash[Symbol, untyped]
-    private def event_target: (JS::Event event) -> untyped
-    private def add_form_field_value: (Hash[Symbol, untyped] data, JS::Element field) -> void
-
-    # Hydration helpers
+    private def event_target: (untyped event) -> untyped
+    private def add_form_field_value: (Hash[Symbol, untyped] data, untyped field) -> void
     private def hydration_match?: (untyped vnode, untyped dom_element) -> bool
     private def warn_hydration_mismatch: (untyped vnode, untyped dom_element) -> void
     private def full_render_fallback: (VDOM::VNode | VDOM::Text | nil new_vdom, untyped server_dom) -> JS::Element
     private def hydrate_child_components: (untyped vnode, untyped dom_element) -> void
-
-    # HTML element methods (DSL)
-    def div: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
-    def span: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
-    def p: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
-    def a: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
-    def h1: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
-    def h2: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
-    def h3: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
-    def h4: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
-    def h5: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
-    def h6: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
-    def ul: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
-    def ol: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
-    def li: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
-    def table: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
-    def thead: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
-    def tbody: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
-    def tr: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
-    def th: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
-    def td: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
-    def form: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
-    def input: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
-    def textarea: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
-    def button: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
-    def select: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
-    def option: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
-    def label: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
-    def header: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
-    def footer: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
-    def nav: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
-    def section: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
-    def article: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
-    def aside: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
-    def img: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
-    def video: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
-    def audio: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
-    def canvas: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
-    def br: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
-    def hr: (?Hash[Symbol, untyped] props) ?{ -> untyped } -> VDOM::Element
   end
 end

--- a/sig/error_boundary.rbs
+++ b/sig/error_boundary.rbs
@@ -5,10 +5,10 @@ module Funicular
     def initialize_state: () -> Hash[Symbol, untyped]
     def catch_error: (Exception error, ?Hash[Symbol, untyped]? error_info) -> bool
     def reset: () -> void
-    def render: () -> (VDOM::VNode | String | Integer | Float | Array[untyped] | nil)
+    def render: (ViewContext h) -> (VDOM::VNode | String | Integer | Float | Array[untyped] | nil)
 
-    private def render_fallback: () -> (VDOM::VNode | String)
-    private def default_fallback: () -> VDOM::VNode
-    private def render_children: () -> VDOM::VNode
+    private def render_fallback: (ViewContext h) -> (VDOM::VNode | String)
+    private def default_fallback: (ViewContext h) -> VDOM::VNode
+    private def render_children: (ViewContext h) -> VDOM::VNode
   end
 end

--- a/sig/form_builder.rbs
+++ b/sig/form_builder.rbs
@@ -1,10 +1,11 @@
 module Funicular
   class FormBuilder
     attr_reader component: Component
+    attr_reader view_context: ViewContext
     attr_reader model_key: Symbol
     attr_reader options: Hash[Symbol, untyped]
 
-    def initialize: (Component component, Symbol model_key, ?Hash[Symbol, untyped] options) -> void
+    def initialize: (Component component, ViewContext view_context, Symbol model_key, ?Hash[Symbol, untyped] options) -> void
 
     # Field builder methods
     def text_field: (Symbol field_name, ?Hash[Symbol, untyped] options) -> VDOM::Element

--- a/sig/html_serializer.rbs
+++ b/sig/html_serializer.rbs
@@ -4,7 +4,8 @@ module Funicular
       VOID_ELEMENTS: Array[String]
       SKIP_PROPS: Array[Symbol]
 
-      def self.serialize: (VNode? vnode) -> String
+      def self.serialize: (VNode? vnode, ?Runtime? runtime) -> String
+      def initialize: (?Runtime? runtime) -> void
       def render: (VNode? vnode) -> String
 
       private

--- a/sig/http.rbs
+++ b/sig/http.rbs
@@ -32,6 +32,7 @@ module Funicular
     private def self.now_seconds: () -> Integer
     private def self.cache_hit?: (untyped entry, Integer ttl) -> bool
     private def self.serve_from_cache: (Hash[String, untyped] entry) { (Response) -> void } -> void
+    private def self.parse_response_body: (untyped text) -> untyped
     private def self.request: (String method, String url, Hash[untyped, untyped]? body, ?cache: Integer?) { (Response) -> void } -> void
   end
 end

--- a/sig/patcher.rbs
+++ b/sig/patcher.rbs
@@ -3,7 +3,7 @@ module Funicular
     BOOLEAN_ATTRIBUTES: Array[String]
 
     class Patcher
-      def initialize: (?JS::Element? doc) -> void
+      def initialize: (?JS::Element? doc, ?Runtime? runtime) -> void
       # `apply` accepts any DOM node so text-node patches (e.g. :replace)
       # can recurse into it; Element-only operations are narrowed inside.
       def apply: (JS::Object element, Array[patch_t] patches) -> JS::Object

--- a/sig/router.rbs
+++ b/sig/router.rbs
@@ -2,22 +2,12 @@ module Funicular
   type route_constraints_t = Hash[Symbol, Regexp]
   type route_definition_t = { method: Symbol, path: String, component: singleton(Component), name: String?, pattern_segments: Array[String], constraints: route_constraints_t }
 
-  # URL helper methods are dynamically generated based on route definitions
-  # Example: router.get('/users/:id', to: UserComponent, as: 'user')
-  # generates: user_path(id) -> String
-  module RouteHelpers
-    # Dynamic methods are generated at runtime by Router#generate_url_helper
-    # Method signatures depend on route parameters:
-    # - No parameters: def helper_name_path: () -> String
-    # - With parameters: def helper_name_path: (Integer | String | untyped) -> String
-    def method_missing: (Symbol method, *untyped args) -> String
-    def respond_to_missing?: (Symbol method, ?bool include_private) -> bool
-  end
-
   class Router
     attr_reader routes: Array[route_definition_t]
     attr_reader current_component: Component?
     attr_reader current_path: String?
+    attr_reader url_helpers: Module
+    attr_reader route_helpers: untyped
 
     def initialize: (JS::Element? container) -> void
     def get: (String path, to: singleton(Component), ?as: String?, ?constraints: route_constraints_t?) -> void
@@ -31,7 +21,6 @@ module Funicular
     def start: (?hydrate: bool) -> void
     def stop: () -> void
     def navigate: (String path) -> void
-    def current_hash_path: () -> String
     def current_location_path: () -> String
 
     private def add_route_with_method: (Symbol method, String path, singleton(Component) component_class, String? name, ?route_constraints_t? constraints) -> void

--- a/sig/runtime.rbs
+++ b/sig/runtime.rbs
@@ -1,0 +1,13 @@
+module Funicular
+  class Runtime
+    attr_accessor router: Router?
+
+    def initialize: (?Router? router) -> void
+    def routes: () -> untyped
+  end
+
+  module EmptyRoutes
+    def self.method_missing: (Symbol name, *untyped args) -> untyped
+    def self.respond_to_missing?: (Symbol name, ?bool include_private) -> bool
+  end
+end

--- a/sig/styles.rbs
+++ b/sig/styles.rbs
@@ -7,11 +7,10 @@ module Funicular
     def to_s: () -> String
   end
 
-  # StyleAccessor provides access to defined styles via method calls
+  # StyleAccessor provides explicit access to defined styles.
   class StyleAccessor
     def initialize: (Hash[Symbol, Hash[Symbol, untyped]] definitions) -> void
-    private def method_missing: (Symbol name, *untyped args) -> StyleValue
-    private def respond_to_missing?: (Symbol name, ?bool include_private) -> bool
+    def []: (Symbol name, ?(Symbol | bool) variant) -> StyleValue
   end
 
   # StyleBuilder is used to define styles within the styles {} block
@@ -19,7 +18,7 @@ module Funicular
     @definitions: Hash[Symbol, Hash[Symbol, untyped]]
 
     def initialize: () -> void
+    def define: (Symbol name, ?(String | Hash[Symbol, untyped]) value, **untyped options) -> void
     def to_definitions: () -> Hash[Symbol, Hash[Symbol, untyped]]
-    private def method_missing: (Symbol name, *untyped args) -> void
   end
 end

--- a/sig/vdom.rbs
+++ b/sig/vdom.rbs
@@ -39,7 +39,7 @@ module Funicular
     class Renderer
       @error_boundary_stack: Array[Funicular::ErrorBoundary]
 
-      def initialize: (?JS::Element? doc) -> void
+      def initialize: (?JS::Element? doc, ?Runtime? runtime) -> void
       def render: (VDOM::VNode | VDOM::Text | nil vnode, ?JS::Element? parent) -> JS::Element
 
       private def current_error_boundary: () -> ErrorBoundary?
@@ -57,9 +57,11 @@ module Funicular
     class Component < VNode
       attr_reader component_class: untyped
       attr_reader props: Hash[Symbol, untyped]
+      attr_reader children: Array[child_t]
       attr_accessor instance: untyped
+      attr_accessor runtime: Runtime?
 
-      def initialize: (untyped component_class, ?Hash[Symbol, untyped] props) -> void
+      def initialize: (untyped component_class, ?Hash[Symbol, untyped] props, ?Array[child_t] children) -> void
       def ==: (untyped other) -> bool
     end
   end

--- a/sig/view_context.rbs
+++ b/sig/view_context.rbs
@@ -1,0 +1,47 @@
+module Funicular
+  class ViewContext
+    HTML_TAGS: Array[String]
+
+    def initialize: (Component component) -> void
+    def state: () -> Component::StateAccessor
+    def props: () -> Hash[Symbol, untyped]
+    def resources: () -> Component::ResourceAccessor
+    def styles: () -> StyleAccessor
+    def routes: () -> untyped
+    def tag: (Symbol | String name, ?Hash[Symbol, untyped] props) ?{ (ViewContext) -> untyped } -> VDOM::Element
+    def component: (singleton(Component) component_class, ?Hash[Symbol, untyped] props) ?{ (ViewContext) -> untyped } -> VDOM::Component
+    def form_for: (Symbol model_key, ?Hash[Symbol, untyped] options) { (FormBuilder) -> void } -> VDOM::Element
+    def suspense: (Symbol name, fallback: untyped, ?error: untyped) { (ViewContext, Component::ResourceAccessor) -> untyped } -> untyped
+    def link_to: (String path, **untyped options) ?{ -> untyped } -> VDOM::Element
+    def button_to: (String path, ?method: Symbol, **untyped options) ?{ -> untyped } -> VDOM::Element
+    def capture: () { (ViewContext) -> untyped } -> Array[VDOM::child_t]
+    def add_child: (untyped child) -> void
+    private def build_element: (Symbol | String tag_name, ?Hash[Symbol, untyped] props) ?{ (ViewContext) -> untyped } -> VDOM::Element
+    private def normalize_props: (Hash[Symbol, untyped] props) -> Hash[Symbol, untyped]
+
+    def div: (?Hash[Symbol, untyped] props) ?{ (ViewContext) -> untyped } -> VDOM::Element
+    def span: (?Hash[Symbol, untyped] props) ?{ (ViewContext) -> untyped } -> VDOM::Element
+    def p: (?Hash[Symbol, untyped] props) ?{ (ViewContext) -> untyped } -> VDOM::Element
+    def a: (?Hash[Symbol, untyped] props) ?{ (ViewContext) -> untyped } -> VDOM::Element
+    def data: (?Hash[Symbol, untyped] props) ?{ (ViewContext) -> untyped } -> VDOM::Element
+    def h1: (?Hash[Symbol, untyped] props) ?{ (ViewContext) -> untyped } -> VDOM::Element
+    def h2: (?Hash[Symbol, untyped] props) ?{ (ViewContext) -> untyped } -> VDOM::Element
+    def h3: (?Hash[Symbol, untyped] props) ?{ (ViewContext) -> untyped } -> VDOM::Element
+    def h4: (?Hash[Symbol, untyped] props) ?{ (ViewContext) -> untyped } -> VDOM::Element
+    def h5: (?Hash[Symbol, untyped] props) ?{ (ViewContext) -> untyped } -> VDOM::Element
+    def h6: (?Hash[Symbol, untyped] props) ?{ (ViewContext) -> untyped } -> VDOM::Element
+    def ul: (?Hash[Symbol, untyped] props) ?{ (ViewContext) -> untyped } -> VDOM::Element
+    def ol: (?Hash[Symbol, untyped] props) ?{ (ViewContext) -> untyped } -> VDOM::Element
+    def li: (?Hash[Symbol, untyped] props) ?{ (ViewContext) -> untyped } -> VDOM::Element
+    def table: (?Hash[Symbol, untyped] props) ?{ (ViewContext) -> untyped } -> VDOM::Element
+    def form: (?Hash[Symbol, untyped] props) ?{ (ViewContext) -> untyped } -> VDOM::Element
+    def input: (?Hash[Symbol, untyped] props) ?{ (ViewContext) -> untyped } -> VDOM::Element
+    def textarea: (?Hash[Symbol, untyped] props) ?{ (ViewContext) -> untyped } -> VDOM::Element
+    def button: (?Hash[Symbol, untyped] props) ?{ (ViewContext) -> untyped } -> VDOM::Element
+    def select: (?Hash[Symbol, untyped] props) ?{ (ViewContext) -> untyped } -> VDOM::Element
+    def option: (?Hash[Symbol, untyped] props) ?{ (ViewContext) -> untyped } -> VDOM::Element
+    def label: (?Hash[Symbol, untyped] props) ?{ (ViewContext) -> untyped } -> VDOM::Element
+    def nav: (?Hash[Symbol, untyped] props) ?{ (ViewContext) -> untyped } -> VDOM::Element
+    def canvas: (?Hash[Symbol, untyped] props) ?{ (ViewContext) -> untyped } -> VDOM::Element
+  end
+end

--- a/test/form_for_test.rb
+++ b/test/form_for_test.rb
@@ -11,8 +11,8 @@ class FormForTest < Picotest::Test
         @submitted = data
       end
 
-      def render
-        form_for(:comment, on_submit: :handle_submit) do |f|
+      def render(h)
+        h.form_for(:comment, on_submit: :handle_submit) do |f|
           f.textarea(:body)
           f.submit("Post")
         end

--- a/test/funicular_test.rb
+++ b/test/funicular_test.rb
@@ -3,6 +3,6 @@ class FunicularTest < Picotest::Test
   end
 
   def test_funicular_version
-    assert_equal('0.1.0', Funicular::VERSION)
+    assert_equal('0.3.0', Funicular::VERSION)
   end
 end

--- a/test/hydration_test.rb
+++ b/test/hydration_test.rb
@@ -13,8 +13,8 @@
 class HydrationTest < Picotest::Test
   def probe
     klass = Class.new(Funicular::Component) do
-      def render
-        div { "x" }
+      def render(h)
+        h.div { "x" }
       end
 
       def match?(vnode, dom)

--- a/test/router_test.rb
+++ b/test/router_test.rb
@@ -70,6 +70,7 @@ class RouterTest < Picotest::Test
     helper = Object.new
     helper.extend(url_helpers)
     assert_equal('/posts', helper.posts_path)
+    assert_equal('/posts', @router.route_helpers.posts_path)
   end
 
   # Test URL helper with single parameter
@@ -79,6 +80,7 @@ class RouterTest < Picotest::Test
     helper = Object.new
     helper.extend(url_helpers)
     assert_equal('/posts/123', helper.post_path(123))
+    assert_equal('/posts/123', @router.route_helpers.post_path(123))
   end
 
   # Test URL helper with multiple parameters

--- a/test/view_context_test.rb
+++ b/test/view_context_test.rb
@@ -1,0 +1,114 @@
+class ViewContextTest < Picotest::Test
+  def test_explicit_state_styles_and_resources_do_not_collide_with_html_methods
+    klass = Class.new(Funicular::Component) do
+      styles { |css| css.define :hash, "hash-class" }
+
+      use_suspense :data, ->(resolve, _reject) { resolve.call("loaded") }
+
+      def initialize_state
+        { class: "state-class", hash: "state-hash" }
+      end
+
+      def render(h)
+        h.data(class: h.styles[:hash]) do
+          "#{state[:class]} #{state[:hash]} #{h.resources[:data]}"
+        end
+      end
+    end
+
+    component = klass.new
+    component.instance_variable_get(:@suspense_data)[:data] = "loaded"
+    component.instance_variable_get(:@suspense_states)[:data] = :resolved
+
+    vnode = component.build_vdom
+
+    assert_equal("data", vnode.tag)
+    assert_equal("hash-class", vnode.props[:class])
+    assert_equal(["state-class state-hash loaded"], vnode.children)
+  end
+
+  def test_component_children_are_vdom_children_not_props
+    child = Class.new(Funicular::Component) do
+      def render(h)
+        h.div { children }
+      end
+    end
+
+    parent = Class.new(Funicular::Component) do
+      define_method(:render) do |h|
+        h.component(child, title: "x") do |hh|
+          hh.span { "inside" }
+        end
+      end
+    end
+
+    vnode = parent.new.build_vdom
+
+    assert_equal(Funicular::VDOM::Component, vnode.class)
+    assert_equal({ title: "x" }, vnode.props)
+    assert_equal(false, vnode.props.key?(:children_block))
+    assert_equal(1, vnode.children.length)
+    assert_equal("span", vnode.children.first.tag)
+  end
+
+  def test_route_helpers_are_runtime_scoped
+    router_a = Funicular::Router.new(nil)
+    router_b = Funicular::Router.new(nil)
+    router_a.get("/users/:id", to: Class.new(Funicular::Component), as: "user")
+    router_b.get("/accounts/:id", to: Class.new(Funicular::Component), as: "user")
+
+    component_a = Class.new(Funicular::Component).new
+    component_b = Class.new(Funicular::Component).new
+    component_a.runtime = Funicular::Runtime.new(router_a)
+    component_b.runtime = Funicular::Runtime.new(router_b)
+
+    assert_equal("/users/7", Funicular::ViewContext.new(component_a).routes.user_path(7))
+    assert_equal("/accounts/7", Funicular::ViewContext.new(component_b).routes.user_path(7))
+  end
+
+  def test_link_to_get_uses_router_navigation
+    klass = Class.new(Funicular::Component) do
+      attr_reader :clicked
+
+      def render(h)
+        h.link_to("/posts") { "Posts" }
+      end
+
+      def handle_link_click(path)
+        @clicked = path
+      end
+    end
+
+    component = klass.new
+    vnode = component.build_vdom
+    vnode.props[:onclick].call(FakeEvent.new)
+
+    assert_equal("/posts", component.clicked)
+    assert_equal(false, vnode.props.key?(:method))
+  end
+
+  def test_link_to_non_get_uses_http_action
+    klass = Class.new(Funicular::Component) do
+      attr_reader :action
+
+      def render(h)
+        h.link_to("/messages/1", method: :delete) { "Delete" }
+      end
+
+      def handle_link_with_method(path, method)
+        @action = [path, method]
+      end
+    end
+
+    component = klass.new
+    vnode = component.build_vdom
+    vnode.props[:onclick].call(FakeEvent.new)
+
+    assert_equal(["/messages/1", :delete], component.action)
+    assert_equal(false, vnode.props.key?(:method))
+  end
+
+  class FakeEvent
+    def preventDefault; end
+  end
+end


### PR DESCRIPTION
This pull request introduces a deliberate breaking redesign of the Funicular component DSL and rendering architecture, updating all demo applications to the new API. Components must now define `render(h)` methods that use an explicit `ViewContext` for all rendering and helper access. State access is now always hash-style (`state[:key]`), and all HTML/component helpers are called through the context object (`h`). The changes are reflected throughout the demo files, including components, event handlers, and test logic.

This change will also be a basis for #13 discussion. I will merge this into master and release funicular 0.3.0 to see how the new design works. Depending on the outcome, I might revert some of the changes.

The most important changes are:

**Breaking DSL and Architecture Redesign:**
- Updated the rendering API to require `render(h)` with a `ViewContext`, removing implicit DSL methods for HTML tags, components, forms, styles, resources, and route helpers. All such helpers are now accessed via the explicit `h` context.
- State access is now explicit and hash-style (e.g., `state[:count]` instead of `state.count`); method-style state access is removed.

**Demo/Test Application Migration:**
- Refactored all demo component `render` methods to use the new `render(h)` signature and to build the DOM using the explicit context object, including proper block argument usage for nested elements [[1]](diffhunk://#diff-e37d31212400e4dce38db1828f26a482cb46a56c3415dbaf077882e1dd6566c1L43-R62) [[2]](diffhunk://#diff-d9978fd1ba5caf60c2edbde4eed494584693f5f770053de9dfbda9905ebd68afL121-R132) [[3]](diffhunk://#diff-a85be603dfd53c72992b08857f76a8ccc8a2d86675d64151a36840ff7164a833L110-R183) [[4]](diffhunk://#diff-7852beb73deec26c36f63245347310d6c973792f6671a08d886f663fcccfad6bL66-R84) [[5]](diffhunk://#diff-7852beb73deec26c36f63245347310d6c973792f6671a08d886f663fcccfad6bL97-R118) [[6]](diffhunk://#diff-7852beb73deec26c36f63245347310d6c973792f6671a08d886f663fcccfad6bL132-R164) [[7]](diffhunk://#diff-7852beb73deec26c36f63245347310d6c973792f6671a08d886f663fcccfad6bL188-R202) [[8]](diffhunk://#diff-7852beb73deec26c36f63245347310d6c973792f6671a08d886f663fcccfad6bL219-R232) [[9]](diffhunk://#diff-e9600a3dc2ec7b3b7dca6159b1574bd1d1173d4640120d28b56a4304a5a1726fL41-R42) [[10]](diffhunk://#diff-e9600a3dc2ec7b3b7dca6159b1574bd1d1173d4640120d28b56a4304a5a1726fL58-R58).
- Updated all state reads and writes in demo/test files to use the new hash-style access [[1]](diffhunk://#diff-d9978fd1ba5caf60c2edbde4eed494584693f5f770053de9dfbda9905ebd68afL47-R47) [[2]](diffhunk://#diff-d9978fd1ba5caf60c2edbde4eed494584693f5f770053de9dfbda9905ebd68afL72-R72) [[3]](diffhunk://#diff-d9978fd1ba5caf60c2edbde4eed494584693f5f770053de9dfbda9905ebd68afL83-R98) [[4]](diffhunk://#diff-e37d31212400e4dce38db1828f26a482cb46a56c3415dbaf077882e1dd6566c1L43-R62) [[5]](diffhunk://#diff-e37d31212400e4dce38db1828f26a482cb46a56c3415dbaf077882e1dd6566c1L92-R92) [[6]](diffhunk://#diff-e37d31212400e4dce38db1828f26a482cb46a56c3415dbaf077882e1dd6566c1L142-R148) [[7]](diffhunk://#diff-7852beb73deec26c36f63245347310d6c973792f6671a08d886f663fcccfad6bL66-R84) [[8]](diffhunk://#diff-7852beb73deec26c36f63245347310d6c973792f6671a08d886f663fcccfad6bL97-R118) [[9]](diffhunk://#diff-7852beb73deec26c36f63245347310d6c973792f6671a08d886f663fcccfad6bL132-R164) [[10]](diffhunk://#diff-7852beb73deec26c36f63245347310d6c973792f6671a08d886f663fcccfad6bL188-R202) [[11]](diffhunk://#diff-7852beb73deec26c36f63245347310d6c973792f6671a08d886f663fcccfad6bL219-R232).

**Error Boundary and Fallback API Update:**
- Updated error boundary demo to use the new context-based rendering for custom fallback UIs and component composition, making all fallback lambdas accept the context object as their first argument.

**Changelog and Documentation:**
- Added a comprehensive changelog entry describing the 0.3.0 breaking changes, migration requirements, and rationale for the new rendering and context architecture.

These changes are required for compatibility with Funicular 0.3.0 and bring all demos and tests in line with the new, explicit, context-driven rendering API.