### PR TITLE
[0.5.0] Introduce SQLite3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ of truth. Entries below accumulate as the feature lands.
 
 ### Added
 
+- The SQLite local-database subsystem is now globally opt-in through
+  `config.local_database = true` and defaults off. REST-only applications do
+  not start SQLite, IndexedDB, Web Locks, replica write-through, or session
+  epochs. Opted-in applications must also declare `config.user_key` or
+  `config.anonymous_only = true`; existing snapshots are retained while the
+  feature is disabled.
+
 - Design documentation for the local database layer:
   `docs/local_database.md` is the user-facing API contract (source-of-truth
   contract, `storage`/`refresh` declarations, `migrate` blocks, `.local`
@@ -264,9 +271,9 @@ of truth. Entries below accumulate as the feature lands.
   separates the fields, so a user_key of "anonymous" or one containing
   separators cannot collide. `resolve_namespace` enforces the
   declaration rules client-side (`Funicular::DB::ConfigError`):
-  user_key and anonymous_only are mutually exclusive, and
-  `storage :local` models require a user_key unless anonymous_only
-  explicitly accepts one shared anonymous namespace.
+  user_key and anonymous_only are mutually exclusive, and every opted-in
+  application requires a user_key unless anonymous_only explicitly accepts
+  one shared anonymous namespace.
 - REST is wired to the local database layer: response values decode
   through the shared codec when instances initialize and when `update`
   applies the server row (ISO 8601 strings become `Time`, 1/0 become

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,25 @@ of truth. Entries below accumulate as the feature lands.
   Locks API drops the page to `volatile` (everything works, nothing
   persists). `Funicular::DB.durability` reports the state; the JS shim
   accepts an injectable Locks API for tests.
+- The persistence core (`mrblib/db.rb`, docs decisions 11/16):
+  whole-database snapshots (serialize -> Base64) in Funicular's OWN
+  IndexedDB store, opened with the in-memory fallback disabled --
+  availability errors (private mode) classify as the `volatile` state,
+  every other storage error stays loud for the boot to fail on.
+  Auto-persist rides the post-commit change-event funnel with a
+  per-role debounce (replica ~5 s, local ~500 ms; a rollback schedules
+  nothing), `Funicular::DB.flush` snapshots immediately (writer only;
+  `ReadOnlyTabError` on a reader, honest no-op on volatile), and a
+  `visibilitychange` backstop persists when the tab hides. A persist
+  landing while that database has an open transaction (a stale timer,
+  the backstop, an in-block flush) refuses to serialize uncommitted
+  pages and defers itself to the commit/rollback settle. Failures are
+  never silent: always logged, plus `config.on_persist_error`.
+  `Funicular::DB.configure` arrives with the persistence knobs
+  (`replica_debounce_ms`/`local_debounce_ms`/
+  `request_persistent_storage` -- `navigator.storage.persist()` is
+  asked only when local data exists -- and the
+  `on_persist_error`/`on_boot_error`/`on_session_change` hooks).
 - The reactivity layer on top of the bus: `Component#watch(:key)` binds
   a state key to a `storage :local`/`.local` Relation -- the block runs
   once, materializes into `state[:key]`, and re-runs (re-subscribing,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -181,6 +181,41 @@ of truth. Entries below accumulate as the feature lands.
   covered too, not only traffic after `DB.boot`, which alone would
   latch too late. Pages without an epoch (no Rails integration yet)
   are unaffected.
+- The Rails half of data isolation and the session epoch (docs
+  decisions 12/13). `Funicular.configure` gains `application_id`
+  (default `"funicular"`; give each app sharing an origin its own),
+  `user_key` (a lambda receiving the controller and returning a
+  stable identifier, nil when signed out), and `anonymous_only` (the
+  explicit opt-out for apps without users) -- setting both is a
+  configuration error raised straight from the initializer. The
+  Railtie now stamps `X-Funicular-Epoch` on every response (emitted
+  lowercase, as the Rack 3 spec requires; HTTP header names are
+  case-insensitive on the wire): the epoch
+  lives in the Rails session PER application_id
+  (`session["funicular_epochs"]`) and rotates whenever the computed
+  user key changes, so login, logout, and direct user switches all
+  rotate it with no application code. Rotation runs in a controller
+  around_action (the user_key lambda needs its controller) that
+  stamps BEFORE the action and re-stamps in its ensure with the
+  post-action identity -- the login/logout actions flip the identity
+  mid-request, and their own response must already carry the rotated
+  epoch. The header itself is written by a Rack middleware sitting
+  ABOVE ActionDispatch's exception renderer: a controller-set header
+  dies with the controller's response when the action raises, and a
+  header-less 500 would read as an epoch mismatch client-side,
+  terminating a healthy page over a mere server error. Session-less
+  Rails API apps stay unbroken: a disabled session leaves the epoch
+  feature off (no cookie identity exists to protect) instead of
+  raising on every action. `picoruby_include_tag` embeds
+  the namespace + epoch metadata as HTML-escaped `data-funicular-*`
+  attributes on the bootstrap script tag -- exactly the contract
+  `DB.read_page_metadata` reads client-side -- with the user-key
+  attribute omitted for signed-out visitors and the epoch drawn from
+  the same session entry the response header uses; the user-key
+  attribute and the epoch identity come from ONE resolver evaluation,
+  so a racy `current_user` cannot embed one user's namespace with
+  another user's epoch. A `user_key` that resolves to an empty string
+  fails loud server-side.
 - `Funicular::DB.wipe` and the mutation generation (docs decision 17):
   one call drops every table in both databases of the current
   namespace, deletes its two snapshot keys, rebuilds the replica DDL +

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,21 @@ of truth. Entries below accumulate as the feature lands.
   models' `local_columns` now fold their migrate blocks (implicit
   `id INTEGER PRIMARY KEY` included), replacing the interim
   UnavailableError.
+- Local CRUD and the bare-class alias on `storage :local` models:
+  synchronous, validated `create` (id from the inserted row; omitted
+  attributes take the SQL DEFAULT while an explicit nil binds NULL; the
+  row is read back, so defaults and codec normalization land in the
+  instance; auto `created_at`/`updated_at`), `#update`
+  (true/false; an update with no actual changes is a no-op that does
+  not touch `updated_at`), `#destroy`, `#reload`, `#new_record?`;
+  `Draft.all` is the whole-table Relation (blocks and params raise --
+  there is no REST side), and `where`/`order`/`limit`/`offset`/`count`/
+  `first`/`exists?`/`find_by`/`delete_all` hang off the bare class,
+  which on other storage kinds points you at `.local`. All local writes
+  fire the `local_table_changed` hook and let SQLite constraint
+  violations escape as `SQLite3::Exception`. `Model.create` now also
+  accepts bare keywords (`Draft.create(title: "x")`) on every storage
+  kind.
 
 ### Changed (BREAKING)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,19 @@ of truth. Entries below accumulate as the feature lands.
   column metadata derives from the server schema (binary attributes
   excluded); materializing a query before `Funicular::DB.boot` (a later
   change) raises `Funicular::DB::UnavailableError`.
+- The client-only-table migration machinery: `Funicular::DB::TableBuilder`
+  (the `t` in migrate blocks -- string/text/integer/float/boolean/datetime
+  columns with `default:`/`null:`, `timestamps`, `index`/`remove_index`,
+  `rename`, `remove`, raw `execute`) and the per-table runner
+  (`Funicular::DB.apply_local_migrations`): fresh and below-baseline
+  tables rebuild from the first retained block, upgrades apply exactly
+  the missing blocks in one transaction (rolled back on failure; in
+  development a failed upgrade auto-resets the table instead), applied
+  versions live in the `funicular_meta` table, and a table newer than
+  the declarations raises `Funicular::DB::SchemaTooNewError`. Local
+  models' `local_columns` now fold their migrate blocks (implicit
+  `id INTEGER PRIMARY KEY` included), replacing the interim
+  UnavailableError.
 
 ### Changed (BREAKING)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,16 @@ of truth. Entries below accumulate as the feature lands.
   raising subscriber is isolated. `Model.local_table_changed` now feeds
   this bus, so every framework write (local CRUD, delete_all, replica
   write-through) announces itself.
+- The writer election (`mrblib/db.rb`, docs decision 14): one tab per
+  namespace persists. `Funicular::DB.elect_writer` runs once at boot
+  with Web Locks' `ifAvailable` -- granted makes the tab the
+  `persistent_writer` (the lock is held by a promise resolved only at
+  `release_writer_lock`, the terminal step-down seam), not granted
+  makes it a `persistent_reader` for the life of the page (no
+  promotion in v1; reload to write), and a missing or failing Web
+  Locks API drops the page to `volatile` (everything works, nothing
+  persists). `Funicular::DB.durability` reports the state; the JS shim
+  accepts an injectable Locks API for tests.
 - The reactivity layer on top of the bus: `Component#watch(:key)` binds
   a state key to a `storage :local`/`.local` Relation -- the block runs
   once, materializes into `state[:key]`, and re-runs (re-subscribing,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,16 @@ of truth. Entries below accumulate as the feature lands.
   (`true`/`false` <-> 1/0, `Time` <-> UTC ISO 8601 TEXT) used on both the
   SQLite and REST boundaries. The model-layer wiring (`storage`, `.local`)
   arrives in a following change; the gem now depends on picoruby-sqlite3.
+- The model declaration DSL: `storage :replica (default) | :ephemeral |
+  :local do ... end` (with `migrate N [, reset: true] do |t| ... end`
+  blocks recorded at class eval and version rules -- baseline and
+  contiguity -- validated there), `refresh :manual` (`:auto`/`:live`
+  raise "not yet supported"), `table_name` (naive pluralization +
+  override), and the `.local` entry point returning a whole-table
+  `Funicular::Relation` (NoTableError on ephemeral models). Replica
+  column metadata derives from the server schema (binary attributes
+  excluded); materializing a query before `Funicular::DB.boot` (a later
+  change) raises `Funicular::DB::UnavailableError`.
 
 ### Changed (BREAKING)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,14 @@ of truth. Entries below accumulate as the feature lands.
   string (`Post.all(page: 2)` -> `GET /posts?page=2`) via the new
   picoruby-uri gem's CRuby-compatible `URI.encode_www_form`. The argument
   existed before but was silently ignored.
+- The local-query foundation (`mrblib/db.rb`, `mrblib/relation.rb`):
+  `Funicular::Relation`, the lazy chainable query builder behind `.local`
+  (where/order/limit/offset; hash, IN, BETWEEN, IS NULL, and raw-fragment
+  conditions; each/to_a/first/count/exists?/find/find_by/delete_all), the
+  `Funicular::DB` error vocabulary, and the shared boolean/datetime codec
+  (`true`/`false` <-> 1/0, `Time` <-> UTC ISO 8601 TEXT) used on both the
+  SQLite and REST boundaries. The model-layer wiring (`storage`, `.local`)
+  arrives in a following change; the gem now depends on picoruby-sqlite3.
 
 ### Changed (BREAKING)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,26 @@ of truth. Entries below accumulate as the feature lands.
   `request_persistent_storage` -- `navigator.storage.persist()` is
   asked only when local data exists -- and the
   `on_persist_error`/`on_boot_error`/`on_session_change` hooks).
+- `Funicular::DB.wipe` and the mutation generation (docs decision 17):
+  one call drops every table in both databases of the current
+  namespace, deletes its two snapshot keys, rebuilds the replica DDL +
+  fingerprint and the local migration state from scratch, and notifies
+  watchers only once the tables are queryable again AND the stale
+  snapshots are really gone (components re-render onto empty tables,
+  never onto missing ones; a failing snapshot delete raises out of
+  wipe before any watcher is told). Writer-only
+  (`ReadOnlyTabError` on a reader; fine on volatile, where there are
+  no snapshots to delete). The wipe is safe mid-flight: it advances
+  the mutation generation FIRST, so REST responses issued before it
+  are discarded -- the callback gets `(nil, Funicular::DB::Error)`
+  instead of resurrecting the previous session's rows -- pending
+  persistence timers are cancelled, and an in-progress snapshot
+  cannot overwrite the cleared state. While either database has an
+  open transaction, wipe refuses loudly BEFORE any side effect: the
+  rebuild would otherwise nest into (or be rolled back with) that
+  transaction. The check cannot be raced, either: wipe never suspends
+  its Task between the check and the end of the rebuild -- the
+  snapshot deletes, the only awaiting operations, come last.
 - The reactivity layer on top of the bus: `Component#watch(:key)` binds
   a state key to a `storage :local`/`.local` Relation -- the block runs
   once, materializes into `state[:key]`, and re-runs (re-subscribing,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,16 @@ of truth. Entries below accumulate as the feature lands.
   models' `local_columns` now fold their migrate blocks (implicit
   `id INTEGER PRIMARY KEY` included), replacing the interim
   UnavailableError.
+- REST is wired to the local database layer: response values decode
+  through the shared codec when instances initialize and when `update`
+  applies the server row (ISO 8601 strings become `Time`, 1/0 become
+  booleans -- `Post.all` and `Post.local.find` now return the same Ruby
+  types), and every successful REST call mirrors its result into the
+  replica through the single apply entry point BEFORE user callbacks
+  run (`all`/`find`/`create` upsert, `update` upserts the applied
+  server row, `destroy` deletes). Write-through stays inert until
+  `Funicular::DB.boot` installs the replica handle, so REST keeps
+  working standalone.
 - The replica-table plumbing (`mrblib/db.rb`): CREATE TABLE derived from
   the server schema (id type follows the server -- INTEGER or TEXT; a
   schema without id raises pointing at `storage :ephemeral`; binary

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,16 @@ of truth. Entries below accumulate as the feature lands.
   models' `local_columns` now fold their migrate blocks (implicit
   `id INTEGER PRIMARY KEY` included), replacing the interim
   UnavailableError.
+- The replica-table plumbing (`mrblib/db.rb`): CREATE TABLE derived from
+  the server schema (id type follows the server -- INTEGER or TEXT; a
+  schema without id raises pointing at `storage :ephemeral`; binary
+  attributes never reach the replica), the canonical-JSON schema
+  fingerprint stored in `funicular_meta` (string equality; a mismatch
+  drops and recreates ALL replica tables empty, refilled by the app's
+  next explicit fetch), and the single write-through entry points
+  `replica_upsert` (whole-row INSERT OR REPLACE through the codec) and
+  `replica_delete` (RETURNING-based), both firing the model's change
+  hook. Boot wiring and the REST call sites arrive next.
 - Local CRUD and the bare-class alias on `storage :local` models:
   synchronous, validated `create` (id from the inserted row; omitted
   attributes take the SQL DEFAULT while an explicit nil binds NULL; the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,10 @@ of truth. Entries below accumulate as the feature lands.
   the missing blocks in one transaction (rolled back on failure; in
   development a failed upgrade auto-resets the table instead), applied
   versions live in the `funicular_meta` table, and a table newer than
-  the declarations raises `Funicular::DB::SchemaTooNewError`. Local
+  the declarations raises `Funicular::DB::SchemaTooNewError`. The column
+  fold is validated before any DDL runs, so declarations SQLite would
+  accept as plain DDL (renaming or removing the implicit `id`) are
+  rejected while the database is still intact. Local
   models' `local_columns` now fold their migrate blocks (implicit
   `id INTEGER PRIMARY KEY` included), replacing the interim
   UnavailableError.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -210,7 +210,11 @@ of truth. Entries below accumulate as the feature lands.
   ABOVE ActionDispatch's exception renderer: a controller-set header
   dies with the controller's response when the action raises, and a
   header-less 500 would read as an epoch mismatch client-side,
-  terminating a healthy page over a mere server error. Session-less
+  terminating a healthy page over a mere server error. Both the
+  concern and the include-tag helper read the session through
+  `request.session`, never the controller/view `session` accessor: an
+  application action named "session" shadows that accessor, and
+  calling it would invoke the action itself. Session-less
   Rails API apps stay unbroken: a disabled session leaves the epoch
   feature off (no cookie identity exists to protect) instead of
   raising on every action. `picoruby_include_tag` embeds

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,16 @@ of truth. Entries below accumulate as the feature lands.
   models' `local_columns` now fold their migrate blocks (implicit
   `id INTEGER PRIMARY KEY` included), replacing the interim
   UnavailableError.
+- The namespace identity (`mrblib/db.rb`): a typed, versioned tuple
+  (`["v1", app, "anonymous"]` / `["v1", app, "user", key]`) encoded as
+  canonical JSON, which every durable name -- the two snapshot keys and
+  the Web Lock name -- derives from. Structure, not delimiters,
+  separates the fields, so a user_key of "anonymous" or one containing
+  separators cannot collide. `resolve_namespace` enforces the
+  declaration rules client-side (`Funicular::DB::ConfigError`):
+  user_key and anonymous_only are mutually exclusive, and
+  `storage :local` models require a user_key unless anonymous_only
+  explicitly accepts one shared anonymous namespace.
 - REST is wired to the local database layer: response values decode
   through the shared codec when instances initialize and when `update`
   applies the server row (ISO 8601 strings become `Time`, 1/0 become

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,21 @@ of truth. Entries below accumulate as the feature lands.
   declared set passes again -- and the lift is provisional: a reset
   that fails mid-rebuild puts SQLite's own write refusal
   (`query_only`) back up before re-raising.
+- The schema boot barrier and the start gate (docs decision 19,
+  wiring half). `Funicular.load_schemas` is now a real barrier: every
+  request settles its slot exactly once -- success, HTTP error, or a
+  schema that arrived but cannot be applied -- so it always
+  completes. All green boots the local database (declared models come
+  from a new Model registry filled at subclass definition; namespace,
+  epoch, and user-key metadata come from the include tag's
+  HTML-escaped `data-funicular-*` attributes) and only then runs the
+  completion block; any failure never invokes the block, reports
+  through the console and `config.on_boot_error`, and marks the boot
+  failed. `Funicular.start` gates on the boot before touching the
+  DOM: replica apps boot inside the barrier, local-only apps boot
+  right in start, and nothing mounts on top of a failed boot. An
+  empty schema set with a schema-less replica model declared fails
+  the boot loud instead of running on missing tables.
 - `Funicular::DB.wipe` and the mutation generation (docs decision 17):
   one call drops every table in both databases of the current
   namespace, deletes its two snapshot keys, rebuilds the replica DDL +

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,41 @@ of truth. Entries below accumulate as the feature lands.
   `request_persistent_storage` -- `navigator.storage.persist()` is
   asked only when local data exists -- and the
   `on_persist_error`/`on_boot_error`/`on_session_change` hooks).
+- `Funicular::DB.boot` (docs decision 19), the client-side boot that
+  wires everything in order: page metadata -> namespace resolution
+  (+ session epoch held for the HTTP layer) -> writer election ->
+  snapshot store (availability errors -> volatile) -> the two
+  `:memory:` connections -> local snapshot restore + migrations ->
+  replica restore + schema-derived DDL -> guarded handles installed
+  (`Funicular::DB.local`/`.replica`, and `Model.local_db`/`replica_db`
+  now consult the boot; reader tabs get `PRAGMA query_only=ON` plus a
+  read-only local proxy) -> `navigator.storage.persist()` when a
+  local model exists -> the visibilitychange backstop. One-shot;
+  raises `UnavailableError` under SSR. The handles gate on
+  `boot_state == :ready`, not on their existence: mid-boot (another
+  Task running during a boot await) and after a failed boot the
+  database is equally unreachable -- and the raw-database paths that
+  bypass the handles carry the gate too: `Model.reset_local` requires
+  `:ready`, `wipe` allows `:ready` or `:failed` (wiping from
+  `on_boot_error` is the official corrupt-snapshot recovery), and
+  `persist_snapshot` -- the final persistence entry that flush and
+  the debounce funnel through -- refuses during `:booting`, so a
+  mid-boot flush cannot overwrite stored snapshots with unrestored
+  databases. Any failure is decision 16's
+  fail loud: `boot_state` becomes `:failed`, the handles are torn
+  back out, the errors hit the console and `config.on_boot_error`,
+  nothing mounts (wired with `Funicular.start` in a following
+  change), and once the hook has had its recovery chance the writer
+  lock is released -- a failed page must not deny the writer slot to
+  every other tab. SchemaTooNew instead
+  completes the boot LOCKED DOWN (docs decision 7): every model-level
+  local operation raises `SchemaTooNewError`, raw SELECT export
+  through `DB.local` survives, writes are refused by SQLite itself.
+  `Model.reset_local` arrives with it: writer-only baseline rebuild of
+  one client-only table that lifts the lockdown once the whole
+  declared set passes again -- and the lift is provisional: a reset
+  that fails mid-rebuild puts SQLite's own write refusal
+  (`query_only`) back up before re-raising.
 - `Funicular::DB.wipe` and the mutation generation (docs decision 17):
   one call drops every table in both databases of the current
   namespace, deletes its two snapshot keys, rebuilds the replica DDL +

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@ of truth. Entries below accumulate as the feature lands.
   epoch, SSR constraints); `docs/architecture.md` gains the
   contributor-facing invariants.
 
+### Removed
+
+- The IndexedDB-backed HTTP response cache (`Funicular::HTTP` `cache:`
+  option, `cache_purge`, `cache_clear`). It was dead code -- no caller
+  anywhere passed `cache:` -- and the local database layer is this
+  release's answer to caching. Structured data belongs in replica tables,
+  not keyed response bodies.
+
 ## [0.4.0] - 2026-07-23
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,16 @@ of truth. Entries below accumulate as the feature lands.
   column metadata derives from the server schema (binary attributes
   excluded); materializing a query before `Funicular::DB.boot` (a later
   change) raises `Funicular::DB::UnavailableError`.
+- Associations: `belongs_to :user` and `has_many :comments` as local-query
+  sugar over the `<name>_id` convention -- `post.user` reads
+  `User.local.find_by(id: post.user_id)`, `post.comments` returns the
+  chainable `Comment.local.where(post_id: post.id)` Relation (usable in
+  `watch`). `class_name:` and `foreign_key:` override the conventions;
+  `through:`, eager loading, and polymorphic associations raise as
+  unsupported in v1. Targets resolve lazily at first read, so model files
+  may load in any order, and a declaration whose name collides with a
+  column, a REST attribute, another declaration, or a `Funicular::Model`
+  instance method is refused instead of silently shadowing it.
 - The client-only-table migration machinery: `Funicular::DB::TableBuilder`
   (the `t` in migrate blocks -- string/text/integer/float/boolean/datetime
   columns with `default:`/`null:`, `timestamps`, `index`/`remove_index`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,28 @@ of truth. Entries below accumulate as the feature lands.
   models' `local_columns` now fold their migrate blocks (implicit
   `id INTEGER PRIMARY KEY` included), replacing the interim
   UnavailableError.
+- The change-event bus (`mrblib/db.rb`): `Funicular::DB.subscribe`/
+  `unsubscribe` per [database role, table], and the raw-SQL protocol
+  `Funicular::DB.notify_changed(Model)` (or `(:local | :replica,
+  table)`; ephemeral models raise NoTableError). Events fire
+  post-commit only: inside a guarded transaction block they coalesce to
+  one event per [role, table] and flush after COMMIT, or vanish with
+  the rollback. Delivery is deferred to the NEXT tick (JS
+  `setTimeout(0)` by default; the scheduler is pluggable and CRuby
+  drains immediately, where no component can be mid-update), coalescing
+  per [role, table] within the tick; an event raised by a subscriber
+  belongs to the following tick -- never nested, never dropped -- and a
+  raising subscriber is isolated. `Model.local_table_changed` now feeds
+  this bus, so every framework write (local CRUD, delete_all, replica
+  write-through) announces itself.
+- The reactivity layer on top of the bus: `Component#watch(:key)` binds
+  a state key to a `storage :local`/`.local` Relation -- the block runs
+  once, materializes into `state[:key]`, and re-runs (re-subscribing,
+  so branchy blocks may switch relations) after every change event on
+  the relation's table; anything that is not a Relation raises, pointing
+  at `Model.on_change`/`off_change`, the public primitive for hashes,
+  counts, and raw-SQL-derived state. Watch subscriptions die with the
+  component even when a lifecycle hook raises.
 - The guarded database handles (`mrblib/db.rb`,
   `Funicular::DB::GuardedDatabase`/`GuardedStatement`/
   `GuardedResultSet`): the proxies `Funicular::DB.local`/`.replica`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,9 @@ of truth. Entries below accumulate as the feature lands.
   columns with `default:`/`null:`, `timestamps`, `index`/`remove_index`,
   `rename`, `remove`, raw `execute`) and the per-table runner
   (`Funicular::DB.apply_local_migrations`): fresh and below-baseline
-  tables rebuild from the first retained block, upgrades apply exactly
+  tables rebuild from the baseline -- the newest `reset: true` block, or
+  the first block; superseded pre-reset history may stay in the code and
+  is never folded or applied -- upgrades apply exactly
   the missing blocks in one transaction (rolled back on failure; in
   development a failed upgrade auto-resets the table instead), applied
   versions live in the `funicular_meta` table, and a table newer than

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,19 @@ of truth. Entries below accumulate as the feature lands.
   models' `local_columns` now fold their migrate blocks (implicit
   `id INTEGER PRIMARY KEY` included), replacing the interim
   UnavailableError.
+- The guarded database handles (`mrblib/db.rb`,
+  `Funicular::DB::GuardedDatabase`/`GuardedStatement`/
+  `GuardedResultSet`): the proxies `Funicular::DB.local`/`.replica`
+  will hand out instead of raw connections. The allowlist is closed --
+  persist/close/serialize/deserialize/backup do not exist in any state,
+  `transaction` yields the proxy itself, and `query` returns a wrapped
+  result set. Read-only handles enforce at EVERY execution entry
+  (execute, step, ResultSet next/reset) via `Statement#readonly?` (a
+  write prepared while writable is still refused after the handle went
+  read-only, one-way), raising
+  `Funicular::DB::ReadOnlyTabError`; ATTACH/DETACH and
+  `PRAGMA query_only` are rejected in every state, comment prefixes
+  included, while read pragmas stay available.
 - The namespace identity (`mrblib/db.rb`): a typed, versioned tuple
   (`["v1", app, "anonymous"]` / `["v1", app, "user", key]`) encoded as
   canonical JSON, which every durable name -- the two snapshot keys and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -145,6 +145,42 @@ of truth. Entries below accumulate as the feature lands.
   right in start, and nothing mounts on top of a failed boot. An
   empty schema set with a schema-less replica model declared fails
   the boot loud instead of running on missing tables.
+- The session-epoch terminal latch (docs decision 13, client half)
+  and HTTP's exactly-once settle. Every `Funicular::HTTP` request now
+  settles its callback exactly once: a rejected fetch (network
+  failure, invalid URL) delivers a status-0 error response instead of
+  hanging the schema barrier and every REST caller, and an exception
+  out of the caller's own block never settles twice. When the page
+  carried a session epoch, every response's `X-Funicular-Epoch` is
+  checked -- a rotated value OR a missing header means this page
+  belongs to a session that no longer exists: the response is
+  discarded (the caller settles with an error, nothing is applied)
+  and the page goes TERMINAL, irreversibly. From then on the page
+  refuses to ISSUE requests as well -- every verb settles immediately
+  with the same session-changed error before any fetch, since a
+  request executed under the new session's cookies could mutate
+  another user's data. A terminal writer steps
+  down completely: pending persist timers are cancelled, the final
+  persistence entry refuses forever, the writer lock frees the slot
+  for a fresh tab -- but only after an in-flight snapshot write has
+  landed, so a new writer can never race the old session's image --
+  and both database handles become a non-persistent read view. The
+  latch is independent of durability: `wipe` and `Model.reset_local`
+  -- the raw paths that bypass the read-only proxies -- refuse on ANY
+  terminated page, including a volatile one, which never steps down
+  to reader. A mismatch landing MID-BOOT (the boot suspends at the
+  writer election and at every storage read, with nothing to tear
+  down yet) aborts the boot through the ordinary failure funnel,
+  releasing a writer lock the election acquired after the
+  termination; as defense in depth, handles installed on a terminal
+  page come up read-only. `config.on_session_change` runs
+  once (default: `location.reload()`). The schema barrier arms the
+  page's epoch BEFORE its first request leaves, and the check itself
+  latches lazily off the page otherwise -- pre-boot HTTP (an
+  ephemeral model's REST call, a direct `HTTP.get` at app init) is
+  covered too, not only traffic after `DB.boot`, which alone would
+  latch too late. Pages without an epoch (no Rails integration yet)
+  are unaffected.
 - `Funicular::DB.wipe` and the mutation generation (docs decision 17):
   one call drops every table in both databases of the current
   namespace, deletes its two snapshot keys, rebuilds the replica DDL +

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ of truth. Entries below accumulate as the feature lands.
   Relations, `watch`, persistence/durability, namespaces and tabs, session
   epoch, SSR constraints); `docs/architecture.md` gains the
   contributor-facing invariants.
+- `Model.all(params)` now forwards `params` as a percent-encoded query
+  string (`Post.all(page: 2)` -> `GET /posts?page=2`) via the new
+  picoruby-uri gem's CRuby-compatible `URI.encode_www_form`. The argument
+  existed before but was silently ignored.
 
 ### Changed (BREAKING)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,22 @@ of truth. Entries below accumulate as the feature lands.
   epoch, SSR constraints); `docs/architecture.md` gains the
   contributor-facing invariants.
 
+### Changed (BREAKING)
+
+- Every `Funicular::Model` REST callback is now uniformly
+  `(result, error)`: on success `result` is the payload (`all` -> array,
+  `find`/`create` -> instance, `update` -> the applied instance, `destroy`
+  -> `true`) and `error` is nil; on failure `result` is nil. `update` and
+  `destroy` used to yield boolean-first `(true/false, data_or_error)`;
+  callsites reading the first argument as a boolean must be updated.
+  `update` with nothing to send (no changes, or binary-only changes) now
+  reports a successful no-op instead of silently not calling the block.
+
+### Fixed
+
+- `Model#initialize` uses key-presence lookups instead of `||`, so a
+  string-keyed `false` (boolean columns) no longer collapses to nil.
+
 ### Removed
 
 - The IndexedDB-backed HTTP response cache (`Funicular::HTTP` `cache:`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,17 @@
-## [Unreleased]
+## [0.5.0] - Unreleased
+
+The local database release: an ActiveRecord-like, reactive local store on
+in-browser SQLite (picoruby-sqlite3), with the Rails server as the source
+of truth. Entries below accumulate as the feature lands.
+
+### Added
+
+- Design documentation for the local database layer:
+  `docs/local_database.md` is the user-facing API contract (source-of-truth
+  contract, `storage`/`refresh` declarations, `migrate` blocks, `.local`
+  Relations, `watch`, persistence/durability, namespaces and tabs, session
+  epoch, SSR constraints); `docs/architecture.md` gains the
+  contributor-facing invariants.
 
 ## [0.4.0] - 2026-07-23
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    funicular (0.4.0)
+    funicular (0.5.0)
       rails (~> 8.0)
 
 GEM

--- a/demo/local_notes.html
+++ b/demo/local_notes.html
@@ -1,0 +1,194 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>Local Notes - Funicular</title>
+</head>
+<body>
+  <div><a href="../index.html">Back</a></div>
+  <h1>Local Notes (Funicular local database)</h1>
+  <div id="app"></div>
+
+  <div class="explain">
+    <p>A server-less demo of the local database layer:
+      <code>storage :local</code>, <code>.local</code> queries,
+      <code>watch</code>, snapshot persistence, the single-writer
+      election, and <code>Funicular::DB.wipe</code>.</p>
+    <ul>
+      <li><b>Add some notes, then reload the page.</b> The writer tab
+        snapshots the database into IndexedDB about half a second
+        after the last write, and the next visit restores it.</li>
+      <li><b>Open this page in a second tab.</b> Only one tab per
+        browser profile wins the writer election; the other becomes a
+        persistent reader whose writes raise. Close the writer tab
+        and reload the reader to take over.</li>
+      <li><b>Press "Wipe everything".</b> Both databases of this
+        namespace are dropped and rebuilt empty, the stored snapshots
+        are deleted, and the watcher re-renders onto empty tables.</li>
+      <li>The list re-renders through
+        <code>watch(:notes) { Note.local.order(created_at: :desc) }</code>
+        after every change event; no manual state bookkeeping.</li>
+    </ul>
+  </div>
+
+  <script type="text/ruby">
+    class Note < Funicular::Model
+      table_name "local_notes"
+      storage :local do
+        migrate 1 do |t|
+          t.string :title
+          t.timestamps
+        end
+      end
+    end
+
+    class NotesApp < Funicular::Component
+      READER_MESSAGE =
+        "This tab is a persistent reader: another tab holds the " \
+        "writer lock. Close the writer tab and reload to write here."
+
+      def initialize_state
+        # start boots the database before anything mounts, so the
+        # durability verdict is already final here.
+        {
+          notes: [],
+          message: "",
+          durability: Funicular::DB.durability,
+        }
+      end
+
+      def component_did_mount
+        watch(:notes) { Note.local.order(created_at: :desc) }
+      end
+
+      def handle_add(event)
+        event.preventDefault
+        field = JS.document.getElementById("note-title")
+        title = field[:value].to_s
+        return if title.empty?
+        begin
+          Note.create(title: title)
+          field[:value] = ""
+          patch(message: "")
+        rescue Funicular::DB::ReadOnlyTabError
+          patch(message: READER_MESSAGE)
+        end
+      end
+
+      def handle_delete(note)
+        -> {
+          begin
+            note.destroy
+            patch(message: "")
+          rescue Funicular::DB::ReadOnlyTabError
+            patch(message: READER_MESSAGE)
+          end
+        }
+      end
+
+      def handle_wipe(event)
+        event.preventDefault
+        begin
+          Funicular::DB.wipe
+          patch(message: "Wiped: tables rebuilt empty, snapshots deleted.")
+        rescue Funicular::DB::ReadOnlyTabError
+          patch(message: READER_MESSAGE)
+        end
+      end
+
+      def render
+        notes = state[:notes]
+        div(class: "notes-app") do
+          p(class: "status") do
+            "durability: #{state[:durability]} | notes: #{notes.size}"
+          end
+          div(class: "composer") do
+            input(type: "text", id: "note-title",
+                  placeholder: "What to remember?")
+            button(onclick: :handle_add) { "Add" }
+            button(onclick: :handle_wipe, class: "danger") do
+              "Wipe everything"
+            end
+          end
+          p(class: "message") { state[:message] }
+          ul(class: "notes") do
+            notes.each do |note|
+              li(key: note.id) do
+                span(class: "title") { note.title }
+                span(class: "stamp") { note.created_at.to_s }
+                button(onclick: handle_delete(note), class: "delete") do
+                  "delete"
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+
+    # No load_schemas round: a local-only app boots right inside
+    # start's gate, on the anonymous "funicular" namespace (this page
+    # carries no include-tag metadata).
+    Funicular.start(NotesApp, container: 'app')
+  </script>
+  <script src="../init.iife.js"></script>
+</body>
+<style>
+.notes-app {
+  max-width: 560px;
+}
+
+.status {
+  color: #555;
+  font-family: monospace;
+}
+
+.composer input {
+  margin-right: 6px;
+  padding: 4px 6px;
+  width: 260px;
+}
+
+.composer button {
+  margin-right: 6px;
+}
+
+.composer .danger {
+  color: #a00;
+}
+
+.message {
+  color: #a00;
+  min-height: 1.2em;
+}
+
+ul.notes {
+  list-style: none;
+  padding: 0;
+}
+
+ul.notes li {
+  border-bottom: 1px solid #ddd;
+  display: flex;
+  gap: 10px;
+  padding: 6px 2px;
+}
+
+ul.notes .title {
+  flex: 1;
+}
+
+ul.notes .stamp {
+  color: #888;
+  font-size: 0.85em;
+}
+
+.explain {
+  border-top: 1px solid #ccc;
+  color: #333;
+  margin-top: 24px;
+  max-width: 640px;
+  padding-top: 12px;
+}
+</style>
+</html>

--- a/demo/local_notes.html
+++ b/demo/local_notes.html
@@ -110,6 +110,9 @@
             "durability: #{state[:durability]} | notes: #{notes.size}"
           end
           div(class: "composer") do
+            # A placeholder disappears as soon as text is typed, so it
+            # cannot be the field's accessible name.
+            label(for: "note-title") { "Note title" }
             input(type: "text", id: "note-title",
                   placeholder: "What to remember?")
             button(onclick: :handle_add) { "Add" }

--- a/demo/local_notes.html
+++ b/demo/local_notes.html
@@ -7,7 +7,13 @@
 <body>
   <div><a href="../index.html">Back</a></div>
   <h1>Local Notes (Funicular local database)</h1>
-  <div id="app"></div>
+  <!-- A page declaring storage :local models must choose its
+       namespace explicitly (docs decision 12) or the boot fails
+       loud. A Rails app gets these attributes from
+       picoruby_include_tag; this static page carries them by hand. -->
+  <div id="app"
+       data-funicular-application-id="local_notes_demo"
+       data-funicular-anonymous-only="true"></div>
 
   <div class="explain">
     <p>A server-less demo of the local database layer:
@@ -57,7 +63,7 @@
         }
       end
 
-      def component_did_mount
+      def component_mounted
         watch(:notes) { Note.local.order(created_at: :desc) }
       end
 
@@ -127,8 +133,11 @@
     end
 
     # No load_schemas round: a local-only app boots right inside
-    # start's gate, on the anonymous "funicular" namespace (this page
-    # carries no include-tag metadata).
+    # start's gate. The namespace comes from the hand-written
+    # data-funicular-* attributes on the #app container above: pages
+    # with storage :local models must declare anonymous_only (or a
+    # user key) explicitly -- a silent shared default would merge
+    # every user's data, so the boot fails loud without it.
     Funicular.start(NotesApp, container: 'app')
   </script>
   <script src="../init.iife.js"></script>

--- a/demo/local_notes.html
+++ b/demo/local_notes.html
@@ -12,6 +12,7 @@
        loud. A Rails app gets these attributes from
        picoruby_include_tag; this static page carries them by hand. -->
   <div id="app"
+       data-funicular-local-database="true"
        data-funicular-application-id="local_notes_demo"
        data-funicular-anonymous-only="true"></div>
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -94,6 +94,13 @@ persistence). The user-facing contract is documented in
 [local_database.md](local_database.md); the contributor-relevant invariants
 are:
 
+- The entire subsystem is optional and defaults off. Rails emits an explicit
+  page opt-in only for `config.local_database = true`; without it schema and
+  REST traffic continue normally, while DB boot, SQLite, IndexedDB, Web Locks,
+  replica write-through, and session-epoch handling do not run. Disabled
+  `storage :local` declarations fail at the pre-DOM start gate, and runtime
+  local APIs raise `UnavailableError`. Disabling does not delete snapshots.
+
 - Two databases split by durability class: `funicular_replica`
   (server-recoverable, dropped and rebuilt on schema mismatch) and
   `funicular_local` (client-only data, evolved via numbered `migrate` blocks
@@ -130,8 +137,8 @@ are:
   encoded identity is used for snapshot keys, the Web Lock name, the
   previous-identity value in the Rails session, and epoch rotation.
   (Configuration contract for user_key/anonymous_only: see the dedicated
-  bullet below.) A separate SESSION EPOCH is managed by the Railtie
-  with no app code: kept in the Rails session, rotated (SecureRandom)
+  bullet below.) When the subsystem is enabled, a separate SESSION EPOCH is
+  managed by the Railtie with no app code: kept in the Rails session, rotated (SecureRandom)
   whenever the computed user_key changes, stamped on all REST/schema
   responses (X-Funicular-Epoch). A mismatching OR MISSING epoch on an
   apply-path response moves the page to a TERMINAL invalid-session state:
@@ -176,7 +183,7 @@ are:
   reset_local (which internally lifts query_only for the rebuild; still
   ReadOnlyTabError on non-writer tabs) are the only doors. No per-table
   nuance in v1.
-- Boot is one state machine (`Funicular::DB.boot`, driven by
+- When opted in, boot is one state machine (`Funicular::DB.boot`, driven by
   Funicular.start, independent of load_schemas usage): declarations ->
   namespace+epoch -> writer election -> local restore+migrations -> replica
   restore+fingerprint (after ALL schemas collected) -> components mount.
@@ -224,13 +231,14 @@ are:
   re-subscribing each evaluation. Hashes/scalars/raw SQL: use Model.on_change
   + patch. (The dependency collector, tables: option, and refresh :auto's
   barrier-time all-endpoint validation are deferred with :auto itself.)
-- user_key is mandatory when local-database models are declared
-  (`anonymous_only = true` is the explicit opt-out for auth-less apps;
-  both set = config error); the AUTHORITATIVE unconfigured check is
-  client-side in DB.boot after all declarations are recorded -- the Rails
-  side raises only when it can reliably detect the misconfiguration.
-  Namespace + epoch metadata are emitted by `picoruby_include_tag` as
-  HTML-escaped data attributes (no new helper; CSR-only apps covered).
+- Every opted-in application requires `user_key`, or `anonymous_only = true`
+  as the explicit choice for an auth-less app (both set = config error), even
+  when it has only replica models. Rails validates after initialization and
+  before helper output; DB.boot validates the emitted contract defensively.
+  The opt-in flag plus namespace and epoch metadata are emitted by
+  `picoruby_include_tag` as HTML-escaped data attributes (no new helper;
+  CSR-only apps covered). No metadata means disabled, never an implicit
+  anonymous `"funicular"` namespace.
   Session epoch state is stored PER application_id
   (session[:funicular_epochs][app_id] = { identity:, epoch: }) so multiple
   Funicular apps sharing one Rails session cannot rotate each other's

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -38,10 +38,12 @@ stay free of browser-only calls on any server code path
 | `patcher.rb`                                            | `Patcher.apply(dom, patches)` -- apply patches to the real DOM                                  |
 | `html_serializer.rb`                                    | `VDOM::HTMLSerializer` -- VDOM to HTML string (used by SSR)                                     |
 | `router.rb`                                             | Client-side router, route DSL, per-runtime route helper object, History API                     |
-| `model.rb`                                              | Object-REST Mapper (`all`/`find`/`create`/`update`/`destroy`)                                   |
-| `http.rb`                                               | Low-level fetch wrapper, CSRF, IndexedDB response cache                                         |
+| `model.rb`                                              | Object-REST Mapper (`all`/`find`/`create`/`update`/`destroy`) + local query API (`storage`/`refresh`, associations, `migrate` blocks) |
+| `db.rb`                                                 | `Funicular::DB`: local SQLite databases, DDL derivation, snapshot persistence, change events, `wipe` |
+| `relation.rb`                                           | Lazy chainable Relation and SQL builder for local queries                                       |
+| `http.rb`                                               | Low-level fetch wrapper, CSRF                                                                   |
 | `cable.rb`                                              | ActionCable-compatible consumer/subscription client                                             |
-| `store.rb`, `store_singleton.rb`, `store_collection.rb` | IndexedDB-backed stores, scope API, `subscribes_to`, event dispatch                             |
+| `store.rb`, `store_singleton.rb`, `store_collection.rb` | IndexedDB-backed stores (superseded by the local database; see below)                           |
 | `form_builder.rb`                                       | `form_for` field helpers with inline error rendering                                            |
 | `0_validations.rb`, `1_validators.rb`                   | ActiveModel-style validators and `errors`                                                       |
 | `styles.rb`                                             | CSS-in-Ruby bareword `styles do ... end` builder and generated `styles.name` accessors          |
@@ -83,6 +85,174 @@ Unknown style lookups raise instead of returning an empty class string.
 Component children are ordinary VDOM children stored on
 `VDOM::Component#children`; there is no delayed `children_block` prop. This keeps
 SSR, diffing, ErrorBoundary rendering, and hydration on the same data model.
+
+## Local database (sqlite3)
+
+`Funicular::Model` is backed by an in-browser SQLite database
+(picoruby-sqlite3 on wasm: `:memory:` database + IndexedDB snapshot
+persistence). The user-facing contract is documented in
+[local_database.md](local_database.md); the contributor-relevant invariants
+are:
+
+- Two databases split by durability class: `funicular_replica`
+  (server-recoverable, dropped and rebuilt on schema mismatch) and
+  `funicular_local` (client-only data, evolved via numbered `migrate` blocks
+  with per-table versions in a meta table; never dropped in production --
+  dev auto-resets on migration failure, `reset: true` baselines and
+  `Model.reset_local` are the explicit reset paths). Both auto-persist,
+  in the `persistent_writer` state only, via debounce plus a
+  `visibilitychange` backstop.
+- One apply entry point: every FRAMEWORK-CONTROLLED replica write
+  (fetch-through, write-through, and, in the future, Cable-pushed
+  replication) funnels through the same upsert/delete path in
+  `Funicular::DB`, which is also where per-table change events fire. The
+  sanctioned exception is app-level raw SQL through the guarded handles,
+  whose contract is to call `notify_changed` afterwards. Relation#delete_all
+  exists only for `storage :local`; on replica Relations it raises
+  ReplicaWriteError even on the writer tab.
+- The source-of-truth contract on `Funicular::Model`: the bare class targets
+  the model's source of truth -- REST verbs with optional callbacks of ONE
+  shape, `(result, error)`, for replica/ephemeral models (BREAKING vs <=0.4:
+  update/destroy were boolean-first), the local table for `storage :local`
+  models (there the `.local` prefix is an optional alias). `.local` is the
+  explicitly-marked local/cache view: it returns immediate values and raises
+  on genuine bugs; on ephemeral models it raises
+  `Funicular::DB::NoTableError`.
+- Boot barrier: all schemas are collected before replica DDL/fingerprint
+  work runs (exactly once per boot); any schema failure fails startup with
+  aggregated errors. The fingerprint covers DDL-affecting data only and IS
+  the canonical schema JSON, stored in a replica metadata table and
+  compared by string equality (no digest dependency; never user_version).
+- Isolation: namespace identity is a typed, versioned tuple
+  (["v1", app_id, "anonymous"] / ["v1", app_id, "user", key]) encoded as
+  canonical JSON -- never naive concatenation (collision-free even for a
+  literal "anonymous" user key or delimiter-containing values); the same
+  encoded identity is used for snapshot keys, the Web Lock name, the
+  previous-identity value in the Rails session, and epoch rotation.
+  (Configuration contract for user_key/anonymous_only: see the dedicated
+  bullet below.) A separate SESSION EPOCH is managed by the Railtie
+  with no app code: kept in the Rails session, rotated (SecureRandom)
+  whenever the computed user_key changes, stamped on all REST/schema
+  responses (X-Funicular-Epoch). A mismatching OR MISSING epoch on an
+  apply-path response moves the page to a TERMINAL invalid-session state:
+  the response is discarded and replica applies, local writes, raw writes,
+  and persistence are refused for the life of the page (a non-reloading
+  on_session_change hook cannot re-enable them; default hook reloads). The
+  terminal flag is an irreversible latch independent of durability state;
+  a terminal WRITER steps down -- debounce cancelled, in-flight persist
+  serialized, lock-holding promise resolved so the lock releases,
+  connections kept only as a non-persistent read view.
+- Durability is a three-state machine per page: persistent_writer (holds
+  the Web Lock; restores, persists, writes), persistent_reader (replica
+  fully functional incl. in-memory revalidation writes, never persisted;
+  LOCAL connection PRAGMA query_only=ON; local writes and
+  flush/wipe/reset_local raise ReadOnlyTabError; persist/close are not
+  on the proxy surface at all, on any tab), and
+  volatile (everything works including local writes, nothing persists;
+  entered when Web Locks or IndexedDB are unavailable; named distinctly
+  from the `storage :ephemeral` model declaration). Lock protocol: boot
+  decides instantly via `ifAvailable: true`; a reader stays reader for the
+  life of the page (no promotion in v1 -- reload to write); the writer
+  parks the lock on a promise resolved at teardown. DB handles
+  are guarded proxies with a closed allowlist, never raw SQLite3::Database:
+  proxy `transaction` yields the proxy (the gem's own transaction yields
+  the raw db), `prepare` returns a guarded statement, batch/deserialize/
+  commit/rollback are classified; pending notify_changed state is tied to
+  raw-transaction commit/rollback. Read-only states are enforced per
+  STATEMENT at execution time via sqlite3_stmt_readonly
+  (Statement#readonly?, new sqlite3 API): write statements -> framework
+  exception; PRAGMA query_only/ATTACH/DETACH rejected separately (SQLite
+  classifies them read-only; query_only alone is not a guarantee -- it can
+  be switched OFF); execute_batch refused outright in read-only states;
+  EVERY execution entry point re-checks the current latch/state when run
+  (execute, step, ResultSet#next, get_first_* alike).
+- `wipe` (writer-only) advances the MUTATION GENERATION (deliberately not
+  called "epoch" -- the session epoch is a different mechanism): stale
+  in-flight applies are rejected, debounce timers cancelled, watchers
+  notified only after DBs are queryable again. If ANY local table's stored
+  migration version exceeds the declared maximum, the WHOLE local DB fails
+  loud: every local-model operation (read or write, any table) raises
+  SchemaTooNewError and the DB sits at query_only=ON; raw SELECT export and
+  reset_local (which internally lifts query_only for the rebuild; still
+  ReadOnlyTabError on non-writer tabs) are the only doors. No per-table
+  nuance in v1.
+- Boot is one state machine (`Funicular::DB.boot`, driven by
+  Funicular.start, independent of load_schemas usage): declarations ->
+  namespace+epoch -> writer election -> local restore+migrations -> replica
+  restore+fingerprint (after ALL schemas collected) -> components mount.
+  Schema failure: completion block not invoked, console.error always,
+  on_boot_error(errors) when set. The HTTP layer settles every schema
+  request exactly once (success / HTTP error / parse error / Promise
+  rejection), so the barrier cannot hang; an empty schema set is valid only
+  when no replica models are declared.
+- picoruby-indexeddb error classification cannot ride the generic JS
+  Promise bridge (it carries only error.message; JS::Promise#await raises a
+  string): the gem's own EM_JS promises resolve a TAGGED result -- success
+  as { ok:, value: }, failure as { ok:, name:, message: } -- converted to
+  values/typed Ruby exceptions; the same shape applies to the request and
+  transaction helpers, not just open. Only listed availability errors
+  (SecurityError, InvalidStateError, missing global) fall back to the
+  in-memory store (-> volatile state); quota and data errors surface;
+  onblocked is not availability failure -- it waits with a fixed timeout
+  (default 5000ms), raises a typed BlockedError on expiry, and a late open
+  success after the timeout closes that connection immediately; open cleans
+  up its callback registry in ensure.
+- picoruby-sqlite3 gains official primitives instead of Funicular poking
+  internals: open a memory DB without snapshot binding (no restore/no
+  persist -- plain `close` on an unbound DB persists nothing, so no
+  `close(persist: false)` variant is needed) and `Statement#readonly?`. (No
+  named-snapshot-deletion API: it would target the gem's built-in store,
+  which Funicular does not use -- `wipe` deletes the two namespaced keys
+  directly from Funicular's own KVS.) Snapshots are stored Base64-encoded
+  (binary Strings do not survive the JS bridge). The proxy exposes NO
+  `persist`/`close` on any tab: the framework's DBs are unbound memory DBs
+  (SQLite-level persist has no valid target; close would destroy a
+  framework-owned connection). Snapshot I/O itself is OWNED BY FUNICULAR:
+  `Funicular::DB` opens its IndexedDB store with `fallback: false` and does
+  its own serialize/deserialize round trips -- the sqlite3 gem's built-in
+  STORE_NAME persistence (whose KVS defaults to fallback: true and would
+  hide unavailability) is not used by Funicular. Storage failure at boot,
+  v1: availability errors on open -> volatile (backend absent by design);
+  ANY other storage failure -- open errors
+  (QuotaExceeded/Unknown/Version/Blocked-timeout) or snapshot GET errors
+  (quota/data) -- FAILS THE BOOT: components do not mount, console.error +
+  on_boot_error. Recovery: corrupt snapshot (GET failure, handle exists) ->
+  the hook may call wipe then reload; open failure -> fix browser state,
+  reload. No latches, no partial boot, no in-page recovery (deferred).
+- watch, v1: the block must return a Relation (else a helpful raise); the
+  framework materializes it and subscribes to that Relation's table,
+  re-subscribing each evaluation. Hashes/scalars/raw SQL: use Model.on_change
+  + patch. (The dependency collector, tables: option, and refresh :auto's
+  barrier-time all-endpoint validation are deferred with :auto itself.)
+- user_key is mandatory when local-database models are declared
+  (`anonymous_only = true` is the explicit opt-out for auth-less apps;
+  both set = config error); the AUTHORITATIVE unconfigured check is
+  client-side in DB.boot after all declarations are recorded -- the Rails
+  side raises only when it can reliably detect the misconfiguration.
+  Namespace + epoch metadata are emitted by `picoruby_include_tag` as
+  HTML-escaped data attributes (no new helper; CSR-only apps covered).
+  Session epoch state is stored PER application_id
+  (session[:funicular_epochs][app_id] = { identity:, epoch: }) so multiple
+  Funicular apps sharing one Rails session cannot rotate each other's
+  epochs.
+- notify_changed takes a model class or (role, table) pair -- change
+  identity is [database_role, table_name]; inside a raw transaction the
+  event and persist scheduling defer to commit and vanish on rollback.
+- Event bus: change events fire post-commit, coalesced to one per table per
+  transaction; watcher delivery is queued (never nested inside a component
+  update) and subscriber exceptions are isolated.
+- SSR: all SQLite3 access is deferred inside methods so class bodies still
+  evaluate under CRuby; materializing a local query during SSR raises
+  `Funicular::DB::UnavailableError` (fail loud, never an empty result).
+
+The Store layer (`store.rb`, `store_singleton.rb`, `store_collection.rb`) is
+superseded by this: every Store feature has a local-database counterpart
+(scopes -> tables/where, `expires_in` -> `refresh :auto`, `on_change` ->
+table change events + `watch`, `subscribes_to` -> future `refresh :live`,
+`cleared_on`/`dispatch` -> `Funicular::DB.wipe`). Store stays in the tree
+untouched for now -- its `subscribes_to` implementation is the design
+reference for `refresh :live` -- but nothing new builds on it, and it will be
+deprecated and removed once `refresh :live` ships.
 
 ## `lib/` Rails integration
 

--- a/docs/local_database.md
+++ b/docs/local_database.md
@@ -421,9 +421,16 @@ Edge semantics are pinned down, ActiveRecord-style:
   shared codec (`true`/`false` <-> 1/0, `Time` <-> ISO 8601 TEXT normalized
   to UTC at fixed precision -- arbitrary ISO 8601 offsets would not sort
   chronologically as strings) used identically by writes, reads, and
-  condition binding. The SAME codec is applied when REST responses
-  initialize model instances, so `Post.all` and `Post.local.find` return
-  the same Ruby types for the same attribute.
+  condition binding. Datetime STRINGS handed to the typed side (a
+  `datetime` column in a hash condition or a local write) are parsed and
+  re-normalized to the same UTC fixed-precision form; malformed ones raise
+  `ArgumentError` at bind time, not at query time. The SAME codec is
+  applied when REST responses initialize model instances, so `Post.all`
+  and `Post.local.find` return the same Ruby types for the same attribute.
+  One boundary: binds on a RAW SQL fragment carry no column type, so they
+  are encoded by value (`true`/`false` and `Time` instances converted;
+  strings pass through untouched) -- format datetime strings there as UTC
+  ISO 8601 yourself, as the examples do.
 
 Multiple `where` calls AND together. `OR`, `JOIN`, `GROUP BY`, and anything
 else SQL can do remain available through the raw-fragment form or, for full

--- a/docs/local_database.md
+++ b/docs/local_database.md
@@ -1,7 +1,9 @@
 # Local Database
 
-Funicular apps get a real relational database inside the browser: SQLite,
+Funicular can provide a real relational database inside the browser: SQLite,
 compiled to WebAssembly, queried from Ruby with an ActiveRecord-flavored API.
+The subsystem is disabled by default; an application that does not opt in
+remains REST-only and does not open SQLite, IndexedDB, or Web Locks.
 
 ```ruby
 Post.local.where(published: true).order(created_at: :desc).limit(10).each do |post|
@@ -73,6 +75,33 @@ the bare class and `.local` are interchangeable: `Draft.where(...)` is
 
 ## Quick start
 
+First, enable the subsystem and declare how browser storage is isolated:
+
+```ruby
+# config/initializers/funicular.rb (Rails)
+Funicular.configure do |config|
+  config.local_database = true
+  config.user_key = ->(controller) {
+    controller.current_user&.storage_key
+  }
+end
+```
+
+An application with no user accounts can deliberately share one anonymous
+namespace instead:
+
+```ruby
+Funicular.configure do |config|
+  config.local_database = true
+  config.anonymous_only = true
+end
+```
+
+Enabling the feature without exactly one of these identity declarations fails
+during Rails startup. Conversely, adding `.local` calls while leaving the
+feature disabled raises a clear runtime error, and declaring `storage :local`
+while disabled prevents `Funicular.start` from mounting the application.
+
 ```ruby
 # app/funicular/models/post.rb
 class Post < Funicular::Model
@@ -113,8 +142,9 @@ end
 
 What happens here:
 
-1. `Post` is an ordinary schema-loaded model. By default it gets a replica
-   table, auto-created from the schema your Rails server already delivers.
+1. `Post` is an ordinary schema-loaded model. When the local database is
+   enabled, the default `storage :replica` gives it a table auto-created from
+   the schema your Rails server already delivers.
 2. `Post.all { ... }` fetches from the REST endpoint as it always has; the
    framework additionally upserts every fetched row into the replica table
    (fetch-through).
@@ -125,9 +155,9 @@ What happens here:
 
 ## Declaring models
 
-Two orthogonal declarations control a model's relationship with the local
-database. Both have defaults chosen so that the common case needs no
-declaration at all.
+Two orthogonal declarations control a model's relationship with an enabled
+local database. Both have defaults chosen so that the common opted-in case
+needs no declaration at all.
 
 ### `storage` -- where the model's data lives
 
@@ -156,10 +186,10 @@ storage :local
 
 #### How the databases boot
 
-Database startup is one state machine (`Funicular::DB.boot`), driven by
-`Funicular.start`, and it runs whether or not the app uses server schemas
-at all -- an app with only `storage :local` models and no
-`Funicular.load_schemas` call still gets namespace resolution, writer
+When `config.local_database = true`, database startup is one state machine
+(`Funicular::DB.boot`), driven by `Funicular.start`, and it runs whether or not
+the app uses server schemas at all -- an app with only `storage :local` models
+and no `Funicular.load_schemas` call still gets namespace resolution, writer
 election, snapshot restore, and local migrations. The order is fixed:
 
 1. Model class bodies only record declarations; nothing touches SQLite.
@@ -173,7 +203,10 @@ election, snapshot restore, and local migrations. The order is fixed:
 6. Components mount/hydrate only after the databases they can reach are
    queryable; a `watch` can never observe a half-booted database.
 
-If any schema request fails, startup fails loudly and precisely: the
+With the local database disabled, schema requests and REST CRUD still run,
+but successful schema loading proceeds directly to component startup without
+waiting for a database. If any schema request fails, startup fails loudly and
+precisely in either mode: the
 `load_schemas` completion block is NOT invoked (so the app's
 `Funicular.start` call inside it never runs), the replica database is not
 initialized (a partial replica would be worse than none), and the failure
@@ -185,10 +218,10 @@ unset never means silence.
 -- success, HTTP error status, parse error, and fetch Promise rejection
 (network down, CORS, aborted) -- into exactly one callback invocation per
 request, so the barrier always settles; it cannot hang waiting for a
-request whose Promise rejected. And an EMPTY schema set is only a valid
-boot when no replica models are declared -- replica models with zero loaded
-schemas would mean mounting components over nonexistent tables, so that is
-a boot failure too.
+request whose Promise rejected. When the database is enabled, an EMPTY schema
+set is only a valid boot when no replica models are declared -- replica models
+with zero loaded schemas would mean mounting components over nonexistent
+tables, so that is a boot failure too.
 
 The schema fingerprint covers only what affects SQLite DDL -- table names,
 column names and types, and the id type. Endpoint or validation changes on
@@ -692,6 +725,7 @@ configuration API):
 ```ruby
 # config/initializers/funicular.rb (Rails)
 Funicular.configure do |config|
+  config.local_database = true
   config.application_id = "my_app"          # default: "funicular"
   config.user_key = ->(controller) {
     controller.current_user&.storage_key    # see below
@@ -715,8 +749,9 @@ canonical JSON, and that ONE encoded identity is used everywhere it
 matters: snapshot keys, the Web Lock name, the previous-identity value in
 the Rails session, and the epoch-rotation comparison.
 
-**Configuring `user_key` is mandatory for apps that use the local
-database.** The gem cannot detect whether your app has authentication, and
+**Opting in and configuring an identity are both mandatory.** Set
+`config.local_database = true`, then configure `user_key` or explicitly choose
+`anonymous_only`. The gem cannot detect whether your app has authentication, and
 a forgotten `user_key` would silently put every logged-in user into the
 shared `anonymous` namespace AND stop the session epoch from rotating --
 both isolation mechanisms broken at once. So the contract is explicit:
@@ -724,25 +759,28 @@ declare one or the other,
 
 ```ruby
 Funicular.configure do |config|
+  config.local_database = true
   config.user_key = ->(controller) { ... }   # apps with authentication
   # or, for apps that genuinely have no users:
   config.anonymous_only = true
 end
 ```
 
-and an app that declares local-database models without doing either fails
-loudly. The authoritative check runs client-side, in the database boot,
-after every model declaration has been recorded -- the server cannot always
-know at render time whether client-side local-DB models exist, so the
-helper embeds "unconfigured" metadata as-is and the server raises only in
-the cases it can detect reliably. Setting BOTH `user_key` and
-`anonymous_only` is also a configuration error -- the framework never picks
-one silently.
+and an opted-in app without either declaration fails during Rails startup.
+The include helper validates again before emitting metadata, and the client
+boot defensively refuses missing identity metadata. Setting BOTH `user_key`
+and `anonymous_only` is also a configuration error -- the framework never
+picks one silently.
 
-The namespace and epoch metadata reach the page through
+The opt-in flag, namespace, and epoch metadata reach the page through
 `picoruby_include_tag` -- the helper every Funicular layout already has --
 as HTML-escaped data attributes, so CSR-only and local-only apps need no
-new helper and no template change.
+new helper and no template change. Without the opt-in attribute, the client
+does not infer an anonymous `"funicular"` namespace.
+
+Turning the feature off does not delete existing IndexedDB snapshots. If the
+application later enables it with the same identity, those snapshots can be
+restored normally.
 
 At boot the client opens only the current namespace's databases. Table
 names, SQL, and your model code are untouched by any of this -- isolation
@@ -939,7 +977,8 @@ client-rendered routes (or behind `Funicular.server?` guards in
 
 ## Configuration
 
-Optional, in `app/funicular/initializer.rb`:
+After the Rails-side opt-in shown in Quick start, runtime DB hooks and tuning
+are optional in `app/funicular/initializer.rb`:
 
 ```ruby
 Funicular::DB.configure do
@@ -951,6 +990,10 @@ Funicular::DB.configure do
   config.on_session_change           = nil    # default behavior: reload page
 end
 ```
+
+`Funicular::DB.configure` itself remains valid while the subsystem is
+disabled, so an `on_boot_error` hook can still receive schema-barrier errors;
+the persistence settings are simply inert until the feature is enabled.
 
 The user/application namespace and session epoch are configured on the
 Rails side (`Funicular.configure` -- see Data isolation), not here. Future

--- a/docs/local_database.md
+++ b/docs/local_database.md
@@ -1,0 +1,982 @@
+# Local Database
+
+Funicular apps get a real relational database inside the browser: SQLite,
+compiled to WebAssembly, queried from Ruby with an ActiveRecord-flavored API.
+
+```ruby
+Post.local.where(published: true).order(created_at: :desc).limit(10).each do |post|
+  # instant, synchronous, no spinner -- this never touches the network
+end
+```
+
+This document is the complete guide to the local database layer: what it is
+for, how to declare models, how to query, how data flows in and out, and what
+its durability guarantees are.
+
+## Mental model
+
+**The Rails server is the source of truth. The local database is a structured,
+queryable replica plus a home for client-only data.**
+
+Every piece of data in the local database belongs to one of two categories,
+and the difference matters for everything else in this document:
+
+- **Replica data** is a local copy of rows that live in your Rails database.
+  It arrives via the REST API you already have. Losing it costs nothing but a
+  refetch. It exists so that reads are instant and relational.
+- **Client-only data** exists nowhere but this browser: drafts, local
+  preferences, unsent form state. Losing it means losing user work, so it is
+  persisted more aggressively and never dropped because of anything the
+  server or the replica schema does. The only paths that discard it are the
+  explicit resets (development auto-reset, a `reset: true` baseline,
+  `reset_local`, `wipe`).
+
+Physically these are two separate SQLite databases (`funicular_replica` and
+`funicular_local`), each snapshotted independently to IndexedDB. You never
+open or manage them yourself; model declarations decide where a model's table
+lives.
+
+### The source-of-truth contract
+
+One lexical rule runs through the whole `Funicular::Model` API:
+
+- **The bare class talks to the model's source of truth.** For replica and
+  ephemeral models the truth is the Rails server, so the bare class speaks
+  REST: `Post.all { }`, `Post.find(id) { }`, `Post.create(attrs) { }` --
+  all network, all asynchronous, all reporting through an optional callback
+  block with ONE shape: `(result, error)`. On success `result` is the
+  payload and `error` is nil; on failure `result` is nil. Fire-and-forget
+  (no block) is legal.
+
+> **Breaking change vs Funicular <= 0.4**: `update` and `destroy` used to
+> yield `(true/false, data_or_error)`. Every REST callback is now uniformly
+> `(result, error)`: `all` yields the model array, `find`/`create` the
+> instance, `update` the updated instance (as applied to the replica -- see
+> write-through), `destroy` yields `true`. Existing callsites that read the
+> first argument as a boolean must be updated.
+- **`.local` is the local database view.** `Post.local.where(...)` reads the
+  replica: instant and synchronous, but possibly stale -- writing `.local`
+  is how you acknowledge "this may be a cache". Local reads return values;
+  genuine bugs raise exceptions, with no error-handling ceremony.
+
+```ruby
+Post.all do |posts, error|                # network: block, (result, error)
+  ...
+end
+
+posts = Post.local.where(published: true) # local: immediate return value
+```
+
+For `storage :local` models the local database IS the source of truth, so
+the bare class and `.local` are interchangeable: `Draft.where(...)` is
+`Draft.local.where(...)`; the prefix is optional there.
+
+## Quick start
+
+```ruby
+# app/funicular/models/post.rb
+class Post < Funicular::Model
+  belongs_to :user
+  has_many :comments
+end
+
+# app/funicular/models/draft.rb
+class Draft < Funicular::Model
+  storage :local do
+    migrate 1 do |t|
+      t.string  :title
+      t.text    :body
+      t.integer :post_id
+      t.timestamps
+    end
+  end
+end
+
+# app/funicular/components/blog_index_component.rb
+class BlogIndexComponent < Funicular::Component
+  def initialize_state
+    { posts: [] }
+  end
+
+  def component_mounted
+    watch(:posts) { Post.local.where(published: true).order(created_at: :desc) }
+    Post.all { |_posts, error| patch(error: error) if error }
+  end
+
+  def render
+    div do
+      state[:posts].each { |post| component PostRow, post: post }
+    end
+  end
+end
+```
+
+What happens here:
+
+1. `Post` is an ordinary schema-loaded model. By default it gets a replica
+   table, auto-created from the schema your Rails server already delivers.
+2. `Post.all { ... }` fetches from the REST endpoint as it always has; the
+   framework additionally upserts every fetched row into the replica table
+   (fetch-through).
+3. `watch(:posts)` binds `state[:posts]` to a local query. Whenever the
+   `posts` table changes -- because a fetch landed, or a write went through --
+   the block re-runs and the component re-renders. You never wire this up
+   manually.
+
+## Declaring models
+
+Two orthogonal declarations control a model's relationship with the local
+database. Both have defaults chosen so that the common case needs no
+declaration at all.
+
+### `storage` -- where the model's data lives
+
+```ruby
+storage :replica     # default; you do not write this
+storage :ephemeral
+storage :local
+```
+
+- **`:replica`** (default). The model is backed by a local table derived from
+  the server schema (`Funicular.load_schemas`). REST results flow into it
+  automatically. The table is dropped and rebuilt whenever the server schema
+  changes -- replicas are disposable by design.
+- **`:ephemeral`**. No local table, nothing written to disk. The model
+  behaves exactly like a classic Funicular model: REST only. Use this for
+  sensitive models whose data must not rest in browser storage
+  (authentication/session models are the canonical case). `.local` raises
+  `Funicular::DB::NoTableError`.
+- **`:local`**. Client-only table. No server schema, no REST integration;
+  the table shape is declared with `migrate` blocks on the `storage`
+  declaration itself (below). Writes are local and synchronous. The local
+  table is the source of truth, so the `.local` prefix is optional:
+  `Draft.where(...)` == `Draft.local.where(...)`. `storage :local` is the
+  only variant that takes a block; passing one to `:replica` or `:ephemeral`
+  raises.
+
+#### How the databases boot
+
+Database startup is one state machine (`Funicular::DB.boot`), driven by
+`Funicular.start`, and it runs whether or not the app uses server schemas
+at all -- an app with only `storage :local` models and no
+`Funicular.load_schemas` call still gets namespace resolution, writer
+election, snapshot restore, and local migrations. The order is fixed:
+
+1. Model class bodies only record declarations; nothing touches SQLite.
+2. The application/user namespace and session epoch are resolved from the
+   page.
+3. Writer election runs (Web Lock).
+4. The local database is restored and its migrations applied.
+5. Once ALL requested server schemas have arrived, the replica database is
+   restored and its fingerprint validated -- DDL derivation and comparison
+   run exactly once per boot, over the complete, canonically-ordered set.
+6. Components mount/hydrate only after the databases they can reach are
+   queryable; a `watch` can never observe a half-booted database.
+
+If any schema request fails, startup fails loudly and precisely: the
+`load_schemas` completion block is NOT invoked (so the app's
+`Funicular.start` call inside it never runs), the replica database is not
+initialized (a partial replica would be worse than none), and the failure
+is always written to the console -- `config.on_boot_error` additionally
+receives the aggregated errors naming each failed model, but leaving it
+unset never means silence.
+
+"Fails" is airtight by construction: the HTTP layer converts every outcome
+-- success, HTTP error status, parse error, and fetch Promise rejection
+(network down, CORS, aborted) -- into exactly one callback invocation per
+request, so the barrier always settles; it cannot hang waiting for a
+request whose Promise rejected. And an EMPTY schema set is only a valid
+boot when no replica models are declared -- replica models with zero loaded
+schemas would mean mounting components over nonexistent tables, so that is
+a boot failure too.
+
+The schema fingerprint covers only what affects SQLite DDL -- table names,
+column names and types, and the id type. Endpoint or validation changes on
+the server do NOT rebuild the replica. The fingerprint is the canonical
+schema JSON itself, stored in a metadata table inside the replica database
+and compared by plain string equality -- no hash algorithm, no extra
+dependency, no collision to reason about (and no `PRAGMA user_version`,
+which is a 32-bit integer and could not hold it anyway).
+
+When the fingerprint mismatches, tables are dropped and recreated -- and the
+rebuilt replica starts EMPTY. The framework still never issues implicit
+HTTP: rows reappear at your app's next explicit fetch.
+
+### `refresh` -- how replica data stays fresh
+
+v1 ships exactly one policy, and it is the default, so you never write this
+declaration: **manual**. The framework never issues an HTTP request on its
+own. Replica tables change only when your code fetches
+(`Post.all { ... }`, `Post.find(id) { ... }`) or writes through
+(`create`/`update`/`destroy`). Predictable and boring, in the good sense --
+and combined with `watch`, explicit fetching is already reactive: the fetch
+lands, the table changes, every watching component re-renders.
+
+The axis exists because it has a future: `refresh :auto`
+(stale-while-revalidate against an authoritative index endpoint) and
+`refresh :live` (ActionCable-pushed replication) are planned as drop-in
+upgrades for models already written with `watch` -- app code will not
+change. Declaring `:auto` or `:live` today raises "not yet supported" at
+class-definition time, as does declaring `refresh` on `:ephemeral` or
+`:local` models.
+
+### Table names
+
+Table names derive from the class name with naive pluralization: `Post` ->
+`posts`, `Category` -> `categories`. There is no inflector dictionary in the
+browser runtime, so irregular names must be declared:
+
+```ruby
+class Person < Funicular::Model
+  table_name "people"
+end
+```
+
+### Associations
+
+```ruby
+class Post < Funicular::Model
+  belongs_to :user
+  has_many :comments
+end
+```
+
+Associations are local-query sugar over the `<name>_id` convention:
+
+- `post.user` runs `User.local.find_by(id: post.user_id)` -- returns an
+  instance or `nil`.
+- `post.comments` returns `Comment.local.where(post_id: post.id)` -- a
+  chainable Relation: `post.comments.order(:created_at).limit(5)`.
+
+Instance-level association readers are unprefixed by design: an instance you
+are holding already came out of the local database (or a fetch that passed
+through it), so its neighborhood reads locally too. The `.local` marker
+belongs at query entry points, where the cache-vs-server decision is made.
+
+Options: `class_name:` and `foreign_key:` when the convention does not fit.
+Not supported in v1: `through:`, `includes`/eager loading, polymorphic
+associations. Note that the classic N+1 concern barely applies here -- each
+"+1" is a microsecond query against local memory, not a network round trip.
+
+Association targets are resolved lazily, at first use -- model files load in
+sorted filename order, so `belongs_to :user` in `post.rb` must not demand
+the `User` constant while `user.rb` is still unloaded. A typo in the target,
+or a reference to a model the client does not carry, fails with a clear
+error the first time the association is read.
+
+Associations are declared on the client, deliberately. Your Rails models may
+have dozens of associations; the client declares only the slice of the graph
+it actually replicates, so the local association surface is exactly what the
+app consciously chose to carry -- nothing auto-generated pointing at tables
+that do not exist here.
+
+### `storage :local do ... end` -- table shape and evolution
+
+Client-only models define their table inside the `storage` declaration, as a
+sequence of numbered `migrate` blocks:
+
+```ruby
+class Draft < Funicular::Model
+  storage :local do
+    migrate 1 do |t|
+      t.string  :title
+      t.text    :body
+      t.integer :post_id
+      t.boolean :pinned, default: false
+      t.index   :post_id
+      t.timestamps       # created_at / updated_at, maintained automatically
+    end
+  end
+end
+```
+
+The table IS the fold of its `migrate` blocks: block 1 creates it, and every
+later change -- additive or destructive -- is simply the next numbered block:
+
+```ruby
+storage :local do
+  migrate 1 do |t|
+    t.string :title
+    t.string :body
+    t.timestamps
+  end
+  migrate 2 do |t|
+    t.rename :body, :content            # destructive steps are ordinary steps
+    t.string :status, default: "draft"  # in later blocks this is ADD COLUMN
+  end
+end
+```
+
+There is no separate schema declaration to keep in sync: the blocks are the
+schema, so declaration and migration can never disagree.
+
+Builder vocabulary: `t.string` / `t.text` / `t.integer` / `t.float` /
+`t.boolean` / `t.datetime` (options: `default:`, `null:`), `t.timestamps`,
+`t.index` / `t.remove_index`, `t.rename :old, :new`, `t.remove :column`, and
+`t.execute "..."` as the raw-SQL escape hatch for data transformations
+(backfills, splitting a column, ...). Types map to SQLite affinities:
+`string`/`text` -> TEXT, `integer` -> INTEGER, `float` -> REAL, `boolean` ->
+INTEGER (0/1, converted at the Ruby boundary), `datetime` -> TEXT (ISO 8601
+normalized to UTC at fixed precision by the codec -- that normalization is
+what makes string order chronological). Every table gets an implicit
+`id INTEGER PRIMARY KEY`.
+
+How migrations run:
+
+- Ordinarily the first block is version 1. The one exception: the first
+  RETAINED block may carry any positive version when it is a `reset: true`
+  baseline (see below) -- that is what makes deleting pre-baseline history
+  legal. After the first retained block, versions must be contiguous; a gap
+  raises at class-definition time.
+- On boot, the framework compares each table's stored version (kept in a
+  meta table inside the local database) with the declared blocks. A fresh
+  database, or one stored below the baseline, is created/recreated from the
+  baseline definition and then receives the later blocks; a database at or
+  above the baseline receives only its missing later blocks. Application is
+  per table, inside one transaction; failure rolls back and raises -- user
+  data is never left half-migrated.
+- If any table's stored version is NEWER than the declared maximum (a
+  rolled-back deploy), the WHOLE local database fails loud: every
+  local-model operation -- read or write, any table -- raises
+  `Funicular::DB::SchemaTooNewError`, and the database sits at
+  `PRAGMA query_only = ON` so raw SQL cannot write either. (A newer deploy
+  may have renamed or removed columns; old code cannot be trusted on that
+  data, and v1 does not do per-table nuance.) Raw SELECTs against the
+  actual on-disk schema remain possible for inspecting or exporting.
+  Recovery: `reset_local` on the affected table (the framework internally
+  lifts `query_only` for that rebuild; still `ReadOnlyTabError` on
+  non-writer tabs) or a fixed-forward deploy.
+
+#### Resetting a local table
+
+Sometimes migrating is the wrong tool and "throw it away" is the right one.
+Three mechanisms, for three situations:
+
+- **Development auto-reset.** If applying migrations fails in the
+  development environment, the framework drops the table and rebuilds it
+  from the blocks, with a console warning -- iterate on your schema freely.
+  This never happens in production.
+- **Release-time reset: `reset: true`.** Mark a block as a new baseline:
+
+  ```ruby
+  migrate 4, reset: true do |t|
+    t.string :title            # a complete table definition, not a diff
+    t.text   :content
+    t.timestamps
+  end
+  ```
+
+  Clients below version 4 do not migrate: their table is dropped and
+  recreated from this definition, discarding its data -- that is the point.
+  Blocks older than a `reset: true` baseline may be deleted from the code;
+  clients stranded below the baseline simply fall into the reset path. This
+  doubles as the way to squash a long migration history.
+- **Programmatic: `Draft.reset_local`.** Drops and rebuilds the table right
+  now -- for a "clear local data" button or console debugging.
+  `Funicular::DB.wipe` (below) remains the everything-nuke for logout.
+
+## Querying
+
+Local queries live under `.local` (see the source-of-truth contract) and
+return immediately. `where`, `order`, `limit`, and `offset` build a lazy,
+chainable Relation; SQL executes once, when you materialize it.
+
+```ruby
+rel = Post.local.where(published: true)   # no SQL yet
+        .order(created_at: :desc)         # still no SQL
+        .limit(10)
+rel.each { |post| ... }                   # one SELECT, here
+```
+
+### Conditions
+
+Four forms, covering the practical 95%:
+
+```ruby
+Post.local.where(done: false)                      # equality   ... WHERE done = ?
+Post.local.where(id: [1, 2, 3])                    # array      ... WHERE id IN (?, ?, ?)
+Post.local.where(created_at: t1..t2)               # range      ... WHERE created_at BETWEEN ? AND ?
+Post.local.where("published_at < ?", now_iso8601)  # raw SQL fragment with placeholders
+```
+
+Edge semantics are pinned down, ActiveRecord-style:
+
+- `where(deleted_at: nil)` generates `IS NULL`, never `= ?`.
+- `where(id: [])` is an always-empty relation (`WHERE 1=0`), not invalid SQL.
+- An inclusive Range (`1..10`) becomes `>= AND <=`; an exclusive Range
+  (`1...10`) becomes `>= AND <`.
+- Column names in hash conditions and `order` are validated against the
+  model's schema and quoted; unknown columns raise instead of reaching SQL.
+- `offset` without `limit` is legal (emitted as `LIMIT -1 OFFSET n`, which
+  is how SQLite spells it).
+- `count` on a limited/offset relation counts the window (a `COUNT(*)` over
+  a subquery), matching ActiveRecord.
+- `delete_all` raises if the relation carries `order`/`limit`/`offset` --
+  say what you mean with a plain condition. It also exists ONLY for
+  `storage :local` models: on a replica Relation it raises
+  `Funicular::DB::ReplicaWriteError` (writer tab included) -- the server
+  owns replica rows, and deletions reach the replica through write-through
+  `destroy`, never through a local bulk delete.
+- Boolean and datetime values cross the Ruby/SQLite boundary through one
+  shared codec (`true`/`false` <-> 1/0, `Time` <-> ISO 8601 TEXT normalized
+  to UTC at fixed precision -- arbitrary ISO 8601 offsets would not sort
+  chronologically as strings) used identically by writes, reads, and
+  condition binding. The SAME codec is applied when REST responses
+  initialize model instances, so `Post.all` and `Post.local.find` return
+  the same Ruby types for the same attribute.
+
+Multiple `where` calls AND together. `OR`, `JOIN`, `GROUP BY`, and anything
+else SQL can do remain available through the raw-fragment form or, for full
+control, `Funicular::DB.replica.execute(sql, binds)` /
+`Funicular::DB.local.execute(sql, binds)`.
+
+One rule comes with these guarded handles: framework writes all pass through a
+single apply path that fires table change events (which drive `watch`) and
+schedules snapshot persistence. A raw `execute` that WRITES bypasses both.
+Reads need no ceremony, but after writing raw, tell the framework:
+
+```ruby
+Funicular::DB.local.execute("UPDATE drafts SET title = TRIM(title)")
+Funicular::DB.notify_changed(Draft)     # fire watches + schedule persist
+```
+
+`notify_changed` takes the model class (preferred -- it knows both the
+table and which database it lives in) or an explicit pair,
+`notify_changed(:local, :drafts)`; a bare table name would be ambiguous
+between the two databases. Called inside a raw transaction, the
+notification and the persistence scheduling are deferred until commit and
+discarded on rollback, like every framework-internal write.
+
+### Ordering and slicing
+
+```ruby
+Post.local.order(:created_at)                # ASC
+Post.local.order(created_at: :desc)
+Post.local.order(:pinned, created_at: :desc) # multiple keys
+Post.local.limit(20).offset(40)
+```
+
+### Materializers
+
+```ruby
+relation.each { |m| ... }   # enumerate model instances
+relation.to_a               # array of model instances
+relation.first              # instance or nil (adds LIMIT 1)
+relation.count              # SELECT COUNT(*) -- no rows materialized
+relation.exists?            # true/false      -- SELECT 1 LIMIT 1
+```
+
+`Post.local` itself is a Relation over the whole table, so everything hangs
+off it directly:
+
+```ruby
+Post.local.find(42)         # instance, or raises Funicular::RecordNotFound
+Post.local.find_by(id: 42)  # instance or nil
+Post.local.count
+Post.local.first
+Post.local.to_a             # the whole table
+```
+
+Because the `.local` namespace has no REST methods in it, the ActiveRecord
+names are all available with their ActiveRecord semantics -- including
+`find`, which on the bare class remains the REST fetch (`Post.find(id) { }`)
+it has always been.
+
+Rows come back as instances of your model class -- the same class the REST
+mapper returns -- with attribute readers, validations, and associations.
+
+## Writing data
+
+### Replica models: writes go through the server
+
+The server owns replica data, so writes keep their existing REST form -- and
+the local replica follows automatically:
+
+```ruby
+Post.create({ title: "Hello" }) do |post, error|
+  # on success the server's authoritative row was upserted into the replica;
+  # every watch on Post has already re-rendered
+end
+
+post.update(title: "Edited") do |post, error| ... end  # post = updated instance
+post.destroy do |ok, error| ... end                    # ok = true on success
+```
+
+This is called write-through: the framework applies the server's response
+(not your request) to the replica, so the local copy always reflects what the
+server actually stored -- server-side defaults, callbacks, and normalizations
+included. The replica is updated BEFORE your callback runs: inside the
+callback, `Post.local.find(post.id)` already sees the applied row. There is
+no local-write API for replica models in v1; optimistic local writes are a
+possible future layer.
+
+### Local models: writes are local, synchronous, validated
+
+```ruby
+draft = Draft.create(title: "untitled", body: "")   # returns the instance
+draft.update(body: "...")                           # true/false (validations)
+draft.errors                                        # standard validation errors
+draft.destroy                                       # true
+Draft.where("updated_at < ?", cutoff).delete_all    # bulk delete
+```
+
+No blocks -- these cannot fail like a network call can. Validation failures
+report through `valid?`/`errors` exactly like the REST mapper does today.
+
+Local record lifecycle, precisely: a new record is one whose `id` is nil;
+`create` assigns the id from the inserted row. `created_at`/`updated_at`
+(when declared via `t.timestamps`) are maintained automatically; an `update`
+with no actual changes is a no-op that returns true and does not touch
+`updated_at`. SQLite constraint violations (e.g. NOT NULL) escape as
+`SQLite3::Exception` -- they are bugs, not user-facing validation. On
+`storage :local` models the bare class is an alias for `.local`, so
+`Draft.all` returns the whole-table Relation; passing a block to it raises
+(there is no REST side to call).
+
+`delete_all` is the only bulk writer. There is deliberately no `update_all`
+(it would bypass validations); the rare true need is served by raw SQL plus
+`Funicular::DB.notify_changed`.
+
+## Reactivity: `watch`
+
+`watch` is how components consume local data. It binds a state key to a
+Relation:
+
+```ruby
+def component_mounted
+  watch(:todos) { Todo.local.where(done: false).order(:id) }
+end
+```
+
+Semantics -- deliberately simple in v1:
+
+- The block must return a Relation (anything else raises with a helpful
+  message). It runs once immediately; the framework materializes the
+  Relation and places the array in `state[:todos]`.
+- The framework subscribes to the Relation's table. Whenever that table
+  changes -- fetch-through, write-through, local write, wipe -- the block
+  re-runs (and is re-subscribed, in case a branchy block returns a
+  different model's Relation this time) and the key is patched, triggering
+  a re-render.
+- Subscriptions die with the component; unmount cleans up automatically,
+  even when a user lifecycle hook raises on the way out.
+- Re-evaluation is cheap by design: these are microsecond local queries, so
+  the framework can afford table-level (coarse) granularity.
+
+Derived values -- counts, Hashes combining several queries, raw SQL -- use
+the public primitive plus an ordinary `patch`:
+
+```ruby
+def component_mounted
+  @todo_sub = Todo.on_change { patch(open_count: Todo.local.where(done: false).count) }
+  patch(open_count: Todo.local.where(done: false).count)
+end
+
+def component_will_unmount
+  Todo.off_change(@todo_sub)
+end
+```
+
+Delivery guarantees (also for the `on_change` primitive below):
+
+- Change events fire only after the surrounding SQLite transaction commits,
+  and at most once per changed table per transaction -- a 50-row reconcile
+  is one event, not fifty.
+- Watcher updates are queued and coalesced, never delivered inside another
+  component update: a notification arriving mid-`patch` is deferred to the
+  next tick instead of being dropped.
+- A subscriber that raises is isolated: it cannot prevent other subscribers,
+  or the REST callback that triggered the write, from running.
+
+`render` keeps its existing rule: **it reads `state`, nothing else.** `watch`
+exists so that "state" and "live view of the local DB" are the same thing.
+
+## Persistence and durability
+
+SQLite runs in wasm memory; durability comes from snapshotting a whole
+database into IndexedDB. The framework automates the snapshotting, with
+different policies per database:
+
+| | replica DB | local DB |
+|---|---|---|
+| Contains | server-recoverable copies | unrecoverable user data |
+| Auto-persist after a write (`persistent_writer` state only; see Data isolation) | debounced, ~5 s quiet | debounced, ~500 ms quiet |
+| Extra persist | on `visibilitychange` (tab hidden) | on `visibilitychange` |
+| On schema mismatch | dropped and rebuilt | never dropped; migrated |
+
+What this means in practice:
+
+- **A page reload restores both databases from their last snapshot** (when
+  persistence is available -- in the `volatile` state there is no snapshot
+  to come back to). The
+  replica gives you instant first paint from the previous session's data
+  (stale until your fetches revalidate it -- design your
+  screens knowing the first frame may be yesterday's data).
+- **A crash or force-closed tab can lose the seconds since the last
+  snapshot.** For the replica this is a non-event. For local data the
+  window is small (sub-second debounce plus the tab-hidden backstop), but it
+  is not zero: browser storage is best-effort, not a transaction log. Data
+  the user must never lose should eventually reach the server through a REST
+  endpoint; the local DB is not a substitute for that.
+- Browsers may evict IndexedDB under storage pressure. When at least one
+  `storage :local` model is declared -- that is, when data actually worth
+  protecting exists -- the framework requests persistent storage
+  (`navigator.storage.persist()`; note Firefox surfaces this as a user
+  prompt). Replica-only apps never trigger the request. Opt out with
+  `config.request_persistent_storage = false`. Either way, the final word
+  belongs to the browser.
+
+To force a snapshot right now (rarely needed):
+
+```ruby
+Funicular::DB.flush
+```
+
+Persistence runs in the background, and background work can fail (quota
+exceeded, IndexedDB errors). Failures are never silent: they are logged
+prominently, and apps that want to react -- warn the user, disable a form --
+can register a hook:
+
+```ruby
+Funicular::DB.configure do
+  config.on_persist_error = ->(error) { ... }
+end
+```
+
+Snapshot I/O is owned by the framework, not by the SQLite layer: Funicular
+opens the IndexedDB store itself with the automatic in-memory fallback
+DISABLED, so a silently substituted empty store can never masquerade as
+persistence -- unavailability is detected, classified, and announced as the
+`volatile` state instead. Snapshots are stored Base64-encoded (a raw
+SQLite image is a binary String, which does not survive the JS bridge
+intact -- the same encoding the standalone sqlite3 gem uses).
+
+Storage failure at boot has one simple philosophy in v1: **fail loud, fix,
+reload**. There are exactly two behaviors:
+
+- **The browser context has no storage BY DESIGN.** Availability errors on
+  open (missing global, `SecurityError`, `InvalidStateError`) mean private
+  mode or an exotic embedder: the page runs `volatile` (everything works,
+  nothing persists -- see Data isolation).
+- **Anything else fails the boot.** A store open error
+  (`QuotaExceededError`, `UnknownError`, `VersionError`, a `BlockedError`
+  timeout) or a snapshot read error (quota/data on GET) means storage
+  exists but could not be used -- snapshots, including unrecoverable local
+  data, may well be sitting there, so the framework refuses to start on
+  top of them: components do not mount, the failure is written to the
+  console, and `config.on_boot_error` receives it. For a corrupt snapshot
+  (a GET failure -- the store handle exists), the hook may call
+  `Funicular::DB.wipe` to discard it and then reload; for open failures,
+  fix the browser state (quota, blocking tabs) and reload. There is no
+  partial operation on top of unreadable storage.
+
+## Data isolation: users, tabs, and windows
+
+### One namespace per application and user
+
+Snapshots are stored under a namespace built from two parts: an application
+identifier and an opaque user storage key that the Rails server embeds in
+the page (configured once, server-side, via the gem's existing
+configuration API):
+
+```ruby
+# config/initializers/funicular.rb (Rails)
+Funicular.configure do |config|
+  config.application_id = "my_app"          # default: "funicular"
+  config.user_key = ->(controller) {
+    controller.current_user&.storage_key    # see below
+  }
+end
+```
+
+The user key should be a **stable, non-reusable** identifier -- a dedicated
+UUID column is ideal. A raw sequential id works but is discouraged: if your
+app ever deletes and re-issues ids, a new account could inherit an old
+account's snapshot. The value is canonicalized with `to_s`; a signed-out
+visitor gets the shared `anonymous` namespace (shared by every signed-out
+visitor of that browser profile -- treat it as scratch space).
+
+Internally the identity is never a naive string concatenation -- that would
+let `application_id "a:b"` + user `"c"` collide with `"a"` + `"b:c"`, and a
+real user key that happens to be the string `"anonymous"` collide with the
+signed-out namespace. The framework encodes a typed, versioned tuple
+(`["v1", app_id, "anonymous"]` / `["v1", app_id, "user", key]`) as
+canonical JSON, and that ONE encoded identity is used everywhere it
+matters: snapshot keys, the Web Lock name, the previous-identity value in
+the Rails session, and the epoch-rotation comparison.
+
+**Configuring `user_key` is mandatory for apps that use the local
+database.** The gem cannot detect whether your app has authentication, and
+a forgotten `user_key` would silently put every logged-in user into the
+shared `anonymous` namespace AND stop the session epoch from rotating --
+both isolation mechanisms broken at once. So the contract is explicit:
+declare one or the other,
+
+```ruby
+Funicular.configure do |config|
+  config.user_key = ->(controller) { ... }   # apps with authentication
+  # or, for apps that genuinely have no users:
+  config.anonymous_only = true
+end
+```
+
+and an app that declares local-database models without doing either fails
+loudly. The authoritative check runs client-side, in the database boot,
+after every model declaration has been recorded -- the server cannot always
+know at render time whether client-side local-DB models exist, so the
+helper embeds "unconfigured" metadata as-is and the server raises only in
+the cases it can detect reliably. Setting BOTH `user_key` and
+`anonymous_only` is also a configuration error -- the framework never picks
+one silently.
+
+The namespace and epoch metadata reach the page through
+`picoruby_include_tag` -- the helper every Funicular layout already has --
+as HTML-escaped data attributes, so CSR-only and local-only apps need no
+new helper and no template change.
+
+At boot the client opens only the current namespace's databases. Table
+names, SQL, and your model code are untouched by any of this -- isolation
+happens entirely at the snapshot layer. When user B signs in on a machine
+where user A never logged out (or the browser crashed), user B's boot opens
+user B's namespace and never restores user A's replica or drafts. Cross-user
+isolation does not depend on any logout code running. A pleasant side
+effect on shared machines: when user A signs back in, their drafts are
+still there. (Scope this correctly, though: namespacing stops the FRAMEWORK
+from mixing users' data. It is not a security boundary against JavaScript
+already running in the same origin -- browser storage never is.)
+
+If more than one Funicular application shares an origin, give each a
+distinct `application_id`.
+
+### The session epoch: when the user changes under a running tab
+
+All tabs of a profile share one cookie session, so a login/logout in tab B
+silently changes who tab A's requests authenticate as -- and GET requests
+carry no CSRF check, so they would keep succeeding as the new user. Left
+alone, tab A would apply and persist user B's data into user A's namespace.
+
+The framework prevents this with a session epoch, distinct from the storage
+key: an opaque value that changes on every authentication transition. It is
+managed entirely by the gem -- no application code: the Railtie keeps the
+epoch in the Rails session and rotates it (SecureRandom) whenever the
+computed `user_key` differs from the one the session was stamped with, so
+login, logout, and direct user switches all rotate it. Every REST and
+schema response carries the current epoch (an `X-Funicular-Epoch` header);
+the client compares it against the epoch it booted with.
+
+A response entering the apply path with a MISSING epoch header is treated
+exactly like a mismatch -- fail closed, never fail open (a stale cached
+response must not sneak through).
+
+On mismatch the page enters a TERMINAL invalid-session state:
+
+1. the offending response is discarded (never applied to any table),
+2. from that moment on, replica applies, `storage :local` writes, raw
+   writes, and snapshot persistence are ALL refused -- permanently, for the
+   life of the page; a custom hook that chooses not to reload cannot
+   re-enable them,
+3. the `config.on_session_change` hook runs -- its default reloads the
+   page, after which the tab boots cleanly in the new session's namespace.
+
+The terminal flag is an irreversible latch, independent of the durability
+state.
+
+A WRITER tab entering terminal steps down completely: pending debounce
+timers are cancelled, any persist already in flight is serialized with,
+and then the lock-holding promise is resolved so the writer lock is
+RELEASED -- a terminal tab that a custom hook chose not to reload must not
+sit on the old namespace's lock forever, condemning that user's next tab to
+permanent reader status. Its connections remain as a non-persistent read
+view of the moment it died.
+
+Override the hook to show a "you were signed out" dialog instead; what you
+cannot do is keep operating, because the page's data and the session no
+longer belong to the same user.
+
+### One writer per namespace (multiple tabs)
+
+Each tab holds its own in-memory SQLite image; two tabs snapshotting the
+same name would silently overwrite each other ("last persist wins"). The
+framework therefore elects a single writer per namespace using a Web Lock:
+
+Every page runs in exactly one of three durability states:
+
+- **`persistent_writer`** -- the tab holding the lock. Restores snapshots,
+  persists, writes locally and to the replica. Exactly one per namespace.
+- **`persistent_reader`** -- any additional tab, for the LIFE of the page.
+  The replica works fully (restored from the latest snapshot; fetch-through
+  still applies -- those are in-memory replica writes and are allowed) but
+  is never persisted. Writes to `storage :local` models raise
+  `Funicular::DB::ReadOnlyTabError`: unrecoverable data is never written
+  where it would be silently lost. To write, reload after the writer tab
+  has closed -- there is no in-page promotion in v1.
+- **`volatile`** -- everything works, including `storage :local` writes,
+  but NOTHING persists: no snapshot restore-to-disk path exists at all
+  (persist, flush, and the auto-persist on close are disabled). This is
+  the state when coordination or storage is unavailable (below) -- the app
+  stays fully functional, durability is honestly zero, and a prominent
+  error is logged (plus `config.on_persist_error` once at boot). (The name
+  is deliberately NOT "ephemeral": `storage :ephemeral` is a model
+  declaration, an unrelated concept.)
+
+Which state a page gets -- decided instantly at boot, never by waiting:
+
+- Web Locks available: boot requests the lock with `ifAvailable: true`,
+  which returns immediately. Granted -> `persistent_writer` (the lock is
+  held with a promise that resolves only on page teardown); not granted ->
+  `persistent_reader`, permanently for this page.
+- Web Locks API unavailable (very old browsers, some embedded WebViews) ->
+  `volatile`; with no way to coordinate, running uncoordinated persistent
+  writers is the one thing that must never happen.
+- IndexedDB unavailable (blocking private modes) -> `volatile`.
+
+Enforcement lives BELOW the model layer, not in politeness:
+`Funicular::DB.local` / `.replica` hand out guarded proxy handles, never
+the underlying `SQLite3::Database`. The proxy's surface is an explicit
+allowlist, closed against leaking the raw connection: `transaction` is
+implemented by the proxy and yields THE PROXY (never the raw database, as
+the underlying gem's `transaction` would); `prepare` returns a guarded
+statement subject to the same checks; batch execution, `deserialize`, and
+manual `commit`/`rollback` are classified the same way. On a
+`persistent_reader` tab the LOCAL connection runs with
+`PRAGMA query_only = ON` (the replica connection stays writable in memory
+for revalidation) and raw local writes fail. `persist` and `close` are not
+on the proxy surface AT ALL, on any tab: the framework's databases are
+unbound memory databases whose snapshots live in Funicular's own store, so
+the SQLite-level `persist` has no valid target, and `close` would destroy
+a framework-owned connection (the framework closes its connections
+internally, without persisting). Persistence is exclusively
+`Funicular::DB.flush` and the automatic debounce. On a non-writer tab,
+`flush` / `wipe` / `reset_local` raise `ReadOnlyTabError`. There is no
+sequence of public API calls by which a non-writer tab can overwrite the
+snapshot.
+
+And `query_only` itself is guarded -- SQLite's pragma is settable, so it is
+not, by itself, a read-only guarantee. In any read-only state the proxy
+checks every statement at EXECUTION time (not just preparation time) using
+SQLite's own writes-or-not classification (`sqlite3_stmt_readonly`,
+exposed as `Statement#readonly?`), converts write statements into the
+appropriate framework exception, and separately rejects
+connection-state-changing statements that SQLite classifies as "read-only"
+(`PRAGMA query_only`, `ATTACH`, `DETACH`). Batch execution is refused
+outright in read-only states.
+
+Reader-to-writer promotion and cross-tab live synchronization
+(BroadcastChannel) are post-v1 concerns. A reader tab that needs to write
+reloads once the writer tab is gone -- one keypress, zero protocol.
+
+### Private/incognito windows
+
+An incognito window is a separate storage partition: separate cookies,
+separate IndexedDB, separate Web Locks. A normal window and an incognito
+window can therefore even be signed in as different users simultaneously
+without seeing or clobbering each other. Within the incognito session
+everything works normally (multiple incognito tabs share one partition and
+one writer lock), but the partition's IndexedDB is ephemeral: snapshots --
+including `storage :local` data -- vanish when the last incognito window
+closes, which is exactly what private mode promises the user. Browsers that
+block IndexedDB in private mode entirely are detected at open time: the
+IndexedDB bridge preserves the DOMException name, and only the explicitly
+listed availability errors (missing global, `SecurityError`,
+`InvalidStateError` on open) drop the page to the `volatile` state -- the
+app still runs, nothing persists. Quota and ordinary data errors do NOT
+silently fall back: switching to an empty in-memory store would masquerade
+as losing the user's previously persisted data, so those surface through
+logging and `config.on_persist_error` instead. (`onblocked` is not an
+availability failure either; it waits and times out with its own error.)
+
+## Logout: wiping local data
+
+Because namespaces already isolate users, `wipe` is a cleanup tool, not a
+security requirement. Call it when the product wants no trace left on the
+machine (shared terminals, "clear local data" policies):
+
+```ruby
+Funicular::DB.wipe
+```
+
+One call drops every table in both databases of the CURRENT namespace and
+deletes its snapshots -- the two namespaced keys in Funicular's own
+snapshot store. There is no per-model opt-out; a wipe is a wipe -- partial
+wipes are how leftovers happen. (This is also the recovery path when a
+local snapshot became unreadable; see Persistence.)
+
+`wipe` runs on the writer tab (on a non-writer tab it raises
+`ReadOnlyTabError`, like every destructive operation there). On the writer
+it is safe to call at any moment, mid-flight included:
+
+- REST responses that were already in flight when the wipe happened are
+  discarded, not re-applied -- a logout can never resurrect the previous
+  session's rows.
+- Pending persistence timers are cancelled; an in-progress snapshot cannot
+  overwrite the cleared state.
+- Watches fire after the databases are rebuilt and queryable again, so
+  components re-render onto empty tables rather than crashing onto missing
+  ones.
+
+## Server-side rendering
+
+Local queries do not exist on the server. SSR pages are for SEO and first
+paint; they render from server data passed via `state:`, exactly as before.
+
+If a component's server-side render path reaches a local query, it raises
+`Funicular::DB::UnavailableError` with a pointed message -- deliberately loud,
+because silently rendering an empty list would defeat SSR and hide the bug.
+The practical rule: components rendered through SSR read their data from
+state seeded by the controller; `watch`-driven components belong on
+client-rendered routes (or behind `Funicular.server?` guards in
+`component_mounted`, which SSR never calls anyway).
+
+## Configuration
+
+Optional, in `app/funicular/initializer.rb`:
+
+```ruby
+Funicular::DB.configure do
+  config.replica_debounce_ms         = 5000   # default
+  config.local_debounce_ms           = 500    # default
+  config.request_persistent_storage  = true   # default; see Persistence
+  config.on_persist_error            = nil    # ->(error) { ... }
+  config.on_boot_error               = nil    # ->(errors) { ... }; see boot
+  config.on_session_change           = nil    # default behavior: reload page
+end
+```
+
+The user/application namespace and session epoch are configured on the
+Rails side (`Funicular.configure` -- see Data isolation), not here. Future
+knobs (focus-time revalidation, for one) will land here rather than as new
+method surface.
+
+## Limitations and sharp edges (v1)
+
+- **Whole-database snapshots.** Persistence cost scales with database size,
+  not change size. Replicating tens of thousands of rows will make the
+  5-second snapshot noticeable; replicate what your screens need, not your
+  whole warehouse.
+- **Memory-bound.** Both databases live in wasm memory. Same advice.
+- **Binary attributes are not replicated.** This is wire-format reality, not
+  a policy: binary attributes never ride the REST JSON in the first place
+  (they travel through `Funicular::FileUpload`), so there is nothing to put
+  in the replica. Assets that should live client-side (images, files) belong
+  to Blob/object URLs or the Cache API, not a relational table.
+- **Replica rows need an `id`.** Fetch-through upserts key on it. The
+  local `id` column follows the type the
+  server schema declares -- `INTEGER PRIMARY KEY` for integer ids,
+  `TEXT PRIMARY KEY` for UUID-keyed models. A schema-loaded model whose
+  schema has no `id` cannot be replicated: schema loading raises and the
+  message tells you to declare `storage :ephemeral` on it.
+- **A local query can yield.** Today queries never suspend, but the runtime
+  reserves the right (a future VFS may perform I/O per statement). Do not
+  assume the world cannot change between two separate queries; a single
+  query is always internally consistent.
+- **`JOIN`, `OR`, aggregates** beyond `count`: raw SQL escape hatch only.
+- **No optimistic writes** for replica models: a `create`/`update` shows up
+  locally when the server confirms it, not before.
+
+## Relationship to `Funicular::Store`
+
+The local database supersedes the Store layer (`Funicular::Store`,
+`Store::Singleton`, `Store::Collection`). Store remains available and
+unchanged for now, but no new features will build on it, and it will be
+deprecated and removed once `refresh :live` ships. New code should use models
+and `watch`.

--- a/docs/local_database.md
+++ b/docs/local_database.md
@@ -334,7 +334,10 @@ How migrations run:
   baseline definition and then receives the later blocks; a database at or
   above the baseline receives only its missing later blocks. Application is
   per table, inside one transaction; failure rolls back and raises -- user
-  data is never left half-migrated.
+  data is never left half-migrated. Each `migrate` block is evaluated
+  exactly once per migration run (the framework validates and applies the
+  same recorded operations); it also runs when column metadata is first
+  needed, so keep blocks deterministic and free of side effects.
 - If any table's stored version is NEWER than the declared maximum (a
   rolled-back deploy), the WHOLE local database fails loud: every
   local-model operation -- read or write, any table -- raises

--- a/lib/funicular.rb
+++ b/lib/funicular.rb
@@ -2,6 +2,7 @@
 
 require_relative "funicular/version"
 require_relative "funicular/configuration"
+require_relative "funicular/session_epoch"
 require_relative "funicular/compiler"
 require_relative "funicular/plugin"
 require_relative "funicular/schema"

--- a/lib/funicular/assets/funicular.rb
+++ b/lib/funicular/assets/funicular.rb
@@ -19,3 +19,17 @@ Rails.autoloaders.main.ignore(Rails.root.join("app/funicular"))
 #   config.production_source = :cdn
 #   # config.cdn_version = "4.0.0"  # defaults to the version vendored in the gem
 # end
+
+# Local database (SQLite in the browser, docs/local_database.md):
+# disabled by default. Opting in also requires declaring how browser
+# storage is namespaced -- a user_key resolver for apps with
+# authentication, or anonymous_only for apps without users.
+#
+# Funicular.configure do |config|
+#   config.local_database = true
+#   config.user_key = ->(controller) {
+#     controller.request.session[:user_id]&.to_s
+#   }
+#   # or, for apps that genuinely have no users:
+#   # config.anonymous_only = true
+# end

--- a/lib/funicular/configuration.rb
+++ b/lib/funicular/configuration.rb
@@ -26,6 +26,7 @@ module Funicular
     SOURCES = %i[local_debug local_dist cdn].freeze
 
     attr_reader :development_source, :test_source, :production_source
+    attr_reader :application_id, :user_key, :anonymous_only
     attr_writer :cdn_version
 
     def initialize
@@ -33,6 +34,49 @@ module Funicular
       @test_source        = :local_debug
       @production_source  = :local_dist
       @cdn_version        = nil
+      @application_id     = "funicular"
+      @user_key           = nil
+      @anonymous_only     = false
+    end
+
+    # The application's namespace id (docs: local_database.md, data
+    # isolation). Give each Funicular app sharing an origin a distinct
+    # one; it keys the client's snapshot/lock namespace AND the epoch
+    # entry in the Rails session.
+    def application_id=(value)
+      id = value.to_s
+      if id.empty?
+        raise ArgumentError, "Funicular application_id cannot be empty"
+      end
+      @application_id = id
+    end
+
+    # A callable receiving the controller and returning a stable,
+    # non-reusable identifier for the signed-in user (nil when signed
+    # out). Mandatory for apps that declare local-database models,
+    # unless anonymous_only says the app genuinely has no users.
+    def user_key=(value)
+      unless value.respond_to?(:call)
+        raise ArgumentError,
+              "Funicular user_key must be callable (a lambda receiving the controller)"
+      end
+      if @anonymous_only
+        raise ArgumentError,
+              "Funicular user_key and anonymous_only are mutually exclusive; declare one or the other"
+      end
+      @user_key = value
+    end
+
+    # The explicit opt-out for apps without authentication: every
+    # visitor shares the anonymous namespace ON PURPOSE. Mutually
+    # exclusive with user_key -- the framework never picks silently.
+    def anonymous_only=(value)
+      flag = value ? true : false
+      if flag && @user_key
+        raise ArgumentError,
+              "Funicular user_key and anonymous_only are mutually exclusive; declare one or the other"
+      end
+      @anonymous_only = flag
     end
 
     def development_source=(value)

--- a/lib/funicular/configuration.rb
+++ b/lib/funicular/configuration.rb
@@ -26,7 +26,7 @@ module Funicular
     SOURCES = %i[local_debug local_dist cdn].freeze
 
     attr_reader :development_source, :test_source, :production_source
-    attr_reader :application_id, :user_key, :anonymous_only
+    attr_reader :application_id, :user_key, :anonymous_only, :local_database
     attr_writer :cdn_version
 
     def initialize
@@ -37,6 +37,27 @@ module Funicular
       @application_id     = "funicular"
       @user_key           = nil
       @anonymous_only     = false
+      @local_database     = false
+    end
+
+    # The SQLite/IndexedDB subsystem is deliberately opt-in. A plain
+    # Funicular application remains REST-only and pays none of its boot,
+    # storage, locking, or session-epoch costs.
+    def local_database=(value)
+      @local_database = value ? true : false
+    end
+
+    # Called after Rails initializers and again when the include tag is
+    # rendered. The client boot separately validates the emitted contract.
+    # Validation cannot run from local_database= because initializer
+    # assignment order is free.
+    def validate_local_database!
+      return true unless @local_database
+      return true if @user_key || @anonymous_only
+
+      raise ArgumentError,
+            "Funicular local_database requires config.user_key or " \
+            "config.anonymous_only = true"
     end
 
     # The application's namespace id (docs: local_database.md, data
@@ -53,8 +74,8 @@ module Funicular
 
     # A callable receiving the controller and returning a stable,
     # non-reusable identifier for the signed-in user (nil when signed
-    # out). Mandatory for apps that declare local-database models,
-    # unless anonymous_only says the app genuinely has no users.
+    # out). Mandatory whenever the local database is enabled, unless
+    # anonymous_only says the app genuinely has no users.
     def user_key=(value)
       unless value.respond_to?(:call)
         raise ArgumentError,

--- a/lib/funicular/epoch_header.rb
+++ b/lib/funicular/epoch_header.rb
@@ -22,6 +22,9 @@ module Funicular
   # session and no env value the header is simply absent, exactly as
   # before the request.
   class EpochHeader
+    # Every spelling of the header this middleware owns.
+    OWNED_HEADERS = [EpochStamping::HEADER, "X-Funicular-Epoch"].freeze
+
     def initialize(app)
       @app = app
     end
@@ -29,19 +32,19 @@ module Funicular
     def call(env)
       status, headers, body = @app.call(env)
       return [status, headers, body] unless Funicular.configuration.local_database
+      # This header is the framework's to write, so an inner layer's
+      # value is dropped FIRST and unconditionally: a stale one
+      # (stamped before a login/logout rotated the epoch) would let an
+      # old page read the post-transition response as a match --
+      # exactly the boundary decision 13 exists to keep closed. Leaving
+      # it in place when no authoritative epoch is available would be
+      # the same hole with none of the excuses. Both spellings go:
+      # plain header hashes are case-sensitive, so a legacy-cased
+      # duplicate would otherwise ride out alongside our lowercase
+      # (Rack 3) name.
+      OWNED_HEADERS.each { |name| headers.delete(name) }
       epoch = env[EpochStamping::ENV_KEY] || stored_epoch(env)
-      if epoch
-        # The framework's epoch is AUTHORITATIVE and overwrites
-        # whatever an inner layer set: a stale value there (stamped
-        # before a login/logout rotated the epoch) would let an old
-        # page apply the post-transition response as a match --
-        # exactly the boundary decision 13 exists to keep closed. The
-        # capitalized spelling goes too: plain header hashes are
-        # case-sensitive, and a legacy-cased duplicate would otherwise
-        # ride out alongside our lowercase (Rack 3) name.
-        headers.delete("X-Funicular-Epoch")
-        headers[EpochStamping::HEADER] = epoch
-      end
+      headers[EpochStamping::HEADER] = epoch if epoch
       [status, headers, body]
     end
 

--- a/lib/funicular/epoch_header.rb
+++ b/lib/funicular/epoch_header.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require_relative "session_epoch"
+require_relative "epoch_stamping"
+
+module Funicular
+  # Rack middleware writing the X-Funicular-Epoch header onto EVERY
+  # response -- the exception pages ActionDispatch renders included.
+  # A controller-level after_action cannot guarantee that: it never
+  # runs when the action raises, and a header-less 500 reads as an
+  # epoch mismatch client-side, terminating a healthy page over a mere
+  # server error. The Railtie inserts this above
+  # ActionDispatch::ShowExceptions, so the freshly-built exception
+  # response passes through here too.
+  #
+  # The controller concern (EpochStamping) owns the ROTATION -- the
+  # user_key lambda needs its controller -- and leaves the epoch in the
+  # request env; this middleware only writes the header. When the
+  # request died before the concern ran, the stored session epoch
+  # (read without rotating) is the best truthful answer; with no
+  # session and no env value the header is simply absent, exactly as
+  # before the request.
+  class EpochHeader
+    def initialize(app)
+      @app = app
+    end
+
+    def call(env)
+      status, headers, body = @app.call(env)
+      epoch = env[EpochStamping::ENV_KEY] || stored_epoch(env)
+      if epoch
+        # The framework's epoch is AUTHORITATIVE and overwrites
+        # whatever an inner layer set: a stale value there (stamped
+        # before a login/logout rotated the epoch) would let an old
+        # page apply the post-transition response as a match --
+        # exactly the boundary decision 13 exists to keep closed. The
+        # capitalized spelling goes too: plain header hashes are
+        # case-sensitive, and a legacy-cased duplicate would otherwise
+        # ride out alongside our lowercase (Rack 3) name.
+        headers.delete("X-Funicular-Epoch")
+        headers[EpochStamping::HEADER] = epoch
+      end
+      [status, headers, body]
+    end
+
+    private
+
+    def stored_epoch(env)
+      session = env["rack.session"]
+      return nil unless session
+      epochs = session[SessionEpoch::SESSION_KEY]
+      return nil unless epochs.is_a?(Hash)
+      entry = epochs[Funicular.configuration.application_id]
+      return nil unless entry.is_a?(Hash)
+      epoch = entry["epoch"].to_s
+      epoch.empty? ? nil : epoch
+    rescue StandardError
+      # Best effort on the exception path: masking the original error
+      # with a session-read failure would be worse than a missing
+      # header.
+      nil
+    end
+  end
+end

--- a/lib/funicular/epoch_header.rb
+++ b/lib/funicular/epoch_header.rb
@@ -4,8 +4,9 @@ require_relative "session_epoch"
 require_relative "epoch_stamping"
 
 module Funicular
-  # Rack middleware writing the X-Funicular-Epoch header onto EVERY
-  # response -- the exception pages ActionDispatch renders included.
+  # With the local database enabled, this Rack middleware writes the
+  # X-Funicular-Epoch header onto EVERY response -- the exception pages
+  # ActionDispatch renders included. Disabled responses are returned untouched.
   # A controller-level after_action cannot guarantee that: it never
   # runs when the action raises, and a header-less 500 reads as an
   # epoch mismatch client-side, terminating a healthy page over a mere
@@ -27,6 +28,7 @@ module Funicular
 
     def call(env)
       status, headers, body = @app.call(env)
+      return [status, headers, body] unless Funicular.configuration.local_database
       epoch = env[EpochStamping::ENV_KEY] || stored_epoch(env)
       if epoch
         # The framework's epoch is AUTHORITATIVE and overwrites

--- a/lib/funicular/epoch_stamping.rb
+++ b/lib/funicular/epoch_stamping.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require_relative "session_epoch"
+
+module Funicular
+  # Controller mixin installed by the Railtie: rotates the session
+  # epoch where the user_key lambda has its controller, and leaves the
+  # value in the request env for the EpochHeader middleware to write
+  # out (docs decision 13).
+  #
+  # The header itself is deliberately NOT set here: a controller-set
+  # header dies with the controller's response when the action raises,
+  # and the exception page ActionDispatch renders would go out
+  # header-less -- which the client must treat as an epoch mismatch,
+  # terminating a healthy page over a mere 500.
+  #
+  # The epoch is stamped TWICE around the action. Before it, so a
+  # mid-action exception still sends a truthful value; and again in
+  # the ensure, with the POST-action identity, because the very
+  # actions that log a user in or out change the identity INSIDE the
+  # action -- their own response must already carry the rotated epoch,
+  # not leave the rotation to the next request (an old page would
+  # apply the login response as a match).
+  module EpochStamping
+    # Lowercase per the Rack 3 spec (response header names MUST be
+    # lowercase; Rack::Lint enforces it). HTTP header names are
+    # case-insensitive on the wire, so the client contract is
+    # unchanged.
+    HEADER = "x-funicular-epoch"
+    ENV_KEY = "funicular.epoch"
+
+    def self.included(base)
+      base.around_action :stamp_funicular_epoch if base.respond_to?(:around_action)
+    end
+
+    private
+
+    def stamp_funicular_epoch
+      unless Funicular::SessionEpoch.session_available?(session)
+        # No session middleware (API-only Rails): there is no cookie
+        # identity for the epoch to protect, so the feature stays off
+        # instead of breaking every action with a disabled-session
+        # error.
+        return yield
+      end
+      request.env[ENV_KEY] = Funicular::SessionEpoch.stamp!(session, self)
+      yield
+    ensure
+      if Funicular::SessionEpoch.session_available?(session)
+        request.env[ENV_KEY] = Funicular::SessionEpoch.stamp!(session, self)
+      end
+    end
+  end
+end

--- a/lib/funicular/epoch_stamping.rb
+++ b/lib/funicular/epoch_stamping.rb
@@ -35,21 +35,31 @@ module Funicular
 
     private
 
+    # request.session, never the controller's session accessor: an
+    # application action named "session" SHADOWS the accessor, and
+    # calling it from here would invoke the action itself (rendering
+    # twice). The ensure re-reads request.session instead of reusing
+    # the pre-action object because reset_session (a logout) replaces
+    # it mid-action.
     def stamp_funicular_epoch
       local_database = Funicular.configuration.local_database
       return yield unless local_database
-      unless Funicular::SessionEpoch.session_available?(session)
+      sess = request.session
+      unless Funicular::SessionEpoch.session_available?(sess)
         # No session middleware (API-only Rails): there is no cookie
         # identity for the epoch to protect, so the feature stays off
         # instead of breaking every action with a disabled-session
         # error.
         return yield
       end
-      request.env[ENV_KEY] = Funicular::SessionEpoch.stamp!(session, self)
+      request.env[ENV_KEY] = Funicular::SessionEpoch.stamp!(sess, self)
       yield
     ensure
-      if local_database && Funicular::SessionEpoch.session_available?(session)
-        request.env[ENV_KEY] = Funicular::SessionEpoch.stamp!(session, self)
+      if local_database
+        sess = request.session
+        if Funicular::SessionEpoch.session_available?(sess)
+          request.env[ENV_KEY] = Funicular::SessionEpoch.stamp!(sess, self)
+        end
       end
     end
   end

--- a/lib/funicular/epoch_stamping.rb
+++ b/lib/funicular/epoch_stamping.rb
@@ -3,10 +3,10 @@
 require_relative "session_epoch"
 
 module Funicular
-  # Controller mixin installed by the Railtie: rotates the session
-  # epoch where the user_key lambda has its controller, and leaves the
-  # value in the request env for the EpochHeader middleware to write
-  # out (docs decision 13).
+  # Controller mixin installed by the Railtie: when the local database is
+  # enabled, it rotates the session epoch where the user_key lambda has its
+  # controller, and leaves the value in the request env for the EpochHeader
+  # middleware to write out (docs decision 13).
   #
   # The header itself is deliberately NOT set here: a controller-set
   # header dies with the controller's response when the action raises,
@@ -36,6 +36,8 @@ module Funicular
     private
 
     def stamp_funicular_epoch
+      local_database = Funicular.configuration.local_database
+      return yield unless local_database
       unless Funicular::SessionEpoch.session_available?(session)
         # No session middleware (API-only Rails): there is no cookie
         # identity for the epoch to protect, so the feature stays off
@@ -46,7 +48,7 @@ module Funicular
       request.env[ENV_KEY] = Funicular::SessionEpoch.stamp!(session, self)
       yield
     ensure
-      if Funicular::SessionEpoch.session_available?(session)
+      if local_database && Funicular::SessionEpoch.session_available?(session)
         request.env[ENV_KEY] = Funicular::SessionEpoch.stamp!(session, self)
       end
     end

--- a/lib/funicular/helpers/picoruby_helper.rb
+++ b/lib/funicular/helpers/picoruby_helper.rb
@@ -18,6 +18,15 @@ module Funicular
         local_dist:  "dist"
       }.freeze
 
+      LOCAL_DATABASE_METADATA_KEYS = %i[
+        funicular_local_database
+        funicular_application_id
+        funicular_user_key
+        funicular_user_key_configured
+        funicular_anonymous_only
+        funicular_epoch
+      ].freeze
+
       # Minimal CSS the gem ships for class names it emits itself (e.g.
       # FormBuilder error states). Read once; see assets/funicular.css.
       BASE_CSS_PATH = File.expand_path("../assets/funicular.css", __dir__)
@@ -40,11 +49,10 @@ module Funicular
       # base_styles: false to skip it. Any extra options become HTML attributes
       # on the <script> tag.
       #
-      # The tag also carries the local-database page metadata as
+      # When opted in, the tag also carries the local-database page metadata as
       # data-funicular-* attributes (docs: local_database.md, data
       # isolation): the application id, the user-key contract, and the
-      # session epoch. The client boot reads them off the page; apps
-      # without the local database just ignore them.
+      # session epoch. With the feature disabled these attributes are omitted.
       def picoruby_include_tag(source: nil, base_styles: true, **options)
         resolved_source = source ? source.to_sym : Funicular.configuration.source_for(Rails.env)
         src = picoruby_src_for(resolved_source)
@@ -55,8 +63,16 @@ module Funicular
         # a string or dashed spelling cannot smuggle in a duplicate of
         # the same HTML attribute either.
         data = {}
-        (options.delete(:data) || {}).each do |key, value|
-          data[key.to_s.tr("-", "_").to_sym] = value
+        caller_data = (options.delete(:data) || {}).to_a
+        i = 0
+        caller_data_size = caller_data.size
+        while i < caller_data_size
+          key, value = caller_data[i]
+          normalized = key.to_s.tr("-", "_").to_sym
+          unless LOCAL_DATABASE_METADATA_KEYS.include?(normalized)
+            data[normalized] = value
+          end
+          i += 1
         end
         data.merge!(funicular_page_metadata)
         script = tag.script("", src: src, data: data, **options)
@@ -125,8 +141,13 @@ module Funicular
       # can never disagree at render time.
       def funicular_page_metadata
         config = Funicular.configuration
+        return {} unless config.local_database
+        config.validate_local_database!
         ctrl = respond_to?(:controller) ? controller : nil
-        meta = { funicular_application_id: config.application_id }
+        meta = {
+          funicular_local_database: "true",
+          funicular_application_id: config.application_id,
+        }
         meta[:funicular_anonymous_only] = "true" if config.anonymous_only
         # ONE resolver evaluation feeds both the page attribute and the
         # epoch identity below: two evaluations could disagree

--- a/lib/funicular/helpers/picoruby_helper.rb
+++ b/lib/funicular/helpers/picoruby_helper.rb
@@ -75,6 +75,14 @@ module Funicular
           i += 1
         end
         data.merge!(funicular_page_metadata)
+        # The same contract values can arrive as TOP-LEVEL options too
+        # ("data-funicular-epoch" => ..., or data_funicular_epoch:).
+        # Left in options they reach the tag builder unfiltered and
+        # emit a second copy of an attribute the metadata owns -- or,
+        # with the feature disabled, the only copy.
+        options.keys.each do |key|
+          options.delete(key) if reserved_metadata_option?(key)
+        end
         script = tag.script("", src: src, data: data, **options)
         return script unless base_styles
 
@@ -130,6 +138,18 @@ module Funicular
       end
 
       private
+
+      # True for every top-level spelling of a key the page metadata
+      # owns: "data-funicular-epoch", :"data-funicular-epoch", and the
+      # underscored data_funicular_epoch the tag builder dasherizes.
+      # Other data- attributes are the caller's business and survive.
+      def reserved_metadata_option?(key)
+        normalized = key.to_s.tr("-", "_")
+        return false unless normalized.start_with?("data_")
+
+        LOCAL_DATABASE_METADATA_KEYS.include?(
+          normalized.delete_prefix("data_").to_sym)
+      end
 
       # The namespace + epoch metadata the client boot reads
       # (DB.read_page_metadata): attribute values are HTML-escaped by

--- a/lib/funicular/helpers/picoruby_helper.rb
+++ b/lib/funicular/helpers/picoruby_helper.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "funicular/session_epoch"
+
 module Funicular
   module Helpers
     # View helpers exposed to ActionView through Funicular::Railtie.
@@ -37,10 +39,27 @@ module Funicular
       # such as form error states render without host-CSS setup); pass
       # base_styles: false to skip it. Any extra options become HTML attributes
       # on the <script> tag.
+      #
+      # The tag also carries the local-database page metadata as
+      # data-funicular-* attributes (docs: local_database.md, data
+      # isolation): the application id, the user-key contract, and the
+      # session epoch. The client boot reads them off the page; apps
+      # without the local database just ignore them.
       def picoruby_include_tag(source: nil, base_styles: true, **options)
         resolved_source = source ? source.to_sym : Funicular.configuration.source_for(Rails.env)
         src = picoruby_src_for(resolved_source)
-        script = tag.script("", src: src, **options)
+        # Caller extras survive, but the framework's contract values
+        # always win: a data: override of the epoch or the user key
+        # would make the page disagree with its own responses (instant
+        # terminal) or boot the wrong namespace. Keys are normalized so
+        # a string or dashed spelling cannot smuggle in a duplicate of
+        # the same HTML attribute either.
+        data = {}
+        (options.delete(:data) || {}).each do |key, value|
+          data[key.to_s.tr("-", "_").to_sym] = value
+        end
+        data.merge!(funicular_page_metadata)
+        script = tag.script("", src: src, data: data, **options)
         return script unless base_styles
 
         style = tag.style(PicorubyHelper.base_css.html_safe, "data-funicular-base": "")
@@ -95,6 +114,37 @@ module Funicular
       end
 
       private
+
+      # The namespace + epoch metadata the client boot reads
+      # (DB.read_page_metadata): attribute values are HTML-escaped by
+      # the tag helper, so hostile application ids or user keys cannot
+      # break out of the attribute. The user-key attribute is OMITTED
+      # for signed-out visitors (the client boots the anonymous
+      # namespace), and the epoch is stamped through the same session
+      # entry the response header uses -- the page and its responses
+      # can never disagree at render time.
+      def funicular_page_metadata
+        config = Funicular.configuration
+        ctrl = respond_to?(:controller) ? controller : nil
+        meta = { funicular_application_id: config.application_id }
+        meta[:funicular_anonymous_only] = "true" if config.anonymous_only
+        # ONE resolver evaluation feeds both the page attribute and the
+        # epoch identity below: two evaluations could disagree
+        # mid-transition and stamp one user's epoch onto another
+        # user's page namespace.
+        key = nil
+        if config.user_key
+          meta[:funicular_user_key_configured] = "true"
+          key = Funicular::SessionEpoch.user_key(ctrl)
+          meta[:funicular_user_key] = key if key
+        end
+        if respond_to?(:session) &&
+           Funicular::SessionEpoch.session_available?(session)
+          meta[:funicular_epoch] = Funicular::SessionEpoch.stamp_identity!(
+            session, Funicular::SessionEpoch.identity_for(key))
+        end
+        meta
+      end
 
       def picoruby_src_for(source)
         if source == :cdn

--- a/lib/funicular/helpers/picoruby_helper.rb
+++ b/lib/funicular/helpers/picoruby_helper.rb
@@ -159,10 +159,14 @@ module Funicular
           key = Funicular::SessionEpoch.user_key(ctrl)
           meta[:funicular_user_key] = key if key
         end
-        if respond_to?(:session) &&
-           Funicular::SessionEpoch.session_available?(session)
+        # The view's session helper delegates to the controller, where
+        # an action named "session" shadows the accessor -- go through
+        # request.session, which cannot be shadowed.
+        req = respond_to?(:request) ? request : nil
+        sess = req && req.session
+        if sess && Funicular::SessionEpoch.session_available?(sess)
           meta[:funicular_epoch] = Funicular::SessionEpoch.stamp_identity!(
-            session, Funicular::SessionEpoch.identity_for(key))
+            sess, Funicular::SessionEpoch.identity_for(key))
         end
         meta
       end

--- a/lib/funicular/railtie.rb
+++ b/lib/funicular/railtie.rb
@@ -19,6 +19,26 @@ module Funicular
       end
     end
 
+    initializer "funicular.epoch" do |app|
+      # Every response carries X-Funicular-Epoch (docs decision 13):
+      # the controller concern rotates the epoch, the middleware writes
+      # the header. The middleware sits ABOVE the exception renderer so
+      # even a 500 page carries it -- a header-less error response
+      # would terminal the client over a mere server error.
+      require "funicular/epoch_header"
+      if defined?(ActionDispatch::ShowExceptions)
+        app.middleware.insert_before ActionDispatch::ShowExceptions,
+                                     Funicular::EpochHeader
+      else
+        app.middleware.use Funicular::EpochHeader
+      end
+      # :action_controller fires for both Base and API.
+      ActiveSupport.on_load(:action_controller) do
+        require "funicular/epoch_stamping"
+        include Funicular::EpochStamping
+      end
+    end
+
     rake_tasks do
       load "tasks/funicular.rake"
     end

--- a/lib/funicular/railtie.rb
+++ b/lib/funicular/railtie.rb
@@ -20,7 +20,8 @@ module Funicular
     end
 
     initializer "funicular.epoch" do |app|
-      # Every response carries X-Funicular-Epoch (docs decision 13):
+      # When the local database is enabled, every response carries
+      # X-Funicular-Epoch (docs decision 13):
       # the controller concern rotates the epoch, the middleware writes
       # the header. The middleware sits ABOVE the exception renderer so
       # even a 500 page carries it -- a header-less error response
@@ -37,6 +38,10 @@ module Funicular
         require "funicular/epoch_stamping"
         include Funicular::EpochStamping
       end
+    end
+
+    config.after_initialize do
+      Funicular.configuration.validate_local_database!
     end
 
     rake_tasks do

--- a/lib/funicular/session_epoch.rb
+++ b/lib/funicular/session_epoch.rb
@@ -5,9 +5,10 @@ require "securerandom"
 
 module Funicular
   # The server half of the session epoch (docs: local_database.md, "The
-  # session epoch"). The epoch is an opaque value that changes on every
-  # authentication transition; every response carries it in the
-  # X-Funicular-Epoch header, and the client goes terminal on a mismatch
+  # session epoch"). When the local database is enabled, the epoch is an
+  # opaque value that changes on every authentication transition; every
+  # response carries it in the X-Funicular-Epoch header, and the client goes
+  # terminal on a mismatch
   # so a tab can never keep applying data that now belongs to somebody
   # else's cookie session.
   #

--- a/lib/funicular/session_epoch.rb
+++ b/lib/funicular/session_epoch.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+require "json"
+require "securerandom"
+
+module Funicular
+  # The server half of the session epoch (docs: local_database.md, "The
+  # session epoch"). The epoch is an opaque value that changes on every
+  # authentication transition; every response carries it in the
+  # X-Funicular-Epoch header, and the client goes terminal on a mismatch
+  # so a tab can never keep applying data that now belongs to somebody
+  # else's cookie session.
+  #
+  # State lives in the Rails session PER application_id, so several
+  # Funicular apps sharing one cookie session cannot rotate each other's
+  # epochs:
+  #
+  #   session["funicular_epochs"][app_id] = {
+  #     "identity" => <canonical identity JSON>,
+  #     "epoch"    => <opaque hex>,
+  #   }
+  #
+  # String keys throughout: cookie sessions round-trip through JSON.
+  module SessionEpoch
+    SESSION_KEY = "funicular_epochs"
+
+    class << self
+      # A Rails API-only app usually runs WITHOUT a session middleware:
+      # request.session is a disabled stub whose every read and write
+      # raises. Loading Funicular must not break such an app, so both
+      # the controller concern and the include-tag helper check here
+      # and leave the epoch feature OFF -- with no cookie session there
+      # is no shared identity for the epoch to protect in the first
+      # place. Plain hashes (tests, exotic stores) count as enabled.
+      def session_available?(session)
+        return false if session.nil?
+        return true unless session.respond_to?(:enabled?)
+        session.enabled?
+      end
+
+      # The signed-in user's storage key, resolved through the
+      # configured lambda; nil when signed out or when no user_key is
+      # configured (anonymous_only apps included). An empty resolved
+      # key is a broken source and fails loud -- it would fold every
+      # user into one namespace.
+      def user_key(controller)
+        resolver = Funicular.configuration.user_key
+        return nil unless resolver
+        value = resolver.call(controller)
+        return nil if value.nil?
+        key = value.to_s
+        if key.empty?
+          raise Funicular::Error,
+                "Funicular user_key resolved to an empty string; " \
+                "return nil for signed-out visitors instead"
+        end
+        key
+      end
+
+      # The identity for an ALREADY-resolved user key (nil = signed
+      # out), encoded exactly like the client's namespace tuple (docs
+      # decision 12): ["v1", app, "anonymous"] or
+      # ["v1", app, "user", key] as canonical JSON. STRUCTURE separates
+      # the fields, so no delimiter or "anonymous"-as-a-user-key
+      # collisions. Callers that also DISPLAY the key (the include-tag
+      # helper) resolve it once and pass that same value here -- two
+      # resolver evaluations could disagree mid-transition and stamp
+      # one user's epoch onto another user's page namespace.
+      def identity_for(user_key)
+        app_id = Funicular.configuration.application_id
+        if user_key.nil?
+          JSON.generate(["v1", app_id, "anonymous"])
+        else
+          JSON.generate(["v1", app_id, "user", user_key])
+        end
+      end
+
+      # The current identity, resolving the user key through the
+      # configured lambda.
+      def identity(controller)
+        identity_for(user_key(controller))
+      end
+
+      # Returns the application's current epoch, rotating it first
+      # whenever the stored identity differs from the computed one --
+      # login, logout, and a direct user switch are all just "the
+      # identity changed". Writes the session entry on rotation.
+      def stamp!(session, controller)
+        stamp_identity!(session, identity(controller))
+      end
+
+      # The rotation core against a pre-computed identity.
+      def stamp_identity!(session, current)
+        stored = session[SESSION_KEY]
+        epochs = stored.is_a?(Hash) ? stored : {}
+        app_id = Funicular.configuration.application_id
+        entry = epochs[app_id]
+        if entry.is_a?(Hash) && entry["identity"] == current
+          epoch = entry["epoch"].to_s
+          return epoch unless epoch.empty?
+        end
+        epoch = SecureRandom.hex(16)
+        epochs[app_id] = { "identity" => current, "epoch" => epoch }
+        session[SESSION_KEY] = epochs
+        epoch
+      end
+    end
+  end
+end

--- a/lib/funicular/ssr/runtime.rb
+++ b/lib/funicular/ssr/runtime.rb
@@ -36,6 +36,8 @@ module Funicular
         router
         0_validations
         1_validators
+        db
+        relation
         model
         store
         store_singleton

--- a/lib/funicular/version.rb
+++ b/lib/funicular/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Funicular
-  VERSION = "0.4.0"
+  VERSION = "0.5.0"
 end

--- a/lib/tasks/funicular.rake
+++ b/lib/tasks/funicular.rake
@@ -101,12 +101,20 @@ namespace :funicular do
 
       FileUtils.cp(source_js,          dest_js)
       FileUtils.cp(source_css,         dest_css)
-      FileUtils.cp(source_initializer, dest_initializer)
 
       puts "Installed Funicular debug assets:"
       puts "  - #{dest_js}"
       puts "  - #{dest_css}"
-      puts "  - #{dest_initializer}"
+
+      # The initializer belongs to the application once it exists:
+      # re-running the installer must never clobber its configuration
+      # (source choice, local_database opt-in, user_key).
+      if File.exist?(dest_initializer)
+        puts "Skipped #{dest_initializer} (exists; delete it first to reinstall the template)"
+      else
+        FileUtils.cp(source_initializer, dest_initializer)
+        puts "  - #{dest_initializer}"
+      end
     end
 
     desc "Install vendored PicoRuby.wasm artifacts (dist + debug) into public/picoruby/"

--- a/minitest/configuration_test.rb
+++ b/minitest/configuration_test.rb
@@ -65,9 +65,41 @@ class ConfigurationTest < Minitest::Test
   # --- local-database namespace settings (docs decisions 12/13) ---------
 
   def test_namespace_defaults
+    assert_equal false, @config.local_database
     assert_equal "funicular", @config.application_id
     assert_nil @config.user_key
     assert_equal false, @config.anonymous_only
+  end
+
+  def test_local_database_setter_normalizes_truthiness
+    @config.local_database = Object.new
+    assert_equal true, @config.local_database
+    @config.local_database = nil
+    assert_equal false, @config.local_database
+  end
+
+  def test_disabled_local_database_needs_no_identity
+    assert_equal true, @config.validate_local_database!
+  end
+
+  def test_enabled_local_database_requires_an_identity_declaration
+    @config.local_database = true
+    error = assert_raises(ArgumentError) do
+      @config.validate_local_database!
+    end
+    assert_includes error.message, "user_key"
+    assert_includes error.message, "anonymous_only"
+  end
+
+  def test_either_identity_declaration_satisfies_local_database
+    @config.local_database = true
+    @config.anonymous_only = true
+    assert_equal true, @config.validate_local_database!
+
+    fresh = Funicular::Configuration.new
+    fresh.local_database = true
+    fresh.user_key = ->(_controller) { nil }
+    assert_equal true, fresh.validate_local_database!
   end
 
   def test_application_id_rejects_empty_values

--- a/minitest/configuration_test.rb
+++ b/minitest/configuration_test.rb
@@ -61,4 +61,50 @@ class ConfigurationTest < Minitest::Test
       assert_equal vendored, @config.cdn_version
     end
   end
+
+  # --- local-database namespace settings (docs decisions 12/13) ---------
+
+  def test_namespace_defaults
+    assert_equal "funicular", @config.application_id
+    assert_nil @config.user_key
+    assert_equal false, @config.anonymous_only
+  end
+
+  def test_application_id_rejects_empty_values
+    error = assert_raises(ArgumentError) { @config.application_id = "" }
+    assert_includes error.message, "application_id"
+    error = assert_raises(ArgumentError) { @config.application_id = nil }
+    assert_includes error.message, "application_id"
+  end
+
+  def test_application_id_is_canonicalized_with_to_s
+    @config.application_id = :chat_app
+    assert_equal "chat_app", @config.application_id
+  end
+
+  def test_user_key_must_be_callable
+    error = assert_raises(ArgumentError) { @config.user_key = "not callable" }
+    assert_includes error.message, "callable"
+  end
+
+  def test_user_key_and_anonymous_only_are_mutually_exclusive
+    # The reliably-detectable server-side config error: whichever
+    # setter comes second raises, in both orders.
+    @config.user_key = ->(controller) { nil }
+    error = assert_raises(ArgumentError) { @config.anonymous_only = true }
+    assert_includes error.message, "mutually exclusive"
+
+    fresh = Funicular::Configuration.new
+    fresh.anonymous_only = true
+    error = assert_raises(ArgumentError) do
+      fresh.user_key = ->(controller) { nil }
+    end
+    assert_includes error.message, "mutually exclusive"
+  end
+
+  def test_anonymous_only_false_never_conflicts
+    @config.user_key = ->(controller) { nil }
+    @config.anonymous_only = false
+    assert_equal false, @config.anonymous_only
+  end
 end

--- a/minitest/epoch_header_test.rb
+++ b/minitest/epoch_header_test.rb
@@ -15,6 +15,7 @@ class EpochHeaderTest < Minitest::Test
 
   def setup
     @config = Funicular::Configuration.new
+    @config.local_database = true
     Funicular.instance_variable_set(:@configuration, @config)
   end
 
@@ -30,6 +31,16 @@ class EpochHeaderTest < Minitest::Test
     middleware = Funicular::EpochHeader.new(app_returning(200))
     _, headers, = middleware.call({ "funicular.epoch" => "e-ctrl" })
     assert_equal "e-ctrl", headers[HEADER]
+  end
+
+  def test_disabled_local_database_leaves_the_response_untouched
+    @config.local_database = false
+    headers = { HEADER => "inner", "X-Funicular-Epoch" => "legacy" }
+    middleware = Funicular::EpochHeader.new(app_returning(200, headers))
+    _, result, = middleware.call({ "funicular.epoch" => "outer" })
+    assert_same headers, result
+    assert_equal "inner", result[HEADER]
+    assert_equal "legacy", result["X-Funicular-Epoch"]
   end
 
   def test_falls_back_to_the_stored_session_epoch

--- a/minitest/epoch_header_test.rb
+++ b/minitest/epoch_header_test.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "funicular/epoch_header"
+
+# Exercises Funicular::EpochHeader, the middleware that writes
+# X-Funicular-Epoch on every outgoing response: from the env value the
+# controller concern pinned, from the stored session entry when the
+# request died before the concern ran, or not at all when neither
+# exists.
+class EpochHeaderTest < Minitest::Test
+  # Lowercase: the Rack 3 spec requires lowercase response header
+  # names, and HTTP header lookups are case-insensitive client-side.
+  HEADER = "x-funicular-epoch"
+
+  def setup
+    @config = Funicular::Configuration.new
+    Funicular.instance_variable_set(:@configuration, @config)
+  end
+
+  def teardown
+    Funicular.instance_variable_set(:@configuration, nil)
+  end
+
+  def app_returning(status, headers = {})
+    ->(_env) { [status, headers, ["body"]] }
+  end
+
+  def test_writes_the_env_pinned_epoch
+    middleware = Funicular::EpochHeader.new(app_returning(200))
+    _, headers, = middleware.call({ "funicular.epoch" => "e-ctrl" })
+    assert_equal "e-ctrl", headers[HEADER]
+  end
+
+  def test_falls_back_to_the_stored_session_epoch
+    # The concern never ran (an earlier before_action raised, say),
+    # but the session already carries this app's epoch: stamped
+    # without rotation.
+    session = {
+      "funicular_epochs" => {
+        "funicular" => { "identity" => "i", "epoch" => "e-stored" },
+      },
+    }
+    middleware = Funicular::EpochHeader.new(app_returning(500))
+    _, headers, = middleware.call({ "rack.session" => session })
+    assert_equal "e-stored", headers[HEADER]
+  end
+
+  def test_the_env_value_wins_over_the_stored_one
+    session = {
+      "funicular_epochs" => {
+        "funicular" => { "identity" => "i", "epoch" => "e-stored" },
+      },
+    }
+    middleware = Funicular::EpochHeader.new(app_returning(200))
+    _, headers, = middleware.call(
+      { "funicular.epoch" => "e-ctrl", "rack.session" => session })
+    assert_equal "e-ctrl", headers[HEADER]
+  end
+
+  def test_without_any_epoch_the_header_stays_absent
+    middleware = Funicular::EpochHeader.new(app_returning(200))
+    _, headers, = middleware.call({})
+    refute headers.key?(HEADER)
+  end
+
+  def test_respects_the_configured_application_id
+    @config.application_id = "second_app"
+    session = {
+      "funicular_epochs" => {
+        "funicular"  => { "identity" => "i", "epoch" => "e-other" },
+        "second_app" => { "identity" => "i", "epoch" => "e-mine" },
+      },
+    }
+    middleware = Funicular::EpochHeader.new(app_returning(200))
+    _, headers, = middleware.call({ "rack.session" => session })
+    assert_equal "e-mine", headers[HEADER]
+  end
+
+  def test_overwrites_a_stale_inner_header
+    # An inner layer's header may have been stamped BEFORE a login/
+    # logout rotated the epoch; keeping it would let an old page apply
+    # the post-transition response as a match. The framework's value
+    # is authoritative.
+    middleware = Funicular::EpochHeader.new(
+      app_returning(200, { HEADER => "stale-pre-login" }))
+    _, headers, = middleware.call({ "funicular.epoch" => "e-ctrl" })
+    assert_equal "e-ctrl", headers[HEADER]
+  end
+
+  def test_a_legacy_cased_inner_header_cannot_ride_out_as_a_duplicate
+    # Plain header hashes are case-sensitive: a stale capitalized
+    # spelling must be removed, not merely shadowed by our lowercase
+    # (Rack 3) name.
+    middleware = Funicular::EpochHeader.new(
+      app_returning(200, { "X-Funicular-Epoch" => "stale-pre-login" }))
+    _, headers, = middleware.call({ "funicular.epoch" => "e-ctrl" })
+    assert_equal "e-ctrl", headers[HEADER]
+    refute headers.key?("X-Funicular-Epoch")
+  end
+
+  def test_the_header_name_is_lowercase_for_rack_3
+    middleware = Funicular::EpochHeader.new(app_returning(200))
+    _, headers, = middleware.call({ "funicular.epoch" => "e-ctrl" })
+    assert_equal ["x-funicular-epoch"], headers.keys
+  end
+
+  def test_a_broken_session_read_never_masks_the_response
+    broken = Object.new
+    def broken.[](_key)
+      raise "session store exploded"
+    end
+    middleware = Funicular::EpochHeader.new(app_returning(500))
+    status, headers, = middleware.call({ "rack.session" => broken })
+    assert_equal 500, status
+    refute headers.key?(HEADER)
+  end
+end

--- a/minitest/epoch_header_test.rb
+++ b/minitest/epoch_header_test.rb
@@ -75,6 +75,26 @@ class EpochHeaderTest < Minitest::Test
     refute headers.key?(HEADER)
   end
 
+  def test_an_inner_header_is_dropped_when_no_epoch_is_available
+    # No env value and no session: the contract is "no authoritative
+    # epoch, no header". An inner layer's leftover would otherwise
+    # survive as the page's only epoch signal -- and one stamped
+    # before the session rotated would read as a MATCH, keeping a page
+    # alive that decision 13 wants terminal.
+    middleware = Funicular::EpochHeader.new(
+      app_returning(200, { HEADER => "stale-pre-login" }))
+    _, headers, = middleware.call({})
+    refute headers.key?(HEADER)
+  end
+
+  def test_a_legacy_cased_inner_header_is_dropped_without_an_epoch_too
+    middleware = Funicular::EpochHeader.new(
+      app_returning(200, { "X-Funicular-Epoch" => "stale-pre-login" }))
+    _, headers, = middleware.call({})
+    refute headers.key?("X-Funicular-Epoch")
+    refute headers.key?(HEADER)
+  end
+
   def test_respects_the_configured_application_id
     @config.application_id = "second_app"
     session = {

--- a/minitest/epoch_stamping_test.rb
+++ b/minitest/epoch_stamping_test.rb
@@ -12,10 +12,11 @@ require "funicular/epoch_header"
 # a truthful header on the exception page.
 class EpochStampingTest < Minitest::Test
   class FakeRequest
-    attr_reader :env
+    attr_reader :env, :session
 
-    def initialize(env = {})
+    def initialize(env = {}, session = nil)
       @env = env
+      @session = session
     end
   end
 
@@ -31,7 +32,7 @@ class EpochStampingTest < Minitest::Test
     attr_reader :request, :session
 
     def initialize(session, env = {})
-      @request = FakeRequest.new(env)
+      @request = FakeRequest.new(env, session)
       @session = session
     end
 
@@ -96,6 +97,32 @@ class EpochStampingTest < Minitest::Test
 
   def test_including_registers_the_around_action
     assert_includes StampedController.around_actions, :stamp_funicular_epoch
+  end
+
+  # An application may route an action named "session" (a schema
+  # endpoint, say): that action SHADOWS the controller's session
+  # accessor. The concern must read request.session and never notice.
+  # (Not a StampedController subclass: the fake around_action registry
+  # is a class ivar and does not inherit.)
+  class SessionShadowedController < FakeControllerBase
+    include Funicular::EpochStamping
+
+    attr_accessor :current_user_key
+
+    def session
+      raise "the session action was invoked instead of the accessor"
+    end
+  end
+
+  def test_the_stamp_never_calls_the_controller_session_accessor
+    env = {}
+    controller = SessionShadowedController.new(@session, env)
+    controller.current_user_key = "u1"
+    ran = false
+    controller.process { ran = true }
+    assert ran
+    refute_nil env["funicular.epoch"]
+    assert_equal session_epoch, env["funicular.epoch"]
   end
 
   def test_disabled_local_database_does_not_touch_the_session_or_resolver

--- a/minitest/epoch_stamping_test.rb
+++ b/minitest/epoch_stamping_test.rb
@@ -1,0 +1,184 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "funicular/epoch_stamping"
+require "funicular/epoch_header"
+
+# Exercises Funicular::EpochStamping (the controller mixin the Railtie
+# installs) and its interplay with the EpochHeader middleware. The
+# around_action stamps the epoch before the action AND re-stamps in
+# its ensure with the post-action identity: a login/logout inside the
+# action rotates on its own response, and a raising action still gets
+# a truthful header on the exception page.
+class EpochStampingTest < Minitest::Test
+  class FakeRequest
+    attr_reader :env
+
+    def initialize(env = {})
+      @env = env
+    end
+  end
+
+  class FakeControllerBase
+    def self.around_action(name)
+      (@around_actions ||= []) << name
+    end
+
+    def self.around_actions
+      @around_actions || []
+    end
+
+    attr_reader :request, :session
+
+    def initialize(session, env = {})
+      @request = FakeRequest.new(env)
+      @session = session
+    end
+
+    # A minimal filter chain: the action block runs inside every
+    # registered around_action, exceptions propagating like Rails'.
+    def process(&action)
+      chain = self.class.around_actions.reverse.inject(action) do |inner, name|
+        -> { send(name) { inner.call } }
+      end
+      chain.call
+    end
+  end
+
+  class StampedController < FakeControllerBase
+    include Funicular::EpochStamping
+
+    attr_accessor :current_user_key
+  end
+
+  # What request.session looks like in a session-less Rails API app:
+  # enabled? says no, every read and write raises.
+  class DisabledSession
+    def enabled?
+      false
+    end
+
+    def [](_key)
+      raise "sessions are disabled in this application"
+    end
+
+    def []=(_key, _value)
+      raise "sessions are disabled in this application"
+    end
+  end
+
+  def setup
+    @config = Funicular::Configuration.new
+    @config.user_key = ->(controller) { controller.current_user_key }
+    Funicular.instance_variable_set(:@configuration, @config)
+    @session = {}
+  end
+
+  def teardown
+    Funicular.instance_variable_set(:@configuration, nil)
+  end
+
+  def session_epoch
+    entry = @session["funicular_epochs"]
+    entry ? entry["funicular"]["epoch"] : nil
+  end
+
+  # Runs one fake request: the controller starts as initial_key, the
+  # action block may mutate it (login/logout), the env epoch is what
+  # the middleware would write.
+  def run_request(initial_key, env = {}, &action)
+    controller = StampedController.new(@session, env)
+    controller.current_user_key = initial_key
+    controller.process { action ? action.call(controller) : nil }
+    env["funicular.epoch"]
+  end
+
+  def test_including_registers_the_around_action
+    assert_includes StampedController.around_actions, :stamp_funicular_epoch
+  end
+
+  def test_the_epoch_lands_in_the_request_env
+    epoch = run_request("u1")
+    refute_nil epoch
+    refute_empty epoch
+    # Same user, same session: stable across requests.
+    assert_equal epoch, run_request("u1")
+  end
+
+  def test_the_env_value_matches_the_session_entry
+    epoch = run_request("u1")
+    assert_equal epoch, session_epoch
+  end
+
+  def test_a_login_inside_the_action_rotates_on_its_own_response
+    # The page was rendered signed-out; the LOGIN action itself flips
+    # the identity mid-request. Its own response must already carry
+    # the rotated epoch -- with only a pre-action stamp, an old page
+    # would apply the login response as an epoch match and the
+    # rotation would be a request late.
+    anonymous = run_request(nil)
+    login_epoch = run_request(nil) do |controller|
+      controller.current_user_key = "u1"
+    end
+    refute_equal anonymous, login_epoch
+    assert_equal session_epoch, login_epoch
+    # And it holds on the user's next request.
+    assert_equal login_epoch, run_request("u1")
+  end
+
+  def test_a_logout_inside_the_action_rotates_on_its_own_response
+    signed_in = run_request("u1")
+    logout_epoch = run_request("u1") do |controller|
+      controller.current_user_key = nil
+    end
+    refute_equal signed_in, logout_epoch
+    assert_equal session_epoch, logout_epoch
+  end
+
+  def test_a_disabled_session_skips_stamping_but_runs_the_action
+    # Session-less Rails API apps (no session middleware) must keep
+    # working with Funicular merely loaded: the epoch feature stays
+    # off instead of raising on every action.
+    ran = false
+    controller = StampedController.new(DisabledSession.new)
+    controller.current_user_key = "u1"
+    controller.process { ran = true }
+    assert ran
+    assert_nil controller.request.env["funicular.epoch"]
+  end
+
+  def test_an_enabled_session_object_still_stamps
+    enabled = Hash.new
+    def enabled.enabled?
+      true
+    end
+    controller = StampedController.new(enabled)
+    controller.current_user_key = "u1"
+    controller.process { nil }
+    refute_nil controller.request.env["funicular.epoch"]
+  end
+
+  def test_a_raising_action_still_produces_a_stamped_response
+    # The exception renderer builds a FRESH response none of the
+    # controller's headers survive into; the ensure re-stamp plus the
+    # middleware cover it -- with the POST-transition identity even
+    # when the action logged the user in before dying.
+    inner = lambda do |env|
+      controller = StampedController.new(@session, env)
+      controller.current_user_key = nil
+      begin
+        controller.process do
+          controller.current_user_key = "u1"
+          raise "boom in the action"
+        end
+      rescue RuntimeError
+        [500, {}, ["error page"]]
+      end
+    end
+    status, headers, = Funicular::EpochHeader.new(inner).call({})
+    assert_equal 500, status
+    assert_equal session_epoch, headers["x-funicular-epoch"]
+    assert_equal '["v1","funicular","user","u1"]',
+                 @session["funicular_epochs"]["funicular"]["identity"]
+  end
+end

--- a/minitest/epoch_stamping_test.rb
+++ b/minitest/epoch_stamping_test.rb
@@ -69,6 +69,7 @@ class EpochStampingTest < Minitest::Test
 
   def setup
     @config = Funicular::Configuration.new
+    @config.local_database = true
     @config.user_key = ->(controller) { controller.current_user_key }
     Funicular.instance_variable_set(:@configuration, @config)
     @session = {}
@@ -95,6 +96,19 @@ class EpochStampingTest < Minitest::Test
 
   def test_including_registers_the_around_action
     assert_includes StampedController.around_actions, :stamp_funicular_epoch
+  end
+
+  def test_disabled_local_database_does_not_touch_the_session_or_resolver
+    @config.local_database = false
+    @config.user_key = ->(_controller) { flunk "resolver was called" }
+    ran = false
+    session = {}
+    controller = StampedController.new(session)
+    controller.current_user_key = "u1"
+    controller.process { ran = true }
+    assert ran
+    assert_empty session
+    assert_nil controller.request.env["funicular.epoch"]
   end
 
   def test_the_epoch_lands_in_the_request_env

--- a/minitest/picoruby_helper_test.rb
+++ b/minitest/picoruby_helper_test.rb
@@ -99,18 +99,41 @@ class PicorubyHelperTest < Minitest::Test
     assert_includes error.message, "user_key"
   end
 
-  # A harness with the controller/session surface a real view has.
+  # A harness with the controller/request surface a real view has. The
+  # helper reads the session through request.session (the view's own
+  # session helper delegates to the controller, where an action named
+  # "session" shadows it).
   class MetadataHarness < Harness
-    attr_accessor :controller, :session
+    attr_accessor :controller, :request
   end
 
   FakeController = Struct.new(:current_user_key)
+  FakeViewRequest = Struct.new(:session)
 
   def metadata_view(user_key: nil, session: {})
     view = MetadataHarness.new
     view.controller = FakeController.new(user_key)
-    view.session = session
+    view.request = FakeViewRequest.new(session)
     view
+  end
+
+  # A view rendered by a controller that routes an action named
+  # "session": the view's session delegate would invoke that action.
+  # The helper must go through request.session and never notice.
+  class SessionShadowedHarness < MetadataHarness
+    def session
+      raise "the session delegate was invoked instead of request.session"
+    end
+  end
+
+  def test_the_helper_never_calls_the_view_session_delegate
+    @config.local_database = true
+    @config.user_key = ->(controller) { controller.current_user_key }
+    view = SessionShadowedHarness.new
+    view.controller = FakeController.new("u1")
+    view.request = FakeViewRequest.new({})
+    html = view.picoruby_include_tag(source: :local_dist, base_styles: false)
+    assert_includes html, "data-funicular-epoch"
   end
 
   def test_include_tag_embeds_user_key_and_epoch

--- a/minitest/picoruby_helper_test.rb
+++ b/minitest/picoruby_helper_test.rb
@@ -63,6 +63,146 @@ class PicorubyHelperTest < Minitest::Test
     assert_includes html, "defer"
   end
 
+  # --- page metadata (docs decisions 12/13) -----------------------------
+
+  # The plain Harness has no controller/session: only the always-on
+  # application id rides the tag.
+  def test_include_tag_embeds_the_default_application_id
+    html = @view.picoruby_include_tag(source: :local_dist, base_styles: false)
+    assert_includes html, 'data-funicular-application-id="funicular"'
+    refute_includes html, "data-funicular-user-key"
+    refute_includes html, "data-funicular-anonymous-only"
+    refute_includes html, "data-funicular-epoch"
+  end
+
+  def test_include_tag_embeds_anonymous_only
+    @config.anonymous_only = true
+    html = @view.picoruby_include_tag(source: :local_dist, base_styles: false)
+    assert_includes html, 'data-funicular-anonymous-only="true"'
+  end
+
+  # A harness with the controller/session surface a real view has.
+  class MetadataHarness < Harness
+    attr_accessor :controller, :session
+  end
+
+  FakeController = Struct.new(:current_user_key)
+
+  def metadata_view(user_key: nil, session: {})
+    view = MetadataHarness.new
+    view.controller = FakeController.new(user_key)
+    view.session = session
+    view
+  end
+
+  def test_include_tag_embeds_user_key_and_epoch
+    @config.user_key = ->(controller) { controller.current_user_key }
+    session = {}
+    view = metadata_view(user_key: "u1", session: session)
+    html = view.picoruby_include_tag(source: :local_dist, base_styles: false)
+    assert_includes html, 'data-funicular-user-key="u1"'
+    assert_includes html, 'data-funicular-user-key-configured="true"'
+    # The epoch on the page is THE session entry the response header
+    # stamps: page and responses cannot disagree at render time.
+    epoch = session["funicular_epochs"]["funicular"]["epoch"]
+    assert_includes html, %(data-funicular-epoch="#{epoch}")
+  end
+
+  # What request.session looks like in a session-less Rails API app.
+  class DisabledSession
+    def enabled?
+      false
+    end
+
+    def [](_key)
+      raise "sessions are disabled in this application"
+    end
+
+    def []=(_key, _value)
+      raise "sessions are disabled in this application"
+    end
+  end
+
+  def test_a_disabled_session_skips_the_epoch_without_breaking
+    @config.user_key = ->(controller) { controller.current_user_key }
+    view = metadata_view(user_key: "u1", session: DisabledSession.new)
+    html = view.picoruby_include_tag(source: :local_dist, base_styles: false)
+    refute_includes html, "data-funicular-epoch"
+    assert_includes html, 'data-funicular-user-key="u1"'
+  end
+
+  def test_the_resolver_feeds_attribute_and_epoch_from_one_evaluation
+    # A racy resolver (current_user changing between two calls) must
+    # not embed user A's namespace while stamping user B's identity
+    # into the epoch entry: the helper evaluates it exactly once.
+    calls = 0
+    @config.user_key = lambda do |_controller|
+      calls += 1
+      "u#{calls}"
+    end
+    session = {}
+    view = metadata_view(user_key: "ignored", session: session)
+    html = view.picoruby_include_tag(source: :local_dist, base_styles: false)
+    assert_equal 1, calls
+    assert_includes html, 'data-funicular-user-key="u1"'
+    assert_equal '["v1","funicular","user","u1"]',
+                 session["funicular_epochs"]["funicular"]["identity"]
+  end
+
+  def test_signed_out_omits_the_user_key_attribute
+    @config.user_key = ->(controller) { controller.current_user_key }
+    view = metadata_view(user_key: nil)
+    html = view.picoruby_include_tag(source: :local_dist, base_styles: false)
+    refute_includes html, "data-funicular-user-key="
+    assert_includes html, 'data-funicular-user-key-configured="true"'
+  end
+
+  def test_metadata_values_are_html_escaped
+    @config.application_id = %q{"><script>alert(1)</script>}
+    @config.user_key = ->(controller) { controller.current_user_key }
+    view = metadata_view(user_key: %q{"><img src=x>})
+    html = view.picoruby_include_tag(source: :local_dist, base_styles: false)
+    refute_includes html, "<script>alert(1)</script>"
+    refute_includes html, "<img src=x>"
+    assert_includes html, "&quot;&gt;"
+  end
+
+  def test_caller_data_attributes_survive_alongside_the_metadata
+    html = @view.picoruby_include_tag(source: :local_dist, base_styles: false,
+                                      data: { turbo_track: "reload" })
+    assert_includes html, 'data-turbo-track="reload"'
+    assert_includes html, 'data-funicular-application-id="funicular"'
+  end
+
+  def test_caller_data_cannot_override_the_framework_metadata
+    # A data: override of the epoch or the user key would make the
+    # page disagree with its own responses (instant terminal) or boot
+    # the wrong namespace: the framework's values win, in every key
+    # spelling that would render as the same HTML attribute.
+    @config.user_key = ->(controller) { controller.current_user_key }
+    session = {}
+    view = metadata_view(user_key: "u1", session: session)
+    html = view.picoruby_include_tag(
+      source: :local_dist, base_styles: false,
+      data: { funicular_epoch: "evil-symbol",
+              "funicular_user_key" => "evil-string",
+              "funicular-application-id" => "evil-dashed",
+              turbo_track: "reload" })
+    refute_includes html, "evil-symbol"
+    refute_includes html, "evil-string"
+    refute_includes html, "evil-dashed"
+    assert_includes html, 'data-funicular-user-key="u1"'
+    assert_includes html, 'data-funicular-application-id="funicular"'
+    epoch = session["funicular_epochs"]["funicular"]["epoch"]
+    assert_includes html, %(data-funicular-epoch="#{epoch}")
+    # The caller's unrelated attribute still rides along, and no
+    # attribute is emitted twice.
+    assert_includes html, 'data-turbo-track="reload"'
+    assert_equal 1, html.scan("data-funicular-epoch=").size
+    assert_equal 1, html.scan("data-funicular-user-key=").size
+    assert_equal 1, html.scan("data-funicular-application-id=").size
+  end
+
   def test_cdn_source_uses_versioned_jsdelivr_url
     @config.cdn_version = "1.2.3"
     html = @view.picoruby_include_tag(source: :cdn, base_styles: false)

--- a/minitest/picoruby_helper_test.rb
+++ b/minitest/picoruby_helper_test.rb
@@ -263,6 +263,42 @@ class PicorubyHelperTest < Minitest::Test
     refute_includes html, "data-funicular-anonymous-only"
   end
 
+  def test_top_level_options_cannot_override_the_framework_metadata
+    # The contract values can bypass the data: hash entirely and arrive
+    # as top-level options, in any spelling the tag builder accepts.
+    @config.local_database = true
+    @config.user_key = ->(controller) { controller.current_user_key }
+    session = {}
+    view = metadata_view(user_key: "u1", session: session)
+    html = view.picoruby_include_tag(
+      source: :local_dist, base_styles: false,
+      **{ "data-funicular-epoch" => "evil-dashed",
+          :"data-funicular-user-key" => "evil-symbol",
+          data_funicular_application_id: "evil-underscored",
+          "data-turbo-track" => "reload" })
+    refute_includes html, "evil-dashed"
+    refute_includes html, "evil-symbol"
+    refute_includes html, "evil-underscored"
+    assert_includes html, 'data-funicular-user-key="u1"'
+    assert_includes html, 'data-funicular-application-id="funicular"'
+    epoch = session["funicular_epochs"]["funicular"]["epoch"]
+    assert_includes html, %(data-funicular-epoch="#{epoch}")
+    # Unrelated top-level data attributes are the caller's business.
+    assert_includes html, 'data-turbo-track="reload"'
+    assert_equal 1, html.scan("data-funicular-epoch=").size
+    assert_equal 1, html.scan("data-funicular-user-key=").size
+    assert_equal 1, html.scan("data-funicular-application-id=").size
+  end
+
+  def test_top_level_options_cannot_enable_the_disabled_local_database
+    html = @view.picoruby_include_tag(
+      source: :local_dist, base_styles: false,
+      **{ "data-funicular-local-database" => "true",
+          data_funicular_application_id: "injected" })
+    refute_includes html, "data-funicular-local-database"
+    refute_includes html, "injected"
+  end
+
   def test_cdn_source_uses_versioned_jsdelivr_url
     @config.cdn_version = "1.2.3"
     html = @view.picoruby_include_tag(source: :cdn, base_styles: false)

--- a/minitest/picoruby_helper_test.rb
+++ b/minitest/picoruby_helper_test.rb
@@ -65,20 +65,38 @@ class PicorubyHelperTest < Minitest::Test
 
   # --- page metadata (docs decisions 12/13) -----------------------------
 
-  # The plain Harness has no controller/session: only the always-on
-  # application id rides the tag.
-  def test_include_tag_embeds_the_default_application_id
+  def test_disabled_include_tag_omits_all_local_database_metadata
     html = @view.picoruby_include_tag(source: :local_dist, base_styles: false)
-    assert_includes html, 'data-funicular-application-id="funicular"'
+    refute_includes html, "data-funicular-local-database"
+    refute_includes html, "data-funicular-application-id"
     refute_includes html, "data-funicular-user-key"
     refute_includes html, "data-funicular-anonymous-only"
     refute_includes html, "data-funicular-epoch"
   end
 
+  def test_disabled_include_tag_does_not_call_the_identity_resolver_or_session
+    @config.user_key = ->(_controller) { flunk "resolver was called" }
+    session = DisabledSession.new
+    view = metadata_view(user_key: "u1", session: session)
+    html = view.picoruby_include_tag(source: :local_dist, base_styles: false)
+    refute_includes html, "data-funicular-local-database"
+  end
+
   def test_include_tag_embeds_anonymous_only
+    @config.local_database = true
     @config.anonymous_only = true
     html = @view.picoruby_include_tag(source: :local_dist, base_styles: false)
+    assert_includes html, 'data-funicular-local-database="true"'
+    assert_includes html, 'data-funicular-application-id="funicular"'
     assert_includes html, 'data-funicular-anonymous-only="true"'
+  end
+
+  def test_enabled_include_tag_requires_an_identity_declaration
+    @config.local_database = true
+    error = assert_raises(ArgumentError) do
+      @view.picoruby_include_tag(source: :local_dist, base_styles: false)
+    end
+    assert_includes error.message, "user_key"
   end
 
   # A harness with the controller/session surface a real view has.
@@ -96,6 +114,7 @@ class PicorubyHelperTest < Minitest::Test
   end
 
   def test_include_tag_embeds_user_key_and_epoch
+    @config.local_database = true
     @config.user_key = ->(controller) { controller.current_user_key }
     session = {}
     view = metadata_view(user_key: "u1", session: session)
@@ -124,6 +143,7 @@ class PicorubyHelperTest < Minitest::Test
   end
 
   def test_a_disabled_session_skips_the_epoch_without_breaking
+    @config.local_database = true
     @config.user_key = ->(controller) { controller.current_user_key }
     view = metadata_view(user_key: "u1", session: DisabledSession.new)
     html = view.picoruby_include_tag(source: :local_dist, base_styles: false)
@@ -135,6 +155,7 @@ class PicorubyHelperTest < Minitest::Test
     # A racy resolver (current_user changing between two calls) must
     # not embed user A's namespace while stamping user B's identity
     # into the epoch entry: the helper evaluates it exactly once.
+    @config.local_database = true
     calls = 0
     @config.user_key = lambda do |_controller|
       calls += 1
@@ -150,6 +171,7 @@ class PicorubyHelperTest < Minitest::Test
   end
 
   def test_signed_out_omits_the_user_key_attribute
+    @config.local_database = true
     @config.user_key = ->(controller) { controller.current_user_key }
     view = metadata_view(user_key: nil)
     html = view.picoruby_include_tag(source: :local_dist, base_styles: false)
@@ -158,6 +180,7 @@ class PicorubyHelperTest < Minitest::Test
   end
 
   def test_metadata_values_are_html_escaped
+    @config.local_database = true
     @config.application_id = %q{"><script>alert(1)</script>}
     @config.user_key = ->(controller) { controller.current_user_key }
     view = metadata_view(user_key: %q{"><img src=x>})
@@ -168,6 +191,8 @@ class PicorubyHelperTest < Minitest::Test
   end
 
   def test_caller_data_attributes_survive_alongside_the_metadata
+    @config.local_database = true
+    @config.anonymous_only = true
     html = @view.picoruby_include_tag(source: :local_dist, base_styles: false,
                                       data: { turbo_track: "reload" })
     assert_includes html, 'data-turbo-track="reload"'
@@ -179,6 +204,7 @@ class PicorubyHelperTest < Minitest::Test
     # page disagree with its own responses (instant terminal) or boot
     # the wrong namespace: the framework's values win, in every key
     # spelling that would render as the same HTML attribute.
+    @config.local_database = true
     @config.user_key = ->(controller) { controller.current_user_key }
     session = {}
     view = metadata_view(user_key: "u1", session: session)
@@ -201,6 +227,17 @@ class PicorubyHelperTest < Minitest::Test
     assert_equal 1, html.scan("data-funicular-epoch=").size
     assert_equal 1, html.scan("data-funicular-user-key=").size
     assert_equal 1, html.scan("data-funicular-application-id=").size
+  end
+
+  def test_caller_data_cannot_enable_the_disabled_local_database
+    html = @view.picoruby_include_tag(
+      source: :local_dist, base_styles: false,
+      data: { funicular_local_database: "true",
+              "funicular-application-id" => "injected",
+              funicular_anonymous_only: "true" })
+    refute_includes html, "data-funicular-local-database"
+    refute_includes html, "data-funicular-application-id"
+    refute_includes html, "data-funicular-anonymous-only"
   end
 
   def test_cdn_source_uses_versioned_jsdelivr_url

--- a/minitest/session_epoch_test.rb
+++ b/minitest/session_epoch_test.rb
@@ -1,0 +1,122 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# Exercises Funicular::SessionEpoch, the server half of the session
+# epoch (docs decision 13): identity encoding, rotation on every
+# authentication transition, stability while the identity holds, and
+# per-application_id isolation inside one shared Rails session.
+class SessionEpochTest < Minitest::Test
+  FakeController = Struct.new(:current_user_key)
+
+  def setup
+    @config = Funicular::Configuration.new
+    Funicular.instance_variable_set(:@configuration, @config)
+    @session = {}
+  end
+
+  def teardown
+    Funicular.instance_variable_set(:@configuration, nil)
+  end
+
+  def controller_for(key)
+    FakeController.new(key)
+  end
+
+  def configure_user_key
+    @config.user_key = ->(controller) { controller&.current_user_key }
+  end
+
+  def stamp(key)
+    Funicular::SessionEpoch.stamp!(@session, controller_for(key))
+  end
+
+  # --- identity ---------------------------------------------------------
+
+  def test_identity_is_the_typed_versioned_tuple
+    configure_user_key
+    assert_equal '["v1","funicular","anonymous"]',
+                 Funicular::SessionEpoch.identity(controller_for(nil))
+    assert_equal '["v1","funicular","user","u1"]',
+                 Funicular::SessionEpoch.identity(controller_for("u1"))
+  end
+
+  def test_user_key_is_canonicalized_with_to_s
+    configure_user_key
+    assert_equal '["v1","funicular","user","42"]',
+                 Funicular::SessionEpoch.identity(controller_for(42))
+  end
+
+  def test_a_user_key_of_anonymous_cannot_collide_with_signed_out
+    configure_user_key
+    refute_equal Funicular::SessionEpoch.identity(controller_for(nil)),
+                 Funicular::SessionEpoch.identity(controller_for("anonymous"))
+  end
+
+  def test_without_a_user_key_lambda_everyone_is_anonymous
+    assert_equal '["v1","funicular","anonymous"]',
+                 Funicular::SessionEpoch.identity(controller_for("u1"))
+  end
+
+  def test_empty_resolved_user_key_fails_loud
+    configure_user_key
+    error = assert_raises(Funicular::Error) { stamp("") }
+    assert_includes error.message, "empty"
+  end
+
+  # --- rotation ---------------------------------------------------------
+
+  def test_stamp_creates_and_then_holds_an_epoch
+    configure_user_key
+    epoch = stamp("u1")
+    refute_empty epoch
+    assert_equal epoch, stamp("u1")
+    assert_equal epoch, stamp("u1")
+  end
+
+  def test_login_logout_and_switch_all_rotate
+    configure_user_key
+    anonymous = stamp(nil)
+    login = stamp("u1")
+    refute_equal anonymous, login
+    switch = stamp("u2")
+    refute_equal login, switch
+    logout = stamp(nil)
+    refute_equal switch, logout
+    # A fresh anonymous epoch, not the first one resurrected.
+    refute_equal anonymous, logout
+  end
+
+  # --- per-application isolation ----------------------------------------
+
+  def test_epochs_are_tracked_per_application_id
+    configure_user_key
+    epoch_a = stamp("u1")
+    @config.application_id = "second_app"
+    epoch_b = stamp("u1")
+    refute_equal epoch_a, epoch_b
+    # Rotating the second app's epoch leaves the first app's alone.
+    stamp("u2")
+    @config.application_id = "funicular"
+    assert_equal epoch_a, stamp("u1")
+  end
+
+  # --- session shape ------------------------------------------------------
+
+  def test_session_entry_uses_string_keys_for_json_round_trips
+    configure_user_key
+    epoch = stamp("u1")
+    entry = @session["funicular_epochs"]["funicular"]
+    assert_equal '["v1","funicular","user","u1"]', entry["identity"]
+    assert_equal epoch, entry["epoch"]
+  end
+
+  def test_a_corrupt_session_value_is_replaced_not_crashed_on
+    configure_user_key
+    @session["funicular_epochs"] = "garbage"
+    epoch = stamp("u1")
+    refute_empty epoch
+    assert_equal epoch,
+                 @session["funicular_epochs"]["funicular"]["epoch"]
+  end
+end

--- a/minitest/ssr_database_test.rb
+++ b/minitest/ssr_database_test.rb
@@ -42,4 +42,37 @@ class SSRDatabaseTest < Minitest::Test
       model.local_create(title: "nope")
     end
   end
+
+  def test_association_declarations_evaluate_but_reading_raises
+    # Named constants, because the conventions read the class name:
+    # SsrPost -> ssr_post_id, :ssr_comment -> SsrComment.
+    Object.const_set(:SsrComment, Class.new(Funicular::Model) do
+      storage :local do
+        migrate 1 do |t|
+          t.integer :ssr_post_id
+        end
+      end
+    end)
+    Object.const_set(:SsrPost, Class.new(Funicular::Model))
+    # Declared after the constant exists, the way a `class SsrPost <
+    # Funicular::Model` body reads: has_many derives its foreign key
+    # from the declaring class name.
+    SsrPost.class_eval do
+      storage :local do
+        migrate 1 do |t|
+          t.integer :ssr_comment_id
+        end
+      end
+      belongs_to :ssr_comment
+      has_many :ssr_comments
+    end
+    # The declaration side worked: nothing resolved, no SQLite touched.
+    record = SsrPost.new(ssr_comment_id: 1)
+    # Reading one is a local query, and the server has no local database.
+    assert_raises(Funicular::DB::UnavailableError) { record.ssr_comment }
+    assert_raises(Funicular::DB::UnavailableError) { record.ssr_comments.to_a }
+  ensure
+    Object.send(:remove_const, :SsrPost) if Object.const_defined?(:SsrPost)
+    Object.send(:remove_const, :SsrComment) if Object.const_defined?(:SsrComment)
+  end
 end

--- a/minitest/ssr_database_test.rb
+++ b/minitest/ssr_database_test.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# The SSR contract for the local database (docs decision 18): model
+# class bodies evaluate under CRuby -- declarations are recorded, no
+# SQLite is touched -- but booting the database or materializing a
+# local query on the server fails loud with UnavailableError, never an
+# empty result.
+class SSRDatabaseTest < Minitest::Test
+  def setup
+    # Loads the mrblib runtime under CRuby and flips Funicular.server
+    # to true, exactly like a Rails SSR render.
+    Funicular::SSR::Runtime.load_framework!
+  end
+
+  def test_boot_refuses_on_the_server
+    error = assert_raises(Funicular::DB::UnavailableError) do
+      Funicular::DB.boot(models: [], metadata: {})
+    end
+    assert_includes error.message, "SSR"
+    # The refusal is a clean raise, not a failed state: nothing to
+    # tear down, nothing latched.
+    assert_equal :unbooted, Funicular::DB.boot_state
+  end
+
+  def test_a_local_class_body_evaluates_but_materializing_raises
+    model = Class.new(Funicular::Model) do
+      table_name "ssr_drafts"
+      storage :local do
+        migrate 1 do |t|
+          t.string :title
+        end
+      end
+    end
+    # The declaration side worked: storage recorded, no SQLite touched.
+    assert_equal true, model.local?
+    # Materializing is where the server says no.
+    assert_raises(Funicular::DB::UnavailableError) { model.count }
+    assert_raises(Funicular::DB::UnavailableError) { model.local.to_a }
+    assert_raises(Funicular::DB::UnavailableError) do
+      model.local_create(title: "nope")
+    end
+  end
+end

--- a/minitest/validations_test.rb
+++ b/minitest/validations_test.rb
@@ -170,14 +170,15 @@ class ValidationsTest < Minitest::Test
     m = k.new("name" => "ok")
     m.instance_variable_set("@id", 1)
 
-    got_success = :unset
     got_result = :unset
-    m.update("name" => "") do |success, result|
-      got_success = success
+    got_error = :unset
+    m.update("name" => "") do |result, error|
       got_result = result
+      got_error = error
     end
 
-    assert_equal false, got_success
-    assert_equal ["can't be blank"], got_result[:name]
+    # Unified 0.5.0 callback contract: (result, error), result nil on failure
+    assert_nil got_result
+    assert_equal ["can't be blank"], got_error[:name]
   end
 end

--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -7,6 +7,7 @@ MRuby::Gem::Specification.new('picoruby-funicular') do |spec|
     spec.add_dependency 'picoruby-wasm'
   end
   spec.add_dependency 'picoruby-indexeddb'
+  spec.add_dependency 'picoruby-sqlite3'
   spec.add_dependency 'picoruby-json'
   spec.add_dependency 'picoruby-uri'
   spec.add_dependency 'mruby-object-ext', gemdir: "#{MRUBY_ROOT}/mrbgems/picoruby-mruby/lib/mruby/mrbgems/mruby-object-ext"

--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -8,6 +8,7 @@ MRuby::Gem::Specification.new('picoruby-funicular') do |spec|
   end
   spec.add_dependency 'picoruby-indexeddb'
   spec.add_dependency 'picoruby-json'
+  spec.add_dependency 'picoruby-uri'
   spec.add_dependency 'mruby-object-ext', gemdir: "#{MRUBY_ROOT}/mrbgems/picoruby-mruby/lib/mruby/mrbgems/mruby-object-ext"
   spec.add_dependency 'mruby-hash-ext', gemdir: "#{MRUBY_ROOT}/mrbgems/picoruby-mruby/lib/mruby/mrbgems/mruby-hash-ext"
   spec.add_dependency 'mruby-array-ext', gemdir: "#{MRUBY_ROOT}/mrbgems/picoruby-mruby/lib/mruby/mrbgems/mruby-array-ext"

--- a/mrblib/cable.rb
+++ b/mrblib/cable.rb
@@ -229,7 +229,7 @@ module Funicular
 
       # Setup beforeunload handler to persist pending commands
       def setup_beforeunload_handler
-        @beforeunload_callback_id = JS.global.addEventListener("beforeunload") do
+        @beforeunload_callback_id = JS.global.addEventListener("beforeunload", sync: true) do
           save_pending_to_storage
         end
       end

--- a/mrblib/component.rb
+++ b/mrblib/component.rb
@@ -171,6 +171,72 @@ module Funicular
       self
     end
 
+    # Bind a state key to a local-database Relation (docs decision 10):
+    # the block runs once now, and again after every change event on the
+    # relation's table. Each evaluation re-subscribes (a branchy block
+    # may return a different model's relation this time) and patches
+    # state[key], triggering a re-render. Subscriptions die with the
+    # component (see unmount), even when a lifecycle hook raises.
+    def watch(key, &block)
+      unless block
+        raise ArgumentError, "watch requires a block returning a Relation"
+      end
+      evaluate_watch(key, block)
+      nil
+    end
+
+    # Framework use (the subscription re-enters here on every event).
+    def evaluate_watch(key, block)
+      relation = block.call
+      unless relation.is_a?(Funicular::Relation)
+        raise ArgumentError,
+          "the watch(:#{key}) block must return a Funicular::Relation, " \
+          "got #{relation.class}; for hashes, counts, or raw SQL, " \
+          "subscribe with Model.on_change and patch state yourself"
+      end
+      # Materialize BEFORE touching subscriptions: if the query raises,
+      # neither a fresh subscription leaks (initial watch) nor the
+      # previous healthy one is lost (re-evaluation). Next-tick delivery
+      # guarantees no change event interleaves with this evaluation.
+      records = relation.to_a
+      source = relation.__event_source
+      watches = (@__watches ||= {}) # steep:ignore UnannotatedEmptyCollection
+      old = watches[key]
+      Funicular::DB.unsubscribe(old) if old
+      component = self
+      watches[key] = Funicular::DB.subscribe(source[0], source[1]) do |r, t|
+        component.evaluate_watch(key, block)
+      end
+      if @mounted
+        # The normal update contract: patch runs the update lifecycle
+        # (component_will_update/component_updated/component_raised),
+        # normalizes values, and re-renders. The bus's next-tick
+        # delivery guarantees we are never inside another update here.
+        patch(key => records)
+      else
+        # Before mount there is no update lifecycle to honor yet: land
+        # the initial data directly so state is ready for the first
+        # render.
+        @state = @state.merge({ key => records })
+        @state_accessor = nil
+      end
+      nil
+    end
+
+    def cleanup_watches
+      watches = @__watches
+      return nil unless watches
+      keys = watches.keys
+      keys_size = keys.size
+      i = 0
+      while i < keys_size
+        Funicular::DB.unsubscribe(watches[keys[i]])
+        i += 1
+      end
+      @__watches = {}
+      nil
+    end
+
     # Load all registered suspense data
     # Called automatically in component_mounted if suspense definitions exist
     def load_suspense_data
@@ -408,6 +474,10 @@ module Funicular
 
         component_mounted if respond_to?(:component_mounted)
       rescue => e
+        # A failed mount never reaches unmount (@mounted is still
+        # false), so watch subscriptions taken before/during the mount
+        # must be released here or they would pin the dead component.
+        cleanup_watches
         component_raised(e) if respond_to?(:component_raised)
         raise e
       end
@@ -423,9 +493,12 @@ module Funicular
     # window.__FUNICULAR_STATE__ before calling this.
     def hydrate(dom_element)
       return if @mounted
-      raise "hydrate: missing server DOM element" unless dom_element
 
       begin
+        # Inside the begin so a nil element takes the same cleanup path
+        # (releasing watch subscriptions) as every other hydrate failure.
+        raise "hydrate: missing server DOM element" unless dom_element
+
         component_will_mount if respond_to?(:component_will_mount)
 
         # The router/start sets the container; without it, unmount could not
@@ -467,6 +540,9 @@ module Funicular
 
         component_mounted if respond_to?(:component_mounted)
       rescue => e
+        # Same as mount: a failed hydrate cannot be unmounted, so the
+        # watch subscriptions must not outlive it.
+        cleanup_watches
         component_raised(e) if respond_to?(:component_raised)
         raise e
       end
@@ -502,6 +578,11 @@ module Funicular
       rescue => e
         component_raised(e) if respond_to?(:component_raised)
         raise e
+      ensure
+        # Watch subscriptions die with the component NO MATTER WHAT: a
+        # raising lifecycle hook must not leave a zombie watcher
+        # patching an unmounted component (docs decision 10).
+        cleanup_watches
       end
     end
 

--- a/mrblib/db.rb
+++ b/mrblib/db.rb
@@ -1953,9 +1953,28 @@ module Funicular
       end
       return false unless state == :persistent_writer
       cancel_persist_timers
-      wrote_replica = persist_snapshot(:replica)
-      wrote_local = persist_snapshot(:local)
-      wrote_replica || wrote_local
+      # Every REGISTERED database, and never short-circuiting: a local
+      # snapshot that defers (transaction) or fails must not skip the
+      # replica, and the pair reports success only when all of it
+      # landed. A caller about to navigate away reads this return
+      # value as "the data is safe" -- one deferred role makes that a
+      # lie. A role with no database behind it (a page with no local
+      # models, say) is nothing to persist and does not count.
+      roles = [:replica, :local]
+      wrote = 0
+      missed = 0
+      i = 0
+      while i < roles.size
+        role = roles[i]
+        i += 1
+        next unless __registered_database(role)
+        if persist_snapshot(role)
+          wrote += 1
+        else
+          missed += 1
+        end
+      end
+      0 < wrote && missed == 0
     end
 
     # The tab-hidden backstop (docs decision 11): debounce alone would

--- a/mrblib/db.rb
+++ b/mrblib/db.rb
@@ -32,6 +32,10 @@ module Funicular
     # (SSR) or before boot completed.
     class UnavailableError < Error; end
 
+    # The user_key/anonymous_only/application_id declaration is invalid
+    # (docs decision 12); startup must not proceed.
+    class ConfigError < Error; end
+
     # One shared codec for values crossing the Ruby/SQLite boundary.
     # Applied identically to local writes, reads, condition binds, and REST
     # response initialization, so both sides of a model return the same
@@ -736,6 +740,77 @@ module Funicular
 
     def self.index_name(table, columns)
       "index_#{table}_on_#{columns.join("_")}"
+    end
+
+    # ---- namespace identity (docs decisions 12/13) ----------------------
+    #
+    # One browser profile can hold data for several apps and several
+    # users, so everything durable -- the two snapshot keys, the Web
+    # Lock name, the identity the Rails session tracks for epoch
+    # rotation -- hangs off ONE identity: a typed, versioned tuple
+    # encoded as canonical JSON. STRUCTURE separates the fields, not a
+    # delimiter, so a user_key of "anonymous" (or one containing any
+    # separator) can never collide with the anonymous identity or with
+    # another application's.
+
+    # ["v1", app, "anonymous"] or ["v1", app, "user", key] as a JSON
+    # string. Empty application_id/user_key fail loud: they would fold
+    # distinct namespaces into one.
+    def self.namespace_identity(application_id, user_key, anonymous)
+      app = application_id.to_s
+      if app.empty?
+        raise ConfigError,
+          "application_id must be configured (Funicular.configure)"
+      end
+      return JSON.generate(["v1", app, "anonymous"]) if anonymous
+      key = user_key.to_s
+      if key.empty?
+        raise ConfigError, "user_key must not be empty"
+      end
+      JSON.generate(["v1", app, "user", key])
+    end
+
+    # The declaration rules, checked authoritatively on the CLIENT (docs
+    # decision 12: only the client knows whether storage :local models
+    # are declared). user_key_configured says whether a user_key SOURCE
+    # is declared at all; user_key is the value it resolved to for THIS
+    # page load -- nil while signed out. Configuration errors key off
+    # the flag, the anonymous/user choice keys off the value: a
+    # signed-out visit to an app with local models boots into the
+    # anonymous namespace instead of failing.
+    def self.resolve_namespace(application_id:, user_key:,
+                               user_key_configured:, anonymous_only:,
+                               local_models:)
+      if user_key_configured && anonymous_only
+        raise ConfigError,
+          "user_key and anonymous_only are mutually exclusive; " \
+          "configure exactly one"
+      end
+      if !user_key_configured && !anonymous_only && local_models
+        raise ConfigError,
+          "storage :local models are declared but no user_key is " \
+          "configured; set config.user_key, or anonymous_only = true " \
+          "to accept one shared anonymous namespace"
+      end
+      # nil is the legitimate signed-out state. An EMPTY string is a
+      # broken user_key source: it falls through to namespace_identity's
+      # ConfigError, because silently folding it into the shared
+      # anonymous namespace would mix distinct users' data.
+      namespace_identity(application_id, user_key, user_key.nil?)
+    end
+
+    # Everything durable derives its name from the identity string.
+
+    def self.snapshot_key(identity, role)
+      unless role == :replica || role == :local
+        raise ArgumentError,
+          "role must be :replica or :local, got #{role.inspect}"
+      end
+      "funicular:snapshot:#{role}:#{identity}"
+    end
+
+    def self.lock_name(identity)
+      "funicular:lock:#{identity}"
     end
 
     # ---- replica tables: schema-derived DDL + fingerprint ---------------

--- a/mrblib/db.rb
+++ b/mrblib/db.rb
@@ -909,42 +909,69 @@ module Funicular
     # row is authoritative, there is no partial merge). Fires the
     # model's change hook.
     def self.replica_upsert(db, model, attrs)
-      columns = model.local_columns
-      table = validate_identifier(model.table_name)
-      names = columns.keys
-      # @type var cols: Array[String]
-      cols = []
-      # @type var marks: Array[String]
-      marks = []
-      # @type var binds: Array[untyped]
-      binds = []
-      id_present = false
-      names_size = names.size
-      i = 0
-      while i < names_size
-        name = names[i]
-        if attrs.has_key?(name)
-          value = attrs[name]
-        elsif attrs.has_key?(name.to_sym)
-          value = attrs[name.to_sym]
-        else
-          value = nil
-        end
-        id_present = true if name == "id" && !value.nil?
-        cols << "\"#{name}\""
-        marks << "?"
-        binds << Codec.encode(columns[name], value)
-        i += 1
-      end
-      unless id_present
-        raise ArgumentError,
-          "replica upsert into #{model.table_name} requires an id; " \
-          "the server row has none"
-      end
-      db.execute("INSERT OR REPLACE INTO \"#{table}\" " \
-                 "(#{cols.join(", ")}) VALUES (#{marks.join(", ")})", binds)
+      replica_upsert_row(db, model, attrs)
       model.local_table_changed
       true
+    end
+
+    # Batch apply for whole-collection fetches: every row lands -- or,
+    # when any row fails (a malformed value, most likely), NONE does --
+    # inside ONE transaction, and the change hook fires once after the
+    # commit: a 50-row fetch is one event, not fifty.
+    def self.replica_upsert_all(db, model, rows)
+      rows_size = rows.size
+      return true if rows_size == 0
+      db.transaction do
+        i = 0
+        while i < rows_size
+          replica_upsert_row(db, model, rows[i])
+          i += 1
+        end
+      end
+      model.local_table_changed
+      true
+    end
+
+    class << self
+      # NOT a public entry point: writing a row without the change
+      # notification would bypass the apply-path contract. Only
+      # replica_upsert and replica_upsert_all come through here.
+      private def replica_upsert_row(db, model, attrs)
+        columns = model.local_columns
+        table = validate_identifier(model.table_name)
+        names = columns.keys
+        # @type var cols: Array[String]
+        cols = []
+        # @type var marks: Array[String]
+        marks = []
+        # @type var binds: Array[untyped]
+        binds = []
+        id_present = false
+        names_size = names.size
+        i = 0
+        while i < names_size
+          name = names[i]
+          if attrs.has_key?(name)
+            value = attrs[name]
+          elsif attrs.has_key?(name.to_sym)
+            value = attrs[name.to_sym]
+          else
+            value = nil
+          end
+          id_present = true if name == "id" && !value.nil?
+          cols << "\"#{name}\""
+          marks << "?"
+          binds << Codec.encode(columns[name], value)
+          i += 1
+        end
+        unless id_present
+          raise ArgumentError,
+            "replica upsert into #{model.table_name} requires an id; " \
+            "the server row has none"
+        end
+        db.execute("INSERT OR REPLACE INTO \"#{table}\" " \
+                   "(#{cols.join(", ")}) VALUES (#{marks.join(", ")})", binds)
+      end
     end
 
     # Remove one mirrored row (write-through destroy). Notifies only

--- a/mrblib/db.rb
+++ b/mrblib/db.rb
@@ -352,16 +352,18 @@ module Funicular
     # migration version per table (and, later, the replica fingerprint).
     META_TABLE = "funicular_meta"
 
-    # The metadata table belongs to the framework: no model -- local or
-    # replica -- may claim its name (SQLite table names are
-    # case-insensitive, so the check is too).
-    def self.guard_reserved_table(table)
-      if table.downcase == META_TABLE
-        raise ArgumentError,
-          "\"#{table}\" is reserved for framework metadata; pick " \
-          "another table_name"
+    class << self
+      # The metadata table belongs to the framework: no model -- local or
+      # replica -- may claim its name (SQLite table names are
+      # case-insensitive, so the check is too).
+      private def guard_reserved_table(table)
+        if table.downcase == META_TABLE
+          raise ArgumentError,
+            "\"#{table}\" is reserved for framework metadata; pick " \
+            "another table_name"
+        end
+        table
       end
-      table
     end
 
     # SQL identifiers this layer interpolates (table and column names) must
@@ -387,18 +389,20 @@ module Funicular
       s
     end
 
-    # The index of the block the table is (re)built from: the NEWEST
-    # `reset: true` block, or the first block when none is marked. Blocks
-    # before it are superseded history -- they may stay in the code (the
-    # docs only say they MAY be deleted) but are never folded or applied.
-    def self.baseline_index(migrations)
-      base = 0
-      i = 0
-      while i < migrations.size
-        base = i if migrations[i][:reset]
-        i += 1
+    class << self
+      # The index of the block the table is (re)built from: the NEWEST
+      # `reset: true` block, or the first block when none is marked. Blocks
+      # before it are superseded history -- they may stay in the code (the
+      # docs only say they MAY be deleted) but are never folded or applied.
+      private def baseline_index(migrations)
+        base = 0
+        i = 0
+        while i < migrations.size
+          base = i if migrations[i][:reset]
+          i += 1
+        end
+        base
       end
-      base
     end
 
     # Fold a model's migrate blocks into column metadata (column name ->
@@ -409,18 +413,20 @@ module Funicular
       fold_builders(collect_builders(model), model.local_migrations, model)
     end
 
-    # The fold over ALREADY-collected builders: the migration runner
-    # evaluates each migrate block exactly once per run and feeds the same
-    # recorded operations to this validation and to the DDL.
-    def self.fold_builders(builders, migrations, model)
-      # @type var columns: Hash[String, Symbol]
-      columns = { "id" => :integer }
-      i = migrations ? baseline_index(migrations) : 0
-      while i < builders.size
-        fold_ops(columns, builders[i].ops, model)
-        i += 1
+    class << self
+      # The fold over ALREADY-collected builders: the migration runner
+      # evaluates each migrate block exactly once per run and feeds the same
+      # recorded operations to this validation and to the DDL.
+      private def fold_builders(builders, migrations, model)
+        # @type var columns: Hash[String, Symbol]
+        columns = { "id" => :integer }
+        i = migrations ? baseline_index(migrations) : 0
+        while i < builders.size
+          fold_ops(columns, builders[i].ops, model)
+          i += 1
+        end
+        columns
       end
-      columns
     end
 
     # Bring one model's local table to its declared schema. Fresh and
@@ -527,219 +533,221 @@ module Funicular
                  "VALUES (?, ?)", [key, value])
     end
 
-    def self.ensure_meta_table(db)
-      db.execute("CREATE TABLE IF NOT EXISTS \"#{META_TABLE}\" " \
-                 "(key TEXT PRIMARY KEY, value TEXT)")
-    end
-
-    # Run every migrate block against a fresh TableBuilder, returning the
-    # recorded operations in declaration order. The runner calls this
-    # exactly once per migration run; local_columns is the only other
-    # caller. Blocks should stay deterministic and side-effect free.
-    def self.collect_builders(model)
-      migrations = model.local_migrations
-      unless migrations
-        raise ArgumentError,
-          "#{model} has no migrate blocks (is it storage :local?)"
+    class << self
+      private def ensure_meta_table(db)
+        db.execute("CREATE TABLE IF NOT EXISTS \"#{META_TABLE}\" " \
+                   "(key TEXT PRIMARY KEY, value TEXT)")
       end
-      # @type var builders: Array[TableBuilder]
-      builders = []
-      i = 0
-      while i < migrations.size
-        t = TableBuilder.new
-        migrations[i][:block].call(t)
-        builders << t
-        i += 1
-      end
-      builders
-    end
 
-    # Apply one block's column effects to the running fold. Unknown or
-    # duplicate names fail here, before any SQL runs.
-    def self.fold_ops(columns, ops, model)
-      i = 0
-      while i < ops.size
-        op = ops[i]
-        kind = op[0]
-        if kind == :add_column
-          name = op[1]
-          if columns.has_key?(name)
-            raise ArgumentError,
-              "duplicate column #{name.inspect} in #{model.table_name} migrations"
-          end
-          guard_reserved_column(name, model)
-          columns[name] = op[2]
-        elsif kind == :rename
-          old_name = op[1]
-          guard_id(old_name, model)
-          type = columns[old_name]
-          unless type
-            raise ArgumentError,
-              "rename of unknown column #{old_name.inspect} in " \
-              "#{model.table_name} migrations"
-          end
-          if columns.has_key?(op[2])
-            raise ArgumentError,
-              "duplicate column #{op[2].inspect} in #{model.table_name} migrations"
-          end
-          guard_reserved_column(op[2], model)
-          columns.delete(old_name)
-          columns[op[2]] = type
-        elsif kind == :remove
-          name = op[1]
-          guard_id(name, model)
-          unless columns.has_key?(name)
-            raise ArgumentError,
-              "remove of unknown column #{name.inspect} in " \
-              "#{model.table_name} migrations"
-          end
-          columns.delete(name)
+      # Run every migrate block against a fresh TableBuilder, returning the
+      # recorded operations in declaration order. The runner calls this
+      # exactly once per migration run; local_columns is the only other
+      # caller. Blocks should stay deterministic and side-effect free.
+      private def collect_builders(model)
+        migrations = model.local_migrations
+        unless migrations
+          raise ArgumentError,
+            "#{model} has no migrate blocks (is it storage :local?)"
         end
-        # index/remove_index/execute do not affect the fold
-        i += 1
-      end
-    end
-
-    def self.guard_id(name, model)
-      if name == "id"
-        raise ArgumentError,
-          "the id column is implicit and cannot be renamed or removed " \
-          "(#{model.table_name} migrations)"
-      end
-    end
-
-    # A column name must not shadow the model API: the generated reader
-    # would clobber anything the BASE Funicular::Model instance already
-    # responds to (destroy, reload, update, valid?, errors, class, hash,
-    # ...). Checking against the base class -- never the subclass -- keeps
-    # a model's own generated accessors from tripping the guard when its
-    # blocks are folded again.
-    def self.guard_reserved_column(name, model)
-      # The __ prefix is the framework-internal namespace (__custom_*
-      # writer stashes, __local_* helpers): a column named __custom_title
-      # would clobber the alias that wraps a hand-written title= writer.
-      if name.start_with?("__")
-        raise ArgumentError,
-          "column names starting with __ are reserved for framework " \
-          "internals (#{model.table_name} migrations); rename " \
-          "#{name.inspect}"
-      end
-      reserved = @reserved_column_names
-      unless reserved
-        # Both lists: instance_methods alone omits private methods, and a
-        # column named "initialize" or "method_missing" must be rejected
-        # just as hard as "destroy".
-        reserved = Funicular::Model.instance_methods +
-                   Funicular::Model.private_instance_methods
-        @reserved_column_names = reserved
-      end
-      if reserved.include?(name.to_sym)
-        raise ArgumentError,
-          "column name #{name.inspect} collides with a Funicular::Model " \
-          "method (#{model.table_name} migrations); rename the column"
-      end
-    end
-
-    # Apply every block at or after the baseline with version >
-    # from_version (pre-baseline history is never applied), using the
-    # builders the caller already collected and validated. The first
-    # block applied onto a dropped/absent table runs in create mode (its
-    # column ops become the CREATE TABLE); everything later alters.
-    def self.apply_blocks(db, model, from_version, builders)
-      migrations = model.local_migrations
-      table = validate_identifier(model.table_name)
-      i = baseline_index(migrations)
-      creating = from_version < migrations[i][:version]
-      while i < migrations.size
-        if from_version < migrations[i][:version]
-          run_block(db, table, builders[i], creating)
-          creating = false
-        end
-        i += 1
-      end
-    end
-
-    def self.run_block(db, table, builder, create_mode)
-      ops = builder.ops
-      if create_mode
-        # @type var defs: Array[String]
-        defs = ["\"id\" INTEGER PRIMARY KEY"]
+        # @type var builders: Array[TableBuilder]
+        builders = []
         i = 0
-        while i < ops.size
-          op = ops[i]
-          defs << column_ddl(op) if op[0] == :add_column
+        while i < migrations.size
+          t = TableBuilder.new
+          migrations[i][:block].call(t)
+          builders << t
           i += 1
         end
-        db.execute("CREATE TABLE \"#{table}\" (#{defs.join(", ")})")
+        builders
+      end
+
+      # Apply one block's column effects to the running fold. Unknown or
+      # duplicate names fail here, before any SQL runs.
+      private def fold_ops(columns, ops, model)
         i = 0
         while i < ops.size
           op = ops[i]
           kind = op[0]
           if kind == :add_column
-            # already part of the CREATE TABLE
-          elsif kind == :index || kind == :remove_index || kind == :execute
-            run_alter_op(db, table, op)
-          else
-            raise ArgumentError,
-              "#{kind} needs an existing table; not allowed in the block " \
-              "that creates \"#{table}\""
+            name = op[1]
+            if columns.has_key?(name)
+              raise ArgumentError,
+                "duplicate column #{name.inspect} in #{model.table_name} migrations"
+            end
+            guard_reserved_column(name, model)
+            columns[name] = op[2]
+          elsif kind == :rename
+            old_name = op[1]
+            guard_id(old_name, model)
+            type = columns[old_name]
+            unless type
+              raise ArgumentError,
+                "rename of unknown column #{old_name.inspect} in " \
+                "#{model.table_name} migrations"
+            end
+            if columns.has_key?(op[2])
+              raise ArgumentError,
+                "duplicate column #{op[2].inspect} in #{model.table_name} migrations"
+            end
+            guard_reserved_column(op[2], model)
+            columns.delete(old_name)
+            columns[op[2]] = type
+          elsif kind == :remove
+            name = op[1]
+            guard_id(name, model)
+            unless columns.has_key?(name)
+              raise ArgumentError,
+                "remove of unknown column #{name.inspect} in " \
+                "#{model.table_name} migrations"
+            end
+            columns.delete(name)
+          end
+          # index/remove_index/execute do not affect the fold
+          i += 1
+        end
+      end
+
+      private def guard_id(name, model)
+        if name == "id"
+          raise ArgumentError,
+            "the id column is implicit and cannot be renamed or removed " \
+            "(#{model.table_name} migrations)"
+        end
+      end
+
+      # A column name must not shadow the model API: the generated reader
+      # would clobber anything the BASE Funicular::Model instance already
+      # responds to (destroy, reload, update, valid?, errors, class, hash,
+      # ...). Checking against the base class -- never the subclass -- keeps
+      # a model's own generated accessors from tripping the guard when its
+      # blocks are folded again.
+      private def guard_reserved_column(name, model)
+        # The __ prefix is the framework-internal namespace (__custom_*
+        # writer stashes, __local_* helpers): a column named __custom_title
+        # would clobber the alias that wraps a hand-written title= writer.
+        if name.start_with?("__")
+          raise ArgumentError,
+            "column names starting with __ are reserved for framework " \
+            "internals (#{model.table_name} migrations); rename " \
+            "#{name.inspect}"
+        end
+        reserved = @reserved_column_names
+        unless reserved
+          # Both lists: instance_methods alone omits private methods, and a
+          # column named "initialize" or "method_missing" must be rejected
+          # just as hard as "destroy".
+          reserved = Funicular::Model.instance_methods +
+                     Funicular::Model.private_instance_methods
+          @reserved_column_names = reserved
+        end
+        if reserved.include?(name.to_sym)
+          raise ArgumentError,
+            "column name #{name.inspect} collides with a Funicular::Model " \
+            "method (#{model.table_name} migrations); rename the column"
+        end
+      end
+
+      # Apply every block at or after the baseline with version >
+      # from_version (pre-baseline history is never applied), using the
+      # builders the caller already collected and validated. The first
+      # block applied onto a dropped/absent table runs in create mode (its
+      # column ops become the CREATE TABLE); everything later alters.
+      private def apply_blocks(db, model, from_version, builders)
+        migrations = model.local_migrations
+        table = validate_identifier(model.table_name)
+        i = baseline_index(migrations)
+        creating = from_version < migrations[i][:version]
+        while i < migrations.size
+          if from_version < migrations[i][:version]
+            run_block(db, table, builders[i], creating)
+            creating = false
           end
           i += 1
         end
-      else
-        i = 0
-        while i < ops.size
-          run_alter_op(db, table, ops[i])
-          i += 1
+      end
+
+      private def run_block(db, table, builder, create_mode)
+        ops = builder.ops
+        if create_mode
+          # @type var defs: Array[String]
+          defs = ["\"id\" INTEGER PRIMARY KEY"]
+          i = 0
+          while i < ops.size
+            op = ops[i]
+            defs << column_ddl(op) if op[0] == :add_column
+            i += 1
+          end
+          db.execute("CREATE TABLE \"#{table}\" (#{defs.join(", ")})")
+          i = 0
+          while i < ops.size
+            op = ops[i]
+            kind = op[0]
+            if kind == :add_column
+              # already part of the CREATE TABLE
+            elsif kind == :index || kind == :remove_index || kind == :execute
+              run_alter_op(db, table, op)
+            else
+              raise ArgumentError,
+                "#{kind} needs an existing table; not allowed in the block " \
+                "that creates \"#{table}\""
+            end
+            i += 1
+          end
+        else
+          i = 0
+          while i < ops.size
+            run_alter_op(db, table, ops[i])
+            i += 1
+          end
         end
       end
-    end
 
-    def self.run_alter_op(db, table, op)
-      kind = op[0]
-      if kind == :add_column
-        db.execute("ALTER TABLE \"#{table}\" ADD COLUMN #{column_ddl(op)}")
-      elsif kind == :rename
-        db.execute("ALTER TABLE \"#{table}\" RENAME COLUMN \"#{op[1]}\" " \
-                   "TO \"#{op[2]}\"")
-      elsif kind == :remove
-        db.execute("ALTER TABLE \"#{table}\" DROP COLUMN \"#{op[1]}\"")
-      elsif kind == :index
-        db.execute("CREATE INDEX \"#{index_name(table, op[1])}\" " \
-                   "ON \"#{table}\" (#{quoted_list(op[1])})")
-      elsif kind == :remove_index
-        db.execute("DROP INDEX \"#{index_name(table, op[1])}\"")
-      elsif kind == :execute
-        db.execute(op[1])
-      else
-        raise ArgumentError, "unknown migration op #{kind.inspect}"
+      private def run_alter_op(db, table, op)
+        kind = op[0]
+        if kind == :add_column
+          db.execute("ALTER TABLE \"#{table}\" ADD COLUMN #{column_ddl(op)}")
+        elsif kind == :rename
+          db.execute("ALTER TABLE \"#{table}\" RENAME COLUMN \"#{op[1]}\" " \
+                     "TO \"#{op[2]}\"")
+        elsif kind == :remove
+          db.execute("ALTER TABLE \"#{table}\" DROP COLUMN \"#{op[1]}\"")
+        elsif kind == :index
+          db.execute("CREATE INDEX \"#{index_name(table, op[1])}\" " \
+                     "ON \"#{table}\" (#{quoted_list(op[1])})")
+        elsif kind == :remove_index
+          db.execute("DROP INDEX \"#{index_name(table, op[1])}\"")
+        elsif kind == :execute
+          db.execute(op[1])
+        else
+          raise ArgumentError, "unknown migration op #{kind.inspect}"
+        end
       end
-    end
 
-    # op: [:add_column, name, type, default, null]
-    def self.column_ddl(op)
-      sql = "\"#{op[1]}\" #{SQL_TYPES[op[2]]}"
-      default = op[3]
-      unless default.nil?
-        sql += " DEFAULT #{default_literal(op[2], default)}"
+      # op: [:add_column, name, type, default, null]
+      private def column_ddl(op)
+        sql = "\"#{op[1]}\" #{SQL_TYPES[op[2]]}"
+        default = op[3]
+        unless default.nil?
+          sql += " DEFAULT #{default_literal(op[2], default)}"
+        end
+        sql += " NOT NULL" unless op[4]
+        sql
       end
-      sql += " NOT NULL" unless op[4]
-      sql
-    end
 
-    # Defaults go through the shared codec, so `default: false` stores 0
-    # and a Time default stores the canonical UTC string.
-    def self.default_literal(type, value)
-      encoded = Codec.encode(type, value)
-      if encoded.is_a?(String)
-        "'#{encoded.gsub("'", "''")}'"
-      else
-        encoded.to_s
+      # Defaults go through the shared codec, so `default: false` stores 0
+      # and a Time default stores the canonical UTC string.
+      private def default_literal(type, value)
+        encoded = Codec.encode(type, value)
+        if encoded.is_a?(String)
+          "'#{encoded.gsub("'", "''")}'"
+        else
+          encoded.to_s
+        end
       end
-    end
 
-    def self.index_name(table, columns)
-      "index_#{table}_on_#{columns.join("_")}"
+      private def index_name(table, columns)
+        "index_#{table}_on_#{columns.join("_")}"
+      end
     end
 
     # ---- change-event bus (docs decision 10) ----------------------------
@@ -811,20 +819,22 @@ module Funicular
         "role must be :local or :replica, got #{role.inspect}"
     end
 
-    def self.deferral_depth(role)
-      depths = @deferral_depths
-      value = depths ? depths[role] : nil
-      value || 0
-    end
+    class << self
+      private def deferral_depth(role)
+        depths = @deferral_depths
+        value = depths ? depths[role] : nil
+        value || 0
+      end
 
-    def self.pending_seen(role)
-      all = (@pending_seen ||= {}) # steep:ignore UnannotatedEmptyCollection
-      all[role] ||= {}
-    end
+      private def pending_seen(role)
+        all = (@pending_seen ||= {}) # steep:ignore UnannotatedEmptyCollection
+        all[role] ||= {}
+      end
 
-    def self.pending_order(role)
-      all = (@pending_orders ||= {}) # steep:ignore UnannotatedEmptyCollection
-      all[role] ||= []
+      private def pending_order(role)
+        all = (@pending_orders ||= {}) # steep:ignore UnannotatedEmptyCollection
+        all[role] ||= []
+      end
     end
 
     # Transaction hooks (GuardedDatabase), tracked PER ROLE: the local
@@ -866,47 +876,49 @@ module Funicular
       resume_deferred_persist(role)
     end
 
-    # A persist that found its database mid-transaction parked itself
-    # in @persist_deferred (see persist_snapshot); the settle turns the
-    # park into a fresh debounce arm.
-    def self.resume_deferred_persist(role)
-      deferred = @persist_deferred
-      return nil unless deferred
-      return nil unless deferred[role]
-      deferred.delete(role)
-      schedule_persist(role)
-      nil
-    end
-
-    def self.clear_pending(role)
-      seen_all = @pending_seen
-      seen_all.delete(role) if seen_all
-      order_all = @pending_orders
-      order_all.delete(role) if order_all
-      nil
-    end
-
-    # Delivery belongs to the NEXT tick (docs decision 10): a write that
-    # happens during a component update must never patch watchers
-    # synchronously into that update. Until the scheduled drain runs,
-    # events collapse per [role, table]; the first event of a tick
-    # schedules exactly one drain.
-    def self.enqueue_delivery(role, table)
-      # Auto-persist rides the same post-commit funnel (docs decision
-      # 11): every event (re)arms the role's debounce timer, and a
-      # rollback -- which never reaches here -- schedules nothing.
-      schedule_persist(role)
-      pending = (@tick_events ||= {}) # steep:ignore UnannotatedEmptyCollection
-      key = "#{role}:#{table}"
-      unless pending.has_key?(key)
-        pending[key] = true
-        order = (@tick_order ||= []) # steep:ignore UnannotatedEmptyCollection
-        order << [role, table]
+    class << self
+      # A persist that found its database mid-transaction parked itself
+      # in @persist_deferred (see persist_snapshot); the settle turns the
+      # park into a fresh debounce arm.
+      private def resume_deferred_persist(role)
+        deferred = @persist_deferred
+        return nil unless deferred
+        return nil unless deferred[role]
+        deferred.delete(role)
+        schedule_persist(role)
+        nil
       end
-      return nil if @drain_scheduled
-      @drain_scheduled = true
-      schedule_drain
-      nil
+
+      private def clear_pending(role)
+        seen_all = @pending_seen
+        seen_all.delete(role) if seen_all
+        order_all = @pending_orders
+        order_all.delete(role) if order_all
+        nil
+      end
+
+      # Delivery belongs to the NEXT tick (docs decision 10): a write that
+      # happens during a component update must never patch watchers
+      # synchronously into that update. Until the scheduled drain runs,
+      # events collapse per [role, table]; the first event of a tick
+      # schedules exactly one drain.
+      private def enqueue_delivery(role, table)
+        # Auto-persist rides the same post-commit funnel (docs decision
+        # 11): every event (re)arms the role's debounce timer, and a
+        # rollback -- which never reaches here -- schedules nothing.
+        schedule_persist(role)
+        pending = (@tick_events ||= {}) # steep:ignore UnannotatedEmptyCollection
+        key = "#{role}:#{table}"
+        unless pending.has_key?(key)
+          pending[key] = true
+          order = (@tick_order ||= []) # steep:ignore UnannotatedEmptyCollection
+          order << [role, table]
+        end
+        return nil if @drain_scheduled
+        @drain_scheduled = true
+        schedule_drain
+        nil
+      end
     end
 
     # Boot/tests may install their own scheduler (it must eventually
@@ -917,26 +929,28 @@ module Funicular
       @tick_scheduler = scheduler
     end
 
-    def self.schedule_drain
-      scheduler = @tick_scheduler
-      if scheduler
-        scheduler.call
-      elsif Object.const_defined?(:JS)
-        JS.global.setTimeout(0) do
+    class << self
+      private def schedule_drain
+        scheduler = @tick_scheduler
+        if scheduler
+          scheduler.call
+        elsif Object.const_defined?(:JS)
+          JS.global.setTimeout(0) do
+            __drain_events
+          end
+        else
           __drain_events
         end
-      else
-        __drain_events
+        nil
       end
-      nil
-    end
 
-    # Bumped by clear_tick_events: deliveries carrying an older
-    # generation are stale and stop, even MID-DRAIN -- a wipe called
-    # from inside a subscriber must silence the rest of the drain,
-    # which holds its events in a local the buffer clear cannot reach.
-    def self.tick_generation
-      @tick_generation || 0
+      # Bumped by clear_tick_events: deliveries carrying an older
+      # generation are stale and stop, even MID-DRAIN -- a wipe called
+      # from inside a subscriber must silence the rest of the drain,
+      # which holds its events in a local the buffer clear cannot reach.
+      private def tick_generation
+        @tick_generation || 0
+      end
     end
 
     def self.__drain_events
@@ -959,30 +973,32 @@ module Funicular
       nil
     end
 
-    def self.deliver_event(role, table, generation = nil)
-      subs = @subscriptions
-      return unless subs
-      # Snapshot the ids: a handler may (un)subscribe during delivery.
-      ids = subs.keys
-      ids_size = ids.size
-      i = 0
-      while i < ids_size
-        # An earlier subscriber of this very event may have staled the
-        # delivery (wipe): the remaining subscribers hear only from the
-        # wipe's own notification.
-        break if generation && !(tick_generation == generation)
-        entry = subs[ids[i]]
-        if entry && entry[0] == role && entry[1] == table
-          begin
-            entry[2].call(role, table)
-          rescue => e
-            # Subscriber isolation: one broken watcher must not starve
-            # the others (docs decision 10).
-            puts "[Funicular] change subscriber raised: " \
-                 "#{e.class}: #{e.message}"
+    class << self
+      private def deliver_event(role, table, generation = nil)
+        subs = @subscriptions
+        return unless subs
+        # Snapshot the ids: a handler may (un)subscribe during delivery.
+        ids = subs.keys
+        ids_size = ids.size
+        i = 0
+        while i < ids_size
+          # An earlier subscriber of this very event may have staled the
+          # delivery (wipe): the remaining subscribers hear only from the
+          # wipe's own notification.
+          break if generation && !(tick_generation == generation)
+          entry = subs[ids[i]]
+          if entry && entry[0] == role && entry[1] == table
+            begin
+              entry[2].call(role, table)
+            rescue => e
+              # Subscriber isolation: one broken watcher must not starve
+              # the others (docs decision 10).
+              puts "[Funicular] change subscriber raised: " \
+                   "#{e.class}: #{e.message}"
+            end
           end
+          i += 1
         end
-        i += 1
       end
     end
 
@@ -1021,94 +1037,96 @@ module Funicular
       end
     end
 
-    # The first keyword of a statement, lowercased, with leading
-    # whitespace and -- and /* */ comments skipped (a comment prefix
-    # must not smuggle ATTACH past the guard).
-    def self.statement_head(sql)
-      s = sql.to_s
-      read_sql_word(s, skip_sql_blanks(s, 0))[0]
-    end
+    class << self
+      # The first keyword of a statement, lowercased, with leading
+      # whitespace and -- and /* */ comments skipped (a comment prefix
+      # must not smuggle ATTACH past the guard).
+      private def statement_head(sql)
+        s = sql.to_s
+        read_sql_word(s, skip_sql_blanks(s, 0))[0]
+      end
 
-    # The [schema.]name of a PRAGMA statement, starting right after the
-    # PRAGMA keyword (pos). Quoted names ("x", 'x', `x`, [x]) resolve to
-    # their inner text so quoting cannot smuggle query_only past the
-    # guard.
-    def self.pragma_name(s, pos)
-      i = skip_sql_blanks(s, pos)
-      token = read_sql_token(s, i)
-      name = token[0]
-      i = skip_sql_blanks(s, token[1])
-      if s.getbyte(i) == 46 # '.': schema-qualified, the name follows
-        token = read_sql_token(s, skip_sql_blanks(s, i + 1))
+      # The [schema.]name of a PRAGMA statement, starting right after the
+      # PRAGMA keyword (pos). Quoted names ("x", 'x', `x`, [x]) resolve to
+      # their inner text so quoting cannot smuggle query_only past the
+      # guard.
+      private def pragma_name(s, pos)
+        i = skip_sql_blanks(s, pos)
+        token = read_sql_token(s, i)
         name = token[0]
+        i = skip_sql_blanks(s, token[1])
+        if s.getbyte(i) == 46 # '.': schema-qualified, the name follows
+          token = read_sql_token(s, skip_sql_blanks(s, i + 1))
+          name = token[0]
+        end
+        name
       end
-      name
-    end
 
-    # Skip whitespace and -- / /* */ comments; returns the next index.
-    def self.skip_sql_blanks(s, i)
-      len = s.length
-      while i < len
-        c = s.getbyte(i)
-        if c == 32 || c == 9 || c == 10 || c == 13
+      # Skip whitespace and -- / /* */ comments; returns the next index.
+      private def skip_sql_blanks(s, i)
+        len = s.length
+        while i < len
+          c = s.getbyte(i)
+          if c == 32 || c == 9 || c == 10 || c == 13
+            i += 1
+          elsif c == 45 && s.getbyte(i + 1) == 45 # "--" line comment
+            i += 2
+            while i < len && !(s.getbyte(i) == 10)
+              i += 1
+            end
+          elsif c == 47 && s.getbyte(i + 1) == 42 # "/*" block comment
+            i += 2
+            while i < len && !(s.getbyte(i) == 42 && s.getbyte(i + 1) == 47)
+              i += 1
+            end
+            i += 2
+          else
+            break
+          end
+        end
+        i
+      end
+
+      # Read a bare identifier/keyword at i: [downcased word, next index].
+      private def read_sql_word(s, i)
+        len = s.length
+        start = i
+        while i < len
+          c = s.getbyte(i)
+          unless c && ((97 <= c && c <= 122) || (65 <= c && c <= 90) ||
+                       (48 <= c && c <= 57) || c == 95)
+            break
+          end
           i += 1
-        elsif c == 45 && s.getbyte(i + 1) == 45 # "--" line comment
-          i += 2
-          while i < len && !(s.getbyte(i) == 10)
-            i += 1
-          end
-        elsif c == 47 && s.getbyte(i + 1) == 42 # "/*" block comment
-          i += 2
-          while i < len && !(s.getbyte(i) == 42 && s.getbyte(i + 1) == 47)
-            i += 1
-          end
-          i += 2
-        else
-          break
         end
+        word = s[start, i - start]
+        [word ? word.downcase : "", i]
       end
-      i
-    end
 
-    # Read a bare identifier/keyword at i: [downcased word, next index].
-    def self.read_sql_word(s, i)
-      len = s.length
-      start = i
-      while i < len
+      # Like read_sql_word, but also resolves quoted identifiers to their
+      # inner text.
+      private def read_sql_token(s, i)
         c = s.getbyte(i)
-        unless c && ((97 <= c && c <= 122) || (65 <= c && c <= 90) ||
-                     (48 <= c && c <= 57) || c == 95)
-          break
+        closer = nil
+        if c == 91 # [ closes with ]
+          closer = 93
+        elsif c == 34 # "
+          closer = 34
+        elsif c == 39 # '
+          closer = 39
+        elsif c == 96 # `
+          closer = 96
         end
-        i += 1
+        return read_sql_word(s, i) unless closer
+        len = s.length
+        j = i + 1
+        start = j
+        while j < len && !(s.getbyte(j) == closer)
+          j += 1
+        end
+        word = s[start, j - start]
+        [word ? word.downcase : "", j + 1]
       end
-      word = s[start, i - start]
-      [word ? word.downcase : "", i]
-    end
-
-    # Like read_sql_word, but also resolves quoted identifiers to their
-    # inner text.
-    def self.read_sql_token(s, i)
-      c = s.getbyte(i)
-      closer = nil
-      if c == 91 # [ closes with ]
-        closer = 93
-      elsif c == 34 # "
-        closer = 34
-      elsif c == 39 # '
-        closer = 39
-      elsif c == 96 # `
-        closer = 96
-      end
-      return read_sql_word(s, i) unless closer
-      len = s.length
-      j = i + 1
-      start = j
-      while j < len && !(s.getbyte(j) == closer)
-        j += 1
-      end
-      word = s[start, j - start]
-      [word ? word.downcase : "", j + 1]
     end
 
     # The one execution-time gate every guarded entry point shares:
@@ -1466,12 +1484,14 @@ module Funicular
       state
     end
 
-    def self.install_lock_shim
-      return if @lock_shim_installed
-      # @type var global: untyped
-      global = JS.global
-      global.eval(LOCK_SHIM_JS)
-      @lock_shim_installed = true
+    class << self
+      private def install_lock_shim
+        return if @lock_shim_installed
+        # @type var global: untyped
+        global = JS.global
+        global.eval(LOCK_SHIM_JS)
+        @lock_shim_installed = true
+      end
     end
 
     # Terminal step-down (docs decision 13) and teardown: resolving the
@@ -1683,38 +1703,40 @@ module Funicular
       end
     end
 
-    # Private mode or an exotic embedder: everything works, nothing
-    # persists. A held writer lock is released first -- release also
-    # steps @durability down, so volatile is claimed after.
-    def self.__become_volatile(error)
-      release_writer_lock
-      @durability = :volatile
-      puts "[Funicular] persistent storage is unavailable; this page " \
-           "runs volatile (everything works, nothing persists): " \
-           "#{error.class}: #{error.message}"
-      invoke_persist_error_hook(error)
-      nil
-    end
-
-    # Persistence failures are never silent (docs decision 11): always
-    # the log, plus the app's hook when registered.
-    def self.report_persist_error(error)
-      puts "[Funicular] snapshot persistence failed: " \
-           "#{error.class}: #{error.message}"
-      invoke_persist_error_hook(error)
-      nil
-    end
-
-    def self.invoke_persist_error_hook(error)
-      hook = config.on_persist_error
-      return nil unless hook
-      begin
-        hook.call(error)
-      rescue => e
-        puts "[Funicular] on_persist_error hook raised: " \
-             "#{e.class}: #{e.message}"
+    class << self
+      # Private mode or an exotic embedder: everything works, nothing
+      # persists. A held writer lock is released first -- release also
+      # steps @durability down, so volatile is claimed after.
+      private def __become_volatile(error)
+        release_writer_lock
+        @durability = :volatile
+        puts "[Funicular] persistent storage is unavailable; this page " \
+             "runs volatile (everything works, nothing persists): " \
+             "#{error.class}: #{error.message}"
+        invoke_persist_error_hook(error)
+        nil
       end
-      nil
+
+      # Persistence failures are never silent (docs decision 11): always
+      # the log, plus the app's hook when registered.
+      private def report_persist_error(error)
+        puts "[Funicular] snapshot persistence failed: " \
+             "#{error.class}: #{error.message}"
+        invoke_persist_error_hook(error)
+        nil
+      end
+
+      private def invoke_persist_error_hook(error)
+        hook = config.on_persist_error
+        return nil unless hook
+        begin
+          hook.call(error)
+        rescue => e
+          puts "[Funicular] on_persist_error hook raised: " \
+               "#{e.class}: #{e.message}"
+        end
+        nil
+      end
     end
 
     # Advanced by wipe (docs decision 17): a snapshot captured under an
@@ -1729,6 +1751,12 @@ module Funicular
     # written.
     def self.persist_snapshot(role)
       validate_role(role)
+      # Mid-boot the databases are (partly) unrestored while the
+      # election is already won: a snapshot now would overwrite the
+      # stored data with an empty image. The boot itself never
+      # persists, so :booting refuses at this FINAL entry -- flush and
+      # the debounce path funnel through here.
+      return false if boot_state == :booting
       return false unless durability == :persistent_writer
       db = __registered_database(role)
       return false unless db
@@ -1796,28 +1824,30 @@ module Funicular
     # enqueue_delivery funnel means transactional writes schedule at
     # COMMIT and a rollback schedules nothing.
 
-    def self.schedule_persist(role)
-      return nil unless durability == :persistent_writer
-      return nil unless @snapshot_store
-      return nil unless Object.const_defined?(:JS)
-      timers = (@persist_timers ||= {}) # steep:ignore UnannotatedEmptyCollection
-      existing = timers[role]
-      # @type var global: untyped
-      global = JS.global
-      global.clearTimeout(existing) if existing
-      # The clear can come too late: a timer whose JS deadline already
-      # passed has its callback QUEUED on the Ruby side, beyond
-      # clearTimeout's reach. Every (re)arm therefore bumps the role's
-      # token, and only the callback holding the current token acts.
-      tokens = (@persist_timer_tokens ||= {}) # steep:ignore UnannotatedEmptyCollection
-      token = (tokens[role] || 0) + 1
-      tokens[role] = token
-      cfg = config
-      ms = role == :local ? cfg.local_debounce_ms : cfg.replica_debounce_ms
-      timers[role] = global.setTimeout(ms) do
-        __persist_timer_fired(role, token)
+    class << self
+      private def schedule_persist(role)
+        return nil unless durability == :persistent_writer
+        return nil unless @snapshot_store
+        return nil unless Object.const_defined?(:JS)
+        timers = (@persist_timers ||= {}) # steep:ignore UnannotatedEmptyCollection
+        existing = timers[role]
+        # @type var global: untyped
+        global = JS.global
+        global.clearTimeout(existing) if existing
+        # The clear can come too late: a timer whose JS deadline already
+        # passed has its callback QUEUED on the Ruby side, beyond
+        # clearTimeout's reach. Every (re)arm therefore bumps the role's
+        # token, and only the callback holding the current token acts.
+        tokens = (@persist_timer_tokens ||= {}) # steep:ignore UnannotatedEmptyCollection
+        token = (tokens[role] || 0) + 1
+        tokens[role] = token
+        cfg = config
+        ms = role == :local ? cfg.local_debounce_ms : cfg.replica_debounce_ms
+        timers[role] = global.setTimeout(ms) do
+          __persist_timer_fired(role, token)
+        end
+        nil
       end
-      nil
     end
 
     # The armed timer's landing point. A stale callback (its timer was
@@ -2000,6 +2030,16 @@ module Funicular
     # a persistent_reader); volatile is fine too -- the only tab, all
     # memory, no snapshots to delete.
     def self.wipe
+      # Like reset_local, wipe reaches the RAW databases, so a
+      # mid-boot wipe must be kept out (durability is already elected
+      # then). :failed stays allowed: wiping from on_boot_error IS the
+      # official corrupt-snapshot recovery (docs decision 16) -- the
+      # durability check below still requires the failure to have
+      # happened after the election.
+      unless boot_state == :ready || boot_state == :failed
+        raise Error,
+          "wipe requires a booted page (boot state: #{boot_state})"
+      end
       state = durability
       if state == :persistent_reader
         raise ReadOnlyTabError,
@@ -2060,85 +2100,404 @@ module Funicular
       true
     end
 
-    # Empty the next-tick delivery buffer AND stale a drain that is
-    # already running (it holds its events in a local; the generation
-    # bump is what reaches it). A drain merely scheduled stays
-    # scheduled and no-ops; the next enqueue schedules a fresh one.
-    def self.clear_tick_events
-      @tick_generation = tick_generation + 1
-      @tick_order = []
-      @tick_events = {}
-      nil
-    end
-
-    def self.ensure_not_in_transaction(role)
-      db = __registered_database(role)
-      return nil unless db
-      if db.transaction_active?
-        raise Error,
-          "cannot wipe: the #{role} database has an open transaction; " \
-          "settle it (commit or rollback) first"
+    class << self
+      # Empty the next-tick delivery buffer AND stale a drain that is
+      # already running (it holds its events in a local; the generation
+      # bump is what reaches it). A drain merely scheduled stays
+      # scheduled and no-ops; the next enqueue schedules a fresh one.
+      private def clear_tick_events
+        @tick_generation = tick_generation + 1
+        @tick_order = []
+        @tick_events = {}
+        nil
       end
-      nil
-    end
 
-    def self.wipe_role(role)
-      registry = @databases
-      entry = registry ? registry[role] : nil
-      return nil unless entry
-      db = entry[0]
-      return nil unless db
-      models = entry[1]
-      drop_all_tables(db)
-      models_size = models.size
-      if role == :local
+      private def ensure_not_in_transaction(role)
+        db = __registered_database(role)
+        return nil unless db
+        if db.transaction_active?
+          raise Error,
+            "the #{role} database has an open transaction; settle it " \
+            "(commit or rollback) before rebuilding"
+        end
+        nil
+      end
+
+      private def wipe_role(role)
+        registry = @databases
+        entry = registry ? registry[role] : nil
+        return nil unless entry
+        db = entry[0]
+        return nil unless db
+        models = entry[1]
+        drop_all_tables(db)
+        models_size = models.size
+        if role == :local
+          i = 0
+          while i < models_size
+            # The meta table is gone, so every table reads as version 0
+            # and rebuilds from its baseline.
+            apply_local_migrations(db, models[i])
+            i += 1
+          end
+        else
+          # The stored fingerprint is gone too: the fresh-boot path
+          # recreates the declared tables and stores it again.
+          build_replica_tables(db, models)
+        end
+        nil
+      end
+
+      # One change event per wiped table, sent only from wipe's step 5 --
+      # strictly after the rebuild AND the snapshot deletes.
+      private def notify_wiped(role)
+        registry = @databases
+        entry = registry ? registry[role] : nil
+        return nil unless entry
+        return nil unless entry[0]
+        models = entry[1]
+        models_size = models.size
         i = 0
         while i < models_size
-          # The meta table is gone, so every table reads as version 0
-          # and rebuilds from its baseline.
-          apply_local_migrations(db, models[i])
+          notify_changed(role, models[i].table_name)
           i += 1
         end
+        nil
+      end
+
+      private def drop_all_tables(db)
+        rows = db.execute(
+          "SELECT name FROM sqlite_master WHERE type = 'table' " \
+          "AND name NOT LIKE 'sqlite_%'")
+        rows_size = rows.size
+        i = 0
+        while i < rows_size
+          row = rows[i]
+          name = row.is_a?(Hash) ? row.values[0] : row[0]
+          # Unlike model-declared names, this comes from sqlite_master and
+          # may be any legal SQLite identifier. Double embedded quotes.
+          quoted_name = name.to_s.gsub('"', '""')
+          db.execute("DROP TABLE IF EXISTS \"#{quoted_name}\"")
+          i += 1
+        end
+        nil
+      end
+    end
+
+    # ---- boot (docs decision 19) ----------------------------------------
+    #
+    # The client-side boot: everything above wired together in the one
+    # order that works, driven by Funicular.start (a later change).
+    # Failure philosophy is decision 16's fail loud: any error stops
+    # the boot, components stay unmounted (wired with start), and
+    # on_boot_error hears about it. SchemaTooNew is NOT a failure --
+    # the local database completes the boot locked down instead.
+
+    def self.boot_state
+      @boot_state || :unbooted
+    end
+
+    def self.__set_boot_state(state)
+      @boot_state = state
+    end
+
+    # The page's session epoch, held for the HTTP layer (a later
+    # change: X-Funicular-Epoch mismatch -> terminal latch).
+    def self.session_epoch
+      @session_epoch
+    end
+
+    # metadata comes from the page (picoruby_include_tag data
+    # attributes, read in a later change); tests and embedders pass it
+    # directly. Absent keys fall back to a replica-only anonymous
+    # default.
+    def self.boot(models:, metadata: {})
+      if Funicular.server?
+        raise UnavailableError,
+          "Funicular::DB.boot does not run on the server (SSR renders " \
+          "from state, not from a local database)"
+      end
+      unless boot_state == :unbooted
+        raise Error, "DB.boot already ran (state: #{boot_state})"
+      end
+      @boot_state = :booting
+      begin
+        __boot_steps(models, metadata)
+        @boot_state = :ready
+        true
+      rescue => e
+        @boot_state = :failed
+        # No partial boot: whatever was already wired up is torn back
+        # out of reach (the getters below also gate on :ready).
+        @local_handle = nil
+        @replica_handle = nil
+        report_boot_error([e])
+        # The hook above had its recovery chance (a wipe from it runs
+        # as the writer). A page that stays failed can do nothing with
+        # the writer slot except deny it to every other tab -- release
+        # it (no-op when the election never ran or was lost).
+        release_writer_lock
+        false
+      end
+    end
+
+    class << self
+      private def __boot_steps(models, metadata)
+        # @type var local_models: Array[untyped]
+        local_models = []
+        # @type var replica_models: Array[untyped]
+        replica_models = []
+        i = 0
+        models_size = models.size
+        while i < models_size
+          model = models[i]
+          if model.local?
+            local_models << model
+          elsif model.replica?
+            replica_models << model
+          end
+          i += 1
+        end
+        identity = resolve_namespace(
+          application_id: metadata_value(metadata, :application_id,
+                                         "funicular"),
+          user_key: metadata_value(metadata, :user_key, nil),
+          user_key_configured: !!metadata_value(metadata,
+                                                :user_key_configured, false),
+          anonymous_only: !!metadata_value(metadata, :anonymous_only, false),
+          local_models: !local_models.empty?)
+        __set_snapshot_identity(identity)
+        @session_epoch = metadata_value(metadata, :epoch, nil)
+        elect_writer(lock_name(identity))
+        # Availability errors drop to volatile inside; anything else
+        # re-raises and fails the boot (docs decision 16).
+        open_snapshot_store
+        local_db = SQLite3::Database.new(":memory:")
+        replica_db = SQLite3::Database.new(":memory:")
+        __register_database(:local, local_db, local_models)
+        __register_database(:replica, replica_db, replica_models)
+        restore_snapshot(:local)
+        begin
+          i = 0
+          local_size = local_models.size
+          while i < local_size
+            apply_local_migrations(local_db, local_models[i])
+            i += 1
+          end
+        rescue SchemaTooNewError => e
+          # Decision 7: the WHOLE local database fails loud, but the
+          # boot itself completes -- raw SELECT export must survive a
+          # deploy rollback.
+          engage_schema_lockdown(local_db, e)
+        end
+        restore_snapshot(:replica)
+        build_replica_tables(replica_db, replica_models)
+        __install_handles(local_db, replica_db)
+        request_persistent_storage unless local_models.empty?
+        __install_visibility_hook
+        nil
+      end
+
+      private def metadata_value(metadata, key, default)
+        return default unless metadata
+        metadata.has_key?(key) ? metadata[key] : default
+      end
+
+      # Boot failures are never silent (docs decision 16): always the
+      # console, plus the app's hook when registered. The hook receives
+      # the ARRAY of errors -- the schema barrier (a later change)
+      # reports several at once.
+      private def report_boot_error(errors)
+        errors_size = errors.size
+        i = 0
+        while i < errors_size
+          e = errors[i]
+          message = "[Funicular] boot failed: #{e.class}: #{e.message}"
+          if Object.const_defined?(:JS)
+            # @type var global: untyped
+            global = JS.global
+            global[:console].error(message)
+          else
+            puts message
+          end
+          i += 1
+        end
+        hook = config.on_boot_error
+        if hook
+          begin
+            hook.call(errors)
+          rescue => hook_error
+            puts "[Funicular] on_boot_error hook raised: " \
+                 "#{hook_error.class}: #{hook_error.message}"
+          end
+        end
+        nil
+      end
+
+      private def __install_handles(local_db, replica_db)
+        read_only = durability == :persistent_reader
+        # Belt (the proxy refuses at every execution entry) and braces
+        # (SQLite itself refuses): docs decision 15. The replica handle
+        # stays memory-writable even on a reader -- fetch-through
+        # revalidation works there.
+        local_db.execute("PRAGMA query_only = ON") if read_only
+        @local_handle = GuardedDatabase.new(local_db, :local, read_only)
+        @replica_handle = GuardedDatabase.new(replica_db, :replica, false)
+        nil
+      end
+    end
+
+    # The raw-SQL escape hatches (docs decision 20): guarded proxies,
+    # never raw connections. Everything gates on boot_state == :ready,
+    # not on the handle's existence -- mid-boot (an await inside
+    # __boot_steps lets other Tasks run) and after a failed boot the
+    # handles must be equally out of reach.
+    def self.local
+      handle = boot_state == :ready ? @local_handle : nil
+      unless handle
+        raise UnavailableError, "the local database is not booted"
+      end
+      handle
+    end
+
+    def self.replica
+      handle = boot_state == :ready ? @replica_handle : nil
+      unless handle
+        raise UnavailableError, "the replica database is not booted"
+      end
+      handle
+    end
+
+    # The funnel every Model-level local operation goes through
+    # (Model.local_db): ready check, then the SchemaTooNew latch.
+    def self.__model_local_db(model)
+      handle = boot_state == :ready ? @local_handle : nil
+      unless handle
+        raise UnavailableError,
+          "#{model.to_s}: the local database is not booted"
+      end
+      __check_schema_lockdown(model.to_s)
+      handle
+    end
+
+    def self.__model_replica_db
+      boot_state == :ready ? @replica_handle : nil
+    end
+
+    # ---- SchemaTooNew lockdown (docs decision 7) ------------------------
+    #
+    # stored version > declared max means a deploy rollback: the whole
+    # local database refuses to run backwards. Model-level operations
+    # raise; the raw DB.local handle keeps SELECT working (query_only
+    # blocks writes at the SQLite level) so the user's data can still
+    # be exported.
+
+    class << self
+      private def engage_schema_lockdown(db, error)
+        @schema_lockdown = error
+        db.execute("PRAGMA query_only = ON")
+        puts "[Funicular] local database locked down " \
+             "(SchemaTooNew): #{error.message}"
+        nil
+      end
+    end
+
+    def self.schema_lockdown
+      @schema_lockdown
+    end
+
+    class << self
+      private def __check_schema_lockdown(context)
+        error = @schema_lockdown
+        return nil unless error
+        raise SchemaTooNewError,
+          "#{context}: the local database is locked down (#{error.message})"
+      end
+    end
+
+    # Model.reset_local lands here: drop + rebuild ONE table from its
+    # baseline, on the writer (or volatile) tab. When the database sat
+    # locked down, the whole declared set revalidates -- v1 has no
+    # per-table nuance, so the lockdown lifts only when every table
+    # passes again.
+    def self.reset_local_table(model)
+      # Same :ready gate as the handles: this path reaches the RAW
+      # database, so hiding the proxies alone would not keep a
+      # mid-boot (or failed-boot) rebuild out.
+      unless boot_state == :ready
+        raise UnavailableError, "the local database is not booted"
+      end
+      state = durability
+      if state == :persistent_reader
+        raise ReadOnlyTabError,
+          "reset_local requires the writer tab " \
+          "(this tab is a persistent_reader)"
+      end
+      db = __registered_database(:local)
+      unless db
+        raise UnavailableError, "the local database is not booted"
+      end
+      # Same nesting hazard as wipe: never rebuild into an open
+      # transaction.
+      ensure_not_in_transaction(:local)
+      lockdown = @schema_lockdown
+      if lockdown
+        db.execute("PRAGMA query_only = OFF")
+        begin
+          rebuild_local_table(db, model)
+          revalidate_schema_lockdown(db)
+        rescue => e
+          # The lift is provisional: whatever failed here (a broken
+          # rebuild, an ordinary migration error during revalidation),
+          # the lockdown still stands and SQLite's own write refusal
+          # must stand back up with it -- the raw export path is
+          # SELECT-only by contract.
+          db.execute("PRAGMA query_only = ON") if @schema_lockdown
+          raise e
+        end
       else
-        # The stored fingerprint is gone too: the fresh-boot path
-        # recreates the declared tables and stores it again.
-        build_replica_tables(db, models)
+        rebuild_local_table(db, model)
       end
-      nil
+      model.local_table_changed
+      true
     end
 
-    # One change event per wiped table, sent only from wipe's step 5 --
-    # strictly after the rebuild AND the snapshot deletes.
-    def self.notify_wiped(role)
-      registry = @databases
-      entry = registry ? registry[role] : nil
-      return nil unless entry
-      return nil unless entry[0]
-      models = entry[1]
-      models_size = models.size
-      i = 0
-      while i < models_size
-        notify_changed(role, models[i].table_name)
-        i += 1
+    class << self
+      private def revalidate_schema_lockdown(db)
+        registry = @databases
+        entry = registry ? registry[:local] : nil
+        # @type var models: Array[untyped]
+        models = entry ? entry[1] : []
+        begin
+          i = 0
+          models_size = models.size
+          while i < models_size
+            apply_local_migrations(db, models[i])
+            i += 1
+          end
+          @schema_lockdown = nil
+          puts "[Funicular] local database lockdown lifted"
+        rescue SchemaTooNewError => e
+          engage_schema_lockdown(db, e)
+        end
+        nil
       end
-      nil
     end
 
-    def self.drop_all_tables(db)
-      rows = db.execute(
-        "SELECT name FROM sqlite_master WHERE type = 'table' " \
-        "AND name NOT LIKE 'sqlite_%'")
-      rows_size = rows.size
-      i = 0
-      while i < rows_size
-        row = rows[i]
-        name = row.is_a?(Hash) ? row.values[0] : row[0]
-        # Unlike model-declared names, this comes from sqlite_master and
-        # may be any legal SQLite identifier. Double embedded quotes.
-        quoted_name = name.to_s.gsub('"', '""')
-        db.execute("DROP TABLE IF EXISTS \"#{quoted_name}\"")
-        i += 1
-      end
+    # Test seam: boot wires process-global state; per-file test VMs
+    # unwind it between tests.
+    def self.__reset_boot
+      release_writer_lock
+      @boot_state = :unbooted
+      @durability = :unbooted
+      @local_handle = nil
+      @replica_handle = nil
+      @schema_lockdown = nil
+      @session_epoch = nil
+      @databases = nil
+      cancel_persist_timers
+      __set_snapshot_store(nil)
+      __set_snapshot_identity(nil)
       nil
     end
 
@@ -2282,28 +2641,30 @@ module Funicular
       true
     end
 
-    # The table names recorded in a stored canonical fingerprint; empty
-    # when absent or unparsable (fail-safe: nothing extra to drop).
-    def self.stale_replica_tables(stored)
-      # @type var names: Array[String]
-      names = []
-      return names unless stored
-      begin
-        parsed = JSON.parse(stored)
-      rescue
-        return names
+    class << self
+      # The table names recorded in a stored canonical fingerprint; empty
+      # when absent or unparsable (fail-safe: nothing extra to drop).
+      private def stale_replica_tables(stored)
+        # @type var names: Array[String]
+        names = []
+        return names unless stored
+        begin
+          parsed = JSON.parse(stored)
+        rescue
+          return names
+        end
+        return names unless parsed.is_a?(Array)
+        list = parsed[1]
+        return names unless list.is_a?(Array)
+        list_size = list.size
+        i = 0
+        while i < list_size
+          entry = list[i]
+          names << entry[0].to_s if entry.is_a?(Array)
+          i += 1
+        end
+        names
       end
-      return names unless parsed.is_a?(Array)
-      list = parsed[1]
-      return names unless list.is_a?(Array)
-      list_size = list.size
-      i = 0
-      while i < list_size
-        entry = list[i]
-        names << entry[0].to_s if entry.is_a?(Array)
-        i += 1
-      end
-      names
     end
 
     # Apply one server-authoritative row: THE single write-through entry
@@ -2391,15 +2752,17 @@ module Funicular
       deleted
     end
 
-    def self.quoted_list(columns)
-      # @type var quoted: Array[String]
-      quoted = []
-      i = 0
-      while i < columns.size
-        quoted << "\"#{columns[i]}\""
-        i += 1
+    class << self
+      private def quoted_list(columns)
+        # @type var quoted: Array[String]
+        quoted = []
+        i = 0
+        while i < columns.size
+          quoted << "\"#{columns[i]}\""
+          i += 1
+        end
+        quoted.join(", ")
       end
-      quoted.join(", ")
     end
   end
 end

--- a/mrblib/db.rb
+++ b/mrblib/db.rb
@@ -52,7 +52,16 @@ module Funicular
           return 0 if value == false
           value
         elsif type == :datetime
-          value.is_a?(Time) ? time_to_iso(value) : value
+          if value.is_a?(Time)
+            time_to_iso(value)
+          elsif value.is_a?(String)
+            # Strings are re-normalized (offsets folded into UTC, fractions
+            # truncated) so stored TEXT always sorts chronologically;
+            # malformed input raises ArgumentError here, not at query time.
+            time_to_iso(iso_to_time(value))
+          else
+            value
+          end
         else
           value
         end

--- a/mrblib/db.rb
+++ b/mrblib/db.rb
@@ -371,14 +371,30 @@ module Funicular
       s
     end
 
+    # The index of the block the table is (re)built from: the NEWEST
+    # `reset: true` block, or the first block when none is marked. Blocks
+    # before it are superseded history -- they may stay in the code (the
+    # docs only say they MAY be deleted) but are never folded or applied.
+    def self.baseline_index(migrations)
+      base = 0
+      i = 0
+      while i < migrations.size
+        base = i if migrations[i][:reset]
+        i += 1
+      end
+      base
+    end
+
     # Fold a model's migrate blocks into column metadata (column name ->
     # declared type), the implicit id included. Pure: no database touched,
-    # usable before boot.
+    # usable before boot. Folding starts at the baseline, so a reset block
+    # may redefine columns that also appear in the superseded history.
     def self.fold_local_columns(model)
       # @type var columns: Hash[String, Symbol]
       columns = { "id" => :integer }
       builders = collect_builders(model)
-      i = 0
+      migrations = model.local_migrations
+      i = migrations ? baseline_index(migrations) : 0
       while i < builders.size
         fold_ops(columns, builders[i].ops, model)
         i += 1
@@ -387,8 +403,9 @@ module Funicular
     end
 
     # Bring one model's local table to its declared schema. Fresh and
-    # below-baseline tables are rebuilt from the first retained block;
-    # tables between baseline and max get exactly the missing blocks; a
+    # below-baseline tables are rebuilt from the baseline (see
+    # baseline_index); tables between baseline and max get exactly the
+    # missing blocks; a
     # table NEWER than the declarations raises SchemaTooNewError (deploy
     # rollback; the whole-DB lockdown is wired at boot). All applied work
     # runs in one transaction. When an incremental upgrade fails in
@@ -401,7 +418,7 @@ module Funicular
           "#{model} has no migrate blocks (is it storage :local?)"
       end
       table = validate_identifier(model.table_name)
-      baseline = migrations[0][:version]
+      baseline = migrations[baseline_index(migrations)][:version]
       max = migrations[migrations.size - 1][:version]
       stored = stored_table_version(db, table)
       if max < stored
@@ -541,15 +558,16 @@ module Funicular
       end
     end
 
-    # Apply every block with version > from_version. The first block
-    # applied onto a dropped/absent table runs in create mode (its column
-    # ops become the CREATE TABLE); everything later alters.
+    # Apply every block at or after the baseline with version >
+    # from_version (pre-baseline history is never applied). The first
+    # block applied onto a dropped/absent table runs in create mode (its
+    # column ops become the CREATE TABLE); everything later alters.
     def self.apply_blocks(db, model, from_version)
       migrations = model.local_migrations
       builders = collect_builders(model)
       table = validate_identifier(model.table_name)
-      creating = from_version < migrations[0][:version]
-      i = 0
+      i = baseline_index(migrations)
+      creating = from_version < migrations[i][:version]
       while i < migrations.size
         if from_version < migrations[i][:version]
           run_block(db, table, builders[i], creating)

--- a/mrblib/db.rb
+++ b/mrblib/db.rb
@@ -1540,27 +1540,23 @@ module Funicular
       JSON.generate(["v1", app, "user", key])
     end
 
-    # The declaration rules, checked authoritatively on the CLIENT (docs
-    # decision 12: only the client knows whether storage :local models
-    # are declared). user_key_configured says whether a user_key SOURCE
-    # is declared at all; user_key is the value it resolved to for THIS
-    # page load -- nil while signed out. Configuration errors key off
-    # the flag, the anonymous/user choice keys off the value: a
-    # signed-out visit to an app with local models boots into the
-    # anonymous namespace instead of failing.
+    # The declaration rules, checked authoritatively on the client.
+    # Enabling durable browser storage always requires an explicit identity
+    # contract, including replica-only applications. user_key_configured says
+    # whether a user_key SOURCE is declared at all; user_key is the value it
+    # resolved to for THIS page load -- nil while signed out.
     def self.resolve_namespace(application_id:, user_key:,
-                               user_key_configured:, anonymous_only:,
-                               local_models:)
+                               user_key_configured:, anonymous_only:)
       if user_key_configured && anonymous_only
         raise ConfigError,
           "user_key and anonymous_only are mutually exclusive; " \
           "configure exactly one"
       end
-      if !user_key_configured && !anonymous_only && local_models
+      if !user_key_configured && !anonymous_only
         raise ConfigError,
-          "storage :local models are declared but no user_key is " \
-          "configured; set config.user_key, or anonymous_only = true " \
-          "to accept one shared anonymous namespace"
+          "local database is enabled but no user_key is configured; " \
+          "set config.user_key, or anonymous_only = true to accept " \
+          "one shared anonymous namespace"
       end
       # nil is the legitimate signed-out state. An EMPTY string is a
       # broken user_key source: it falls through to namespace_identity's
@@ -1948,6 +1944,7 @@ module Funicular
     # cannot be serialized (see persist_snapshot); its snapshot defers
     # to the commit/rollback settle and flush reports false.
     def self.flush
+      __ensure_local_database_enabled(:flush)
       state = durability
       if state == :persistent_reader
         raise ReadOnlyTabError,
@@ -2066,6 +2063,7 @@ module Funicular
     # a persistent_reader); volatile is fine too -- the only tab, all
     # memory, no snapshots to delete.
     def self.wipe
+      __ensure_local_database_enabled(:wipe)
       # The terminal latch first: on a terminated volatile page the
       # durability checks below would still let this raw path through.
       ensure_session_not_terminated(:wipe)
@@ -2258,24 +2256,30 @@ module Funicular
       @session_epoch
     end
 
-    # metadata comes from the page (the picoruby_include_tag data
-    # attributes); tests and embedders may pass both arguments
-    # directly. Absent metadata falls back to a replica-only anonymous
-    # default; absent models fall back to every declared Model
-    # subclass.
+    # Metadata comes from the page (the picoruby_include_tag data
+    # attributes); tests and embedders may pass it directly. Missing opt-in
+    # or identity metadata is a configuration error. Absent models fall back
+    # to every declared Model subclass.
     def self.boot(models: nil, metadata: nil)
       if Funicular.server?
         raise UnavailableError,
           "Funicular::DB.boot does not run on the server (SSR renders " \
           "from state, not from a local database)"
       end
+      page_metadata = metadata || __page_metadata
+      unless metadata_value(page_metadata, :local_database, false)
+        raise ConfigError,
+          "local database is disabled; set config.local_database = true"
+      end
+      @local_database_latched = true
+      @local_database_enabled = true
       unless boot_state == :unbooted
         raise Error, "DB.boot already ran (state: #{boot_state})"
       end
       @boot_state = :booting
       begin
         __boot_steps(models || Funicular::Model.__registered_models,
-                     metadata || read_page_metadata)
+                     page_metadata)
         @boot_state = :ready
         true
       rescue => e
@@ -2298,18 +2302,27 @@ module Funicular
       false
     end
 
+    # Schema loading still runs for REST-only applications. Its failures use
+    # the same console/hook reporting without pretending that a disabled DB
+    # entered (and failed) its lifecycle.
+    def self.__report_boot_errors(errors)
+      report_boot_error(errors)
+      false
+    end
+
     # The picoruby_include_tag embeds the namespace identity and the
     # session epoch as HTML-escaped data attributes (docs decision 12);
-    # the Rails side emits them in a later change, and this is the
-    # client half of that contract. No tag (or no document -- tests,
-    # exotic embedders) means the replica-only anonymous default.
+    # this is the client half of that contract. No opt-in tag (or no document
+    # in tests and exotic embedders) means that the subsystem is disabled.
     PAGE_METADATA_JS = <<~'FUNICULAR_META_JS'
       (() => {
         if (typeof document === "undefined") return "null";
-        const el = document.querySelector("[data-funicular-application-id]");
+        const el = document.querySelector(
+          '[data-funicular-local-database="true"]');
         if (!el) return "null";
         const d = el.dataset;
         return JSON.stringify({
+          local_database: true,
           application_id: d.funicularApplicationId,
           user_key:
             (d.funicularUserKey === undefined) ? null : d.funicularUserKey,
@@ -2328,12 +2341,54 @@ module Funicular
       return {} if raw == "null" || raw.empty?
       data = JSON.parse(raw)
       {
+        local_database: !!data["local_database"],
         application_id: data["application_id"],
         user_key: data["user_key"],
         user_key_configured: !!data["user_key_configured"],
         anonymous_only: !!data["anonymous_only"],
         epoch: data["epoch"],
       }
+    end
+
+    # Page metadata is immutable for the life of an application boot. Lazy
+    # latching lets model class bodies load without a DOM and keeps an early
+    # top-level local API call consistent with the later start/boot decision.
+    def self.__page_metadata
+      metadata = @page_metadata
+      return metadata if @page_metadata_latched && metadata
+      @page_metadata_latched = true
+      @page_metadata = read_page_metadata
+    end
+
+    def self.local_database_enabled?
+      return false if Funicular.server?
+      return !!@local_database_enabled if @local_database_latched
+      @local_database_latched = true
+      metadata = __page_metadata
+      @local_database_enabled =
+        !!metadata_value(metadata, :local_database, false)
+    end
+
+    # Test/embedder seam for code that installs DB state directly instead of
+    # entering through page metadata and DB.boot.
+    def self.__set_local_database_enabled(value)
+      @local_database_latched = true
+      @local_database_enabled = value ? true : false
+    end
+
+    # Runtime local APIs use UnavailableError. Configuration entry points
+    # (DB.boot/Funicular.start) use ConfigError instead.
+    def self.__ensure_local_database_enabled(operation)
+      if Funicular.server?
+        raise UnavailableError,
+          "#{operation}: the local database is unavailable on the server"
+      end
+      unless local_database_enabled?
+        raise UnavailableError,
+          "#{operation}: local database is disabled; " \
+          "set config.local_database = true"
+      end
+      true
     end
 
     # ---- session epoch: the terminal latch (docs decision 13) -----------
@@ -2357,11 +2412,12 @@ module Funicular
     # HTTP.get at app init) is epoch-checked too, not only traffic
     # after DB.boot -- the boot alone would latch too late.
     def self.__latch_page_epoch
+      return nil unless local_database_enabled?
       epoch = @session_epoch
       return epoch if epoch
       return nil if @page_epoch_latched
       @page_epoch_latched = true
-      @session_epoch = metadata_value(read_page_metadata, :epoch, nil)
+      @session_epoch = metadata_value(__page_metadata, :epoch, nil)
     end
 
     def self.session_terminated?
@@ -2375,6 +2431,7 @@ module Funicular
     # expected value latches lazily right here, so the very first
     # response a page ever receives is already checked.
     def self.__session_epoch_ok?(header)
+      return true unless local_database_enabled?
       expected = __latch_page_epoch
       return true unless expected
       return false if session_terminated?
@@ -2444,12 +2501,11 @@ module Funicular
         end
         identity = resolve_namespace(
           application_id: metadata_value(metadata, :application_id,
-                                         "funicular"),
+                                         nil),
           user_key: metadata_value(metadata, :user_key, nil),
           user_key_configured: !!metadata_value(metadata,
                                                 :user_key_configured, false),
-          anonymous_only: !!metadata_value(metadata, :anonymous_only, false),
-          local_models: !local_models.empty?)
+          anonymous_only: !!metadata_value(metadata, :anonymous_only, false))
         __set_snapshot_identity(identity)
         @session_epoch = metadata_value(metadata, :epoch, nil)
         # A mismatch detected before the boot even started (the schema
@@ -2570,6 +2626,7 @@ module Funicular
     # __boot_steps lets other Tasks run) and after a failed boot the
     # handles must be equally out of reach.
     def self.local
+      __ensure_local_database_enabled(:local)
       handle = boot_state == :ready ? @local_handle : nil
       unless handle
         raise UnavailableError, "the local database is not booted"
@@ -2578,6 +2635,7 @@ module Funicular
     end
 
     def self.replica
+      __ensure_local_database_enabled(:replica)
       handle = boot_state == :ready ? @replica_handle : nil
       unless handle
         raise UnavailableError, "the replica database is not booted"
@@ -2588,6 +2646,7 @@ module Funicular
     # The funnel every Model-level local operation goes through
     # (Model.local_db): ready check, then the SchemaTooNew latch.
     def self.__model_local_db(model)
+      __ensure_local_database_enabled(model.to_s)
       handle = boot_state == :ready ? @local_handle : nil
       unless handle
         raise UnavailableError,
@@ -2638,6 +2697,7 @@ module Funicular
     # per-table nuance, so the lockdown lifts only when every table
     # passes again.
     def self.reset_local_table(model)
+      __ensure_local_database_enabled(:reset_local)
       # The terminal latch first: on a terminated volatile page the
       # durability check below would still let this raw path through.
       ensure_session_not_terminated(:reset_local)
@@ -2714,6 +2774,10 @@ module Funicular
       @replica_handle = nil
       @schema_lockdown = nil
       @session_epoch = nil
+      @page_metadata = nil
+      @page_metadata_latched = false
+      @local_database_enabled = false
+      @local_database_latched = false
       @page_epoch_latched = false
       @session_terminated = false
       @databases = nil

--- a/mrblib/db.rb
+++ b/mrblib/db.rb
@@ -542,6 +542,7 @@ module Funicular
             raise ArgumentError,
               "duplicate column #{name.inspect} in #{model.table_name} migrations"
           end
+          guard_reserved_column(name, model)
           columns[name] = op[2]
         elsif kind == :rename
           old_name = op[1]
@@ -556,6 +557,7 @@ module Funicular
             raise ArgumentError,
               "duplicate column #{op[2].inspect} in #{model.table_name} migrations"
           end
+          guard_reserved_column(op[2], model)
           columns.delete(old_name)
           columns[op[2]] = type
         elsif kind == :remove
@@ -578,6 +580,38 @@ module Funicular
         raise ArgumentError,
           "the id column is implicit and cannot be renamed or removed " \
           "(#{model.table_name} migrations)"
+      end
+    end
+
+    # A column name must not shadow the model API: the generated reader
+    # would clobber anything the BASE Funicular::Model instance already
+    # responds to (destroy, reload, update, valid?, errors, class, hash,
+    # ...). Checking against the base class -- never the subclass -- keeps
+    # a model's own generated accessors from tripping the guard when its
+    # blocks are folded again.
+    def self.guard_reserved_column(name, model)
+      # The __ prefix is the framework-internal namespace (__custom_*
+      # writer stashes, __local_* helpers): a column named __custom_title
+      # would clobber the alias that wraps a hand-written title= writer.
+      if name.start_with?("__")
+        raise ArgumentError,
+          "column names starting with __ are reserved for framework " \
+          "internals (#{model.table_name} migrations); rename " \
+          "#{name.inspect}"
+      end
+      reserved = @reserved_column_names
+      unless reserved
+        # Both lists: instance_methods alone omits private methods, and a
+        # column named "initialize" or "method_missing" must be rejected
+        # just as hard as "destroy".
+        reserved = Funicular::Model.instance_methods +
+                   Funicular::Model.private_instance_methods
+        @reserved_column_names = reserved
+      end
+      if reserved.include?(name.to_sym)
+        raise ArgumentError,
+          "column name #{name.inspect} collides with a Funicular::Model " \
+          "method (#{model.table_name} migrations); rename the column"
       end
     end
 

--- a/mrblib/db.rb
+++ b/mrblib/db.rb
@@ -241,5 +241,416 @@ module Funicular
         s
       end
     end
+
+    # ---- client-only tables: the migrate blocks -------------------------
+    #
+    # `storage :local do migrate N do |t| ... end end` blocks are recorded
+    # by the model DSL and executed here, per table, at boot. The `t`
+    # yielded to a block is a TableBuilder: a pure recorder whose
+    # operations the runner below renders into DDL, and whose column
+    # operations fold into the model's local_columns metadata.
+    class TableBuilder
+      attr_reader :ops
+
+      def initialize
+        @ops = []
+      end
+
+      def string(name, default: nil, null: true)
+        add_column(:string, name, default, null)
+      end
+
+      def text(name, default: nil, null: true)
+        add_column(:text, name, default, null)
+      end
+
+      def integer(name, default: nil, null: true)
+        add_column(:integer, name, default, null)
+      end
+
+      def float(name, default: nil, null: true)
+        add_column(:float, name, default, null)
+      end
+
+      def boolean(name, default: nil, null: true)
+        add_column(:boolean, name, default, null)
+      end
+
+      def datetime(name, default: nil, null: true)
+        add_column(:datetime, name, default, null)
+      end
+
+      # created_at/updated_at, maintained automatically by the local CRUD.
+      def timestamps
+        add_column(:datetime, :created_at, nil, true)
+        add_column(:datetime, :updated_at, nil, true)
+      end
+
+      def index(*columns)
+        @ops << [:index, identifier_list(columns)]
+      end
+
+      def remove_index(*columns)
+        @ops << [:remove_index, identifier_list(columns)]
+      end
+
+      def rename(old_name, new_name)
+        @ops << [:rename, DB.validate_identifier(old_name),
+                 DB.validate_identifier(new_name)]
+      end
+
+      def remove(name)
+        @ops << [:remove, DB.validate_identifier(name)]
+      end
+
+      # Raw-SQL escape hatch; runs as-is and does not affect the column
+      # fold (whatever it does is invisible to local_columns).
+      def execute(sql)
+        @ops << [:execute, sql]
+      end
+
+      private
+
+      def add_column(type, name, default, null)
+        n = DB.validate_identifier(name)
+        if n == "id"
+          raise ArgumentError,
+            "the id column is implicit (INTEGER PRIMARY KEY); do not declare it"
+        end
+        @ops << [:add_column, n, type, default, null]
+      end
+
+      def identifier_list(columns)
+        if columns.empty?
+          raise ArgumentError, "at least one column is required"
+        end
+        # @type var names: Array[String]
+        names = []
+        i = 0
+        while i < columns.size
+          names << DB.validate_identifier(columns[i])
+          i += 1
+        end
+        names
+      end
+    end
+
+    SQL_TYPES = {
+      string: "TEXT",
+      text: "TEXT",
+      integer: "INTEGER",
+      float: "REAL",
+      boolean: "INTEGER",
+      datetime: "TEXT",
+    }
+
+    # One key/value metadata table in the local database holds the applied
+    # migration version per table (and, later, the replica fingerprint).
+    META_TABLE = "funicular_meta"
+
+    # SQL identifiers this layer interpolates (table and column names) must
+    # be plain: ASCII letter or underscore first, then letters, digits,
+    # underscores. Returns the name as a String.
+    def self.validate_identifier(name)
+      s = name.to_s
+      i = 0
+      while i < s.length
+        c = s.getbyte(i)
+        ok = c && (c == 95 || # '_'
+                   (97 <= c && c <= 122) || # a-z
+                   (65 <= c && c <= 90) ||  # A-Z
+                   (0 < i && 48 <= c && c <= 57)) # 0-9, not first
+        unless ok
+          raise ArgumentError, "invalid SQL identifier: #{name.inspect}"
+        end
+        i += 1
+      end
+      if s.empty?
+        raise ArgumentError, "invalid SQL identifier: #{name.inspect}"
+      end
+      s
+    end
+
+    # Fold a model's migrate blocks into column metadata (column name ->
+    # declared type), the implicit id included. Pure: no database touched,
+    # usable before boot.
+    def self.fold_local_columns(model)
+      # @type var columns: Hash[String, Symbol]
+      columns = { "id" => :integer }
+      builders = collect_builders(model)
+      i = 0
+      while i < builders.size
+        fold_ops(columns, builders[i].ops, model)
+        i += 1
+      end
+      columns
+    end
+
+    # Bring one model's local table to its declared schema. Fresh and
+    # below-baseline tables are rebuilt from the first retained block;
+    # tables between baseline and max get exactly the missing blocks; a
+    # table NEWER than the declarations raises SchemaTooNewError (deploy
+    # rollback; the whole-DB lockdown is wired at boot). All applied work
+    # runs in one transaction. When an incremental upgrade fails in
+    # development the table is rebuilt from scratch instead (never in
+    # production). Returns the version the table is at afterwards.
+    def self.apply_local_migrations(db, model)
+      migrations = model.local_migrations
+      unless migrations
+        raise ArgumentError,
+          "#{model} has no migrate blocks (is it storage :local?)"
+      end
+      table = validate_identifier(model.table_name)
+      baseline = migrations[0][:version]
+      max = migrations[migrations.size - 1][:version]
+      stored = stored_table_version(db, table)
+      if max < stored
+        raise SchemaTooNewError,
+          "\"#{table}\" is at migration #{stored} but the code only " \
+          "declares up to #{max} (deploy rollback?); the local database " \
+          "refuses to run backwards"
+      end
+      return max if stored == max
+      if stored < baseline
+        rebuild_local_table(db, model)
+      else
+        begin
+          db.transaction do
+            apply_blocks(db, model, stored)
+            store_table_version(db, table, max)
+          end
+        rescue SQLite3::Exception => e
+          # Explicit re-raise: a bare `raise` would not re-raise on the
+          # mruby VM (it raises a fresh empty RuntimeError).
+          raise e unless Funicular.env.development?
+          # Dev auto-reset: a dirty development table beats hand-repair.
+          rebuild_local_table(db, model)
+        end
+      end
+      max
+    end
+
+    # Drop and rebuild from the baseline, in one transaction: the fresh
+    # path, the below-baseline path, reset_local, and the dev auto-reset
+    # all land here. Returns the resulting version.
+    def self.rebuild_local_table(db, model)
+      migrations = model.local_migrations
+      unless migrations
+        raise ArgumentError,
+          "#{model} has no migrate blocks (is it storage :local?)"
+      end
+      table = validate_identifier(model.table_name)
+      max = migrations[migrations.size - 1][:version]
+      db.transaction do
+        db.execute("DROP TABLE IF EXISTS \"#{table}\"")
+        apply_blocks(db, model, 0)
+        store_table_version(db, table, max)
+      end
+      max
+    end
+
+    def self.stored_table_version(db, table)
+      ensure_meta_table(db)
+      rows = db.execute("SELECT value FROM \"#{META_TABLE}\" WHERE key = ?",
+                        ["table_version:#{table}"])
+      row = rows[0]
+      return 0 unless row
+      (row.is_a?(Hash) ? row.values[0] : row[0]).to_i
+    end
+
+    def self.store_table_version(db, table, version)
+      ensure_meta_table(db)
+      db.execute("INSERT OR REPLACE INTO \"#{META_TABLE}\" (key, value) " \
+                 "VALUES (?, ?)", ["table_version:#{table}", version.to_s])
+    end
+
+    def self.ensure_meta_table(db)
+      db.execute("CREATE TABLE IF NOT EXISTS \"#{META_TABLE}\" " \
+                 "(key TEXT PRIMARY KEY, value TEXT)")
+    end
+
+    # Run every migrate block against a fresh TableBuilder, returning the
+    # recorded operations in declaration order.
+    def self.collect_builders(model)
+      migrations = model.local_migrations
+      unless migrations
+        raise ArgumentError,
+          "#{model} has no migrate blocks (is it storage :local?)"
+      end
+      # @type var builders: Array[TableBuilder]
+      builders = []
+      i = 0
+      while i < migrations.size
+        t = TableBuilder.new
+        migrations[i][:block].call(t)
+        builders << t
+        i += 1
+      end
+      builders
+    end
+
+    # Apply one block's column effects to the running fold. Unknown or
+    # duplicate names fail here, before any SQL runs.
+    def self.fold_ops(columns, ops, model)
+      i = 0
+      while i < ops.size
+        op = ops[i]
+        kind = op[0]
+        if kind == :add_column
+          name = op[1]
+          if columns.has_key?(name)
+            raise ArgumentError,
+              "duplicate column #{name.inspect} in #{model.table_name} migrations"
+          end
+          columns[name] = op[2]
+        elsif kind == :rename
+          old_name = op[1]
+          guard_id(old_name, model)
+          type = columns[old_name]
+          unless type
+            raise ArgumentError,
+              "rename of unknown column #{old_name.inspect} in " \
+              "#{model.table_name} migrations"
+          end
+          if columns.has_key?(op[2])
+            raise ArgumentError,
+              "duplicate column #{op[2].inspect} in #{model.table_name} migrations"
+          end
+          columns.delete(old_name)
+          columns[op[2]] = type
+        elsif kind == :remove
+          name = op[1]
+          guard_id(name, model)
+          unless columns.has_key?(name)
+            raise ArgumentError,
+              "remove of unknown column #{name.inspect} in " \
+              "#{model.table_name} migrations"
+          end
+          columns.delete(name)
+        end
+        # index/remove_index/execute do not affect the fold
+        i += 1
+      end
+    end
+
+    def self.guard_id(name, model)
+      if name == "id"
+        raise ArgumentError,
+          "the id column is implicit and cannot be renamed or removed " \
+          "(#{model.table_name} migrations)"
+      end
+    end
+
+    # Apply every block with version > from_version. The first block
+    # applied onto a dropped/absent table runs in create mode (its column
+    # ops become the CREATE TABLE); everything later alters.
+    def self.apply_blocks(db, model, from_version)
+      migrations = model.local_migrations
+      builders = collect_builders(model)
+      table = validate_identifier(model.table_name)
+      creating = from_version < migrations[0][:version]
+      i = 0
+      while i < migrations.size
+        if from_version < migrations[i][:version]
+          run_block(db, table, builders[i], creating)
+          creating = false
+        end
+        i += 1
+      end
+    end
+
+    def self.run_block(db, table, builder, create_mode)
+      ops = builder.ops
+      if create_mode
+        # @type var defs: Array[String]
+        defs = ["\"id\" INTEGER PRIMARY KEY"]
+        i = 0
+        while i < ops.size
+          op = ops[i]
+          defs << column_ddl(op) if op[0] == :add_column
+          i += 1
+        end
+        db.execute("CREATE TABLE \"#{table}\" (#{defs.join(", ")})")
+        i = 0
+        while i < ops.size
+          op = ops[i]
+          kind = op[0]
+          if kind == :add_column
+            # already part of the CREATE TABLE
+          elsif kind == :index || kind == :remove_index || kind == :execute
+            run_alter_op(db, table, op)
+          else
+            raise ArgumentError,
+              "#{kind} needs an existing table; not allowed in the block " \
+              "that creates \"#{table}\""
+          end
+          i += 1
+        end
+      else
+        i = 0
+        while i < ops.size
+          run_alter_op(db, table, ops[i])
+          i += 1
+        end
+      end
+    end
+
+    def self.run_alter_op(db, table, op)
+      kind = op[0]
+      if kind == :add_column
+        db.execute("ALTER TABLE \"#{table}\" ADD COLUMN #{column_ddl(op)}")
+      elsif kind == :rename
+        db.execute("ALTER TABLE \"#{table}\" RENAME COLUMN \"#{op[1]}\" " \
+                   "TO \"#{op[2]}\"")
+      elsif kind == :remove
+        db.execute("ALTER TABLE \"#{table}\" DROP COLUMN \"#{op[1]}\"")
+      elsif kind == :index
+        db.execute("CREATE INDEX \"#{index_name(table, op[1])}\" " \
+                   "ON \"#{table}\" (#{quoted_list(op[1])})")
+      elsif kind == :remove_index
+        db.execute("DROP INDEX \"#{index_name(table, op[1])}\"")
+      elsif kind == :execute
+        db.execute(op[1])
+      else
+        raise ArgumentError, "unknown migration op #{kind.inspect}"
+      end
+    end
+
+    # op: [:add_column, name, type, default, null]
+    def self.column_ddl(op)
+      sql = "\"#{op[1]}\" #{SQL_TYPES[op[2]]}"
+      default = op[3]
+      unless default.nil?
+        sql += " DEFAULT #{default_literal(op[2], default)}"
+      end
+      sql += " NOT NULL" unless op[4]
+      sql
+    end
+
+    # Defaults go through the shared codec, so `default: false` stores 0
+    # and a Time default stores the canonical UTC string.
+    def self.default_literal(type, value)
+      encoded = Codec.encode(type, value)
+      if encoded.is_a?(String)
+        "'#{encoded.gsub("'", "''")}'"
+      else
+        encoded.to_s
+      end
+    end
+
+    def self.index_name(table, columns)
+      "index_#{table}_on_#{columns.join("_")}"
+    end
+
+    def self.quoted_list(columns)
+      # @type var quoted: Array[String]
+      quoted = []
+      i = 0
+      while i < columns.size
+        quoted << "\"#{columns[i]}\""
+        i += 1
+      end
+      quoted.join(", ")
+    end
   end
 end

--- a/mrblib/db.rb
+++ b/mrblib/db.rb
@@ -115,7 +115,7 @@ module Funicular
         min = digits_at(str, 14, 2)
         sep_at(str, 16, 58)  # ':'
         sec = digits_at(str, 17, 2)
-        if mon < 1 || 12 < mon || day < 1 || 31 < day ||
+        if mon < 1 || 12 < mon || day < 1 || days_in_month(year, mon) < day ||
            23 < hour || 59 < min || 60 < sec
           raise ArgumentError, "invalid datetime: #{str.inspect}"
         end
@@ -183,12 +183,22 @@ module Funicular
         era * 146097 + doe - 719468
       end
 
+      def self.days_in_month(year, mon)
+        return 31 if mon == 1 || mon == 3 || mon == 5 || mon == 7 ||
+                     mon == 8 || mon == 10 || mon == 12
+        return 30 unless mon == 2
+        (year % 4 == 0 && (year % 100 != 0 || year % 400 == 0)) ? 29 : 28
+      end
+
       # Parse the "HH:MM" part of a "+HH:MM" zone tail starting at `pos`
       # (the sign byte) and return it in seconds, always positive.
       def self.zone_offset(str, pos)
         oh = digits_at(str, pos + 1, 2)
         sep_at(str, pos + 3, 58) # ':'
         om = digits_at(str, pos + 4, 2)
+        if 23 < oh || 59 < om
+          raise ArgumentError, "invalid datetime: #{str.inspect}"
+        end
         oh * 3600 + om * 60
       end
 

--- a/mrblib/db.rb
+++ b/mrblib/db.rb
@@ -742,6 +742,361 @@ module Funicular
       "index_#{table}_on_#{columns.join("_")}"
     end
 
+    # ---- guarded database handles (docs decision 15) --------------------
+    #
+    # Funicular::DB.local/.replica hand out these proxies, never raw
+    # connections. The allowlist is CLOSED: persist/close/serialize/
+    # deserialize/backup do not exist here in ANY state, so no caller
+    # can snapshot, close, or swap the database out from under the
+    # framework. Read-only enforcement happens at every execution entry
+    # via Statement#readonly? -- a statement prepared while writable is
+    # still refused once the handle went read-only.
+
+    # Statements that subvert framework control are rejected in every
+    # state: ATTACH/DETACH escape to other database files, and
+    # PRAGMA query_only would lift (or fake) the read-only lockdown.
+    # sqlite3_stmt_readonly classifies all three as read-only, so the
+    # statement-level check alone would let them through.
+    def self.guard_statement_sql(sql)
+      s = sql.to_s
+      i = skip_sql_blanks(s, 0)
+      head = read_sql_word(s, i)
+      word = head[0]
+      if word == "attach" || word == "detach"
+        raise ArgumentError,
+          "ATTACH/DETACH are not available through the guarded " \
+          "database handle"
+      end
+      # Only the PRAGMA NAME decides (read pragmas stay available):
+      # "PRAGMA table_info(query_only)" is fine, "PRAGMA query_only",
+      # "PRAGMA main.query_only = OFF" and quoted spellings are not.
+      if word == "pragma" && pragma_name(s, head[1]) == "query_only"
+        raise ArgumentError,
+          "PRAGMA query_only is managed by the framework and cannot be " \
+          "issued through the guarded database handle"
+      end
+    end
+
+    # The first keyword of a statement, lowercased, with leading
+    # whitespace and -- and /* */ comments skipped (a comment prefix
+    # must not smuggle ATTACH past the guard).
+    def self.statement_head(sql)
+      s = sql.to_s
+      read_sql_word(s, skip_sql_blanks(s, 0))[0]
+    end
+
+    # The [schema.]name of a PRAGMA statement, starting right after the
+    # PRAGMA keyword (pos). Quoted names ("x", 'x', `x`, [x]) resolve to
+    # their inner text so quoting cannot smuggle query_only past the
+    # guard.
+    def self.pragma_name(s, pos)
+      i = skip_sql_blanks(s, pos)
+      token = read_sql_token(s, i)
+      name = token[0]
+      i = skip_sql_blanks(s, token[1])
+      if s.getbyte(i) == 46 # '.': schema-qualified, the name follows
+        token = read_sql_token(s, skip_sql_blanks(s, i + 1))
+        name = token[0]
+      end
+      name
+    end
+
+    # Skip whitespace and -- / /* */ comments; returns the next index.
+    def self.skip_sql_blanks(s, i)
+      len = s.length
+      while i < len
+        c = s.getbyte(i)
+        if c == 32 || c == 9 || c == 10 || c == 13
+          i += 1
+        elsif c == 45 && s.getbyte(i + 1) == 45 # "--" line comment
+          i += 2
+          while i < len && !(s.getbyte(i) == 10)
+            i += 1
+          end
+        elsif c == 47 && s.getbyte(i + 1) == 42 # "/*" block comment
+          i += 2
+          while i < len && !(s.getbyte(i) == 42 && s.getbyte(i + 1) == 47)
+            i += 1
+          end
+          i += 2
+        else
+          break
+        end
+      end
+      i
+    end
+
+    # Read a bare identifier/keyword at i: [downcased word, next index].
+    def self.read_sql_word(s, i)
+      len = s.length
+      start = i
+      while i < len
+        c = s.getbyte(i)
+        unless c && ((97 <= c && c <= 122) || (65 <= c && c <= 90) ||
+                     (48 <= c && c <= 57) || c == 95)
+          break
+        end
+        i += 1
+      end
+      word = s[start, i - start]
+      [word ? word.downcase : "", i]
+    end
+
+    # Like read_sql_word, but also resolves quoted identifiers to their
+    # inner text.
+    def self.read_sql_token(s, i)
+      c = s.getbyte(i)
+      closer = nil
+      if c == 91 # [ closes with ]
+        closer = 93
+      elsif c == 34 # "
+        closer = 34
+      elsif c == 39 # '
+        closer = 39
+      elsif c == 96 # `
+        closer = 96
+      end
+      return read_sql_word(s, i) unless closer
+      len = s.length
+      j = i + 1
+      start = j
+      while j < len && !(s.getbyte(j) == closer)
+        j += 1
+      end
+      word = s[start, j - start]
+      [word ? word.downcase : "", j + 1]
+    end
+
+    # The one execution-time gate every guarded entry point shares:
+    # read-only handles run read-only statements only, no matter when
+    # the statement (or its result set) was created.
+    def self.enforce_read_only(read_only, raw_stmt)
+      if read_only && !raw_stmt.readonly?
+        raise ReadOnlyTabError,
+          "this tab cannot write to the local database (read-only state)"
+      end
+    end
+
+    class GuardedStatement
+      def initialize(stmt, guard)
+        @stmt = stmt
+        @guard = guard
+      end
+
+      def bind_params(*bind_vars)
+        @stmt.bind_params(*bind_vars)
+      end
+
+      def readonly?
+        @stmt.readonly?
+      end
+
+      def columns
+        @stmt.columns
+      end
+
+      def close
+        @stmt.close
+      end
+
+      def closed?
+        @stmt.closed?
+      end
+
+      # Returns materialized rows, never the raw ResultSet (the closed
+      # allowlist would otherwise leak through it).
+      def execute(*bind_vars)
+        check_writable
+        @stmt.execute(*bind_vars).to_a
+      end
+
+      def step
+        check_writable
+        @stmt.step
+      end
+
+      private
+
+      def check_writable
+        DB.enforce_read_only(@guard.read_only?, @stmt)
+      end
+    end
+
+    # Wraps a raw ResultSet so stepping it re-checks the read-only state
+    # every time: a write+RETURNING result set created while writable
+    # must refuse to step after the handle went read-only.
+    class GuardedResultSet
+      def initialize(rs, stmt, guard)
+        @rs = rs
+        @stmt = stmt
+        @guard = guard
+      end
+
+      def next
+        check_writable
+        @rs.next
+      end
+
+      def each
+        row = self.next
+        while row
+          yield row
+          row = self.next
+        end
+        self
+      end
+
+      def to_a
+        # @type var rows: Array[untyped]
+        rows = []
+        row = self.next
+        while row
+          rows << row
+          row = self.next
+        end
+        rows
+      end
+
+      # reset rebinds and re-runs the statement: same gate as stepping.
+      def reset(*bind_params)
+        check_writable
+        @rs.reset(*bind_params)
+      end
+
+      def eof?
+        @rs.eof?
+      end
+
+      def close
+        @rs.close
+      end
+
+      def closed?
+        @rs.closed?
+      end
+
+      def columns
+        @rs.columns
+      end
+
+      def types
+        @rs.types
+      end
+
+      private
+
+      def check_writable
+        DB.enforce_read_only(@guard.read_only?, @stmt)
+      end
+    end
+
+    class GuardedDatabase
+      def initialize(db, read_only = false)
+        @db = db
+        @read_only = read_only
+      end
+
+      def read_only?
+        @read_only
+      end
+
+      # One-way by design: persistent_reader tabs stay readers for the
+      # life of the page and the terminal latch only ever tightens.
+      def __become_read_only
+        @read_only = true
+      end
+
+      def execute(sql, bind_vars = [])
+        prepare(sql) do |stmt|
+          rows = stmt.execute(*bind_vars)
+          if block_given?
+            rows_size = rows.size
+            i = 0
+            while i < rows_size
+              yield rows[i]
+              i += 1
+            end
+          end
+          rows
+        end
+      end
+
+      def prepare(sql)
+        DB.guard_statement_sql(sql)
+        stmt = GuardedStatement.new(@db.prepare(sql), self)
+        return stmt unless block_given?
+        begin
+          yield stmt
+        ensure
+          stmt.close unless stmt.closed?
+        end
+      end
+
+      # SQLite3::Database#query equivalent: a result set you step through
+      # yourself -- wrapped, so neither the raw connection nor the raw
+      # ResultSet ever surfaces. With a block the set is closed for you.
+      def query(sql, bind_vars = [])
+        DB.guard_statement_sql(sql)
+        stmt = @db.prepare(sql)
+        stmt.bind_params(*bind_vars) unless bind_vars.empty?
+        result = GuardedResultSet.new(
+          SQLite3::ResultSet.new(@db, stmt), stmt, self)
+        return result unless block_given?
+        begin
+          yield result
+        ensure
+          result.close
+        end
+      end
+
+      def get_first_row(sql, bind_vars = [])
+        execute(sql, bind_vars)[0]
+      end
+
+      def get_first_value(sql, bind_vars = [])
+        row = execute(sql, bind_vars)[0]
+        return nil unless row
+        row.is_a?(Hash) ? row.values[0] : row[0]
+      end
+
+      # Yields THIS proxy (docs decision 15), so raw connections never
+      # surface through the transaction block either.
+      def transaction(mode = :deferred)
+        mode_sql = if mode == :deferred
+          "DEFERRED"
+        elsif mode == :immediate
+          "IMMEDIATE"
+        elsif mode == :exclusive
+          "EXCLUSIVE"
+        else
+          raise ArgumentError, "invalid transaction mode #{mode.inspect}"
+        end
+        execute("BEGIN #{mode_sql} TRANSACTION")
+        return true unless block_given?
+        aborting = false
+        begin
+          yield self
+        rescue => e
+          aborting = true
+          # Explicit re-raise: a bare `raise` would not re-raise on the
+          # mruby VM.
+          raise e
+        ensure
+          aborting ? rollback : commit
+        end
+      end
+
+      def commit
+        execute("COMMIT TRANSACTION")
+        true
+      end
+
+      def rollback
+        execute("ROLLBACK TRANSACTION")
+        true
+      end
+    end
+
     # ---- namespace identity (docs decisions 12/13) ----------------------
     #
     # One browser profile can hold data for several apps and several

--- a/mrblib/db.rb
+++ b/mrblib/db.rb
@@ -2644,15 +2644,20 @@ module Funicular
     end
 
     # The funnel every Model-level local operation goes through
-    # (Model.local_db): ready check, then the SchemaTooNew latch.
+    # (Model.local_db): select the database for the model's storage role,
+    # check readiness, then apply the local-only SchemaTooNew latch.
     def self.__model_local_db(model)
       __ensure_local_database_enabled(model.to_s)
-      handle = boot_state == :ready ? @local_handle : nil
+      replica = model.replica?
+      handle = if boot_state == :ready
+        replica ? @replica_handle : @local_handle
+      end
       unless handle
         raise UnavailableError,
-          "#{model.to_s}: the local database is not booted"
+          "#{model.to_s}: the #{replica ? 'replica' : 'local'} database " \
+          "is not booted"
       end
-      __check_schema_lockdown(model.to_s)
+      __check_schema_lockdown(model.to_s) unless replica
       handle
     end
 

--- a/mrblib/db.rb
+++ b/mrblib/db.rb
@@ -850,13 +850,32 @@ module Funicular
         enqueue_delivery(event[0], event[1])
         i += 1
       end
+      resume_deferred_persist(role)
     end
 
     def self.__rollback_deferral(role)
       depths = (@deferral_depths ||= {}) # steep:ignore UnannotatedEmptyCollection
       depth = deferral_depth(role)
       depths[role] = depth - 1 if 0 < depth
-      clear_pending(role) if deferral_depth(role) == 0
+      return unless deferral_depth(role) == 0
+      clear_pending(role)
+      # A persist refused mid-transaction re-arms even here: the
+      # refusal may have consumed a debounce owed to EARLIER committed
+      # writes, and snapshotting the rolled-back (= committed) state is
+      # correct.
+      resume_deferred_persist(role)
+    end
+
+    # A persist that found its database mid-transaction parked itself
+    # in @persist_deferred (see persist_snapshot); the settle turns the
+    # park into a fresh debounce arm.
+    def self.resume_deferred_persist(role)
+      deferred = @persist_deferred
+      return nil unless deferred
+      return nil unless deferred[role]
+      deferred.delete(role)
+      schedule_persist(role)
+      nil
     end
 
     def self.clear_pending(role)
@@ -873,6 +892,10 @@ module Funicular
     # events collapse per [role, table]; the first event of a tick
     # schedules exactly one drain.
     def self.enqueue_delivery(role, table)
+      # Auto-persist rides the same post-commit funnel (docs decision
+      # 11): every event (re)arms the role's debounce timer, and a
+      # rollback -- which never reaches here -- schedules nothing.
+      schedule_persist(role)
       pending = (@tick_events ||= {}) # steep:ignore UnannotatedEmptyCollection
       key = "#{role}:#{table}"
       unless pending.has_key?(key)
@@ -1524,6 +1547,417 @@ module Funicular
 
     def self.lock_name(identity)
       "funicular:lock:#{identity}"
+    end
+
+    # ---- configuration (docs decision 20: the DB-side knobs) ------------
+    #
+    #   Funicular::DB.configure do
+    #     config.local_debounce_ms = 200
+    #   end
+    #
+    # The block runs with DB as self, so the bareword `config` resolves
+    # here. Identity (application_id/user_key) is NOT configured here --
+    # it arrives from the page, configured on the Rails side (docs
+    # decision 12).
+
+    class Config
+      attr_accessor :replica_debounce_ms
+      attr_accessor :local_debounce_ms
+      attr_accessor :request_persistent_storage
+      attr_accessor :on_persist_error
+      attr_accessor :on_boot_error
+      attr_accessor :on_session_change
+
+      def initialize
+        @replica_debounce_ms = 5000
+        @local_debounce_ms = 500
+        @request_persistent_storage = true
+        @on_persist_error = nil
+        @on_boot_error = nil
+        @on_session_change = nil
+      end
+    end
+
+    def self.config
+      @config ||= Config.new
+    end
+
+    def self.configure(&block)
+      raise ArgumentError, "configure requires a block" unless block
+      instance_exec(&block) # steep:ignore
+      nil
+    end
+
+    # Test seam: configuration is process-global, so per-file test VMs
+    # restore the defaults between tests.
+    def self.__reset_config
+      @config = nil
+    end
+
+    # ---- persistence (docs decisions 11/16) -----------------------------
+    #
+    # Durability = whole-database snapshots (serialize -> Base64) in
+    # Funicular's OWN IndexedDB store, opened with the in-memory
+    # fallback DISABLED: a silently substituted empty store must never
+    # masquerade as persistence. Availability errors mean the browser
+    # context has no storage BY DESIGN -> the volatile state; every
+    # other storage error re-raises, for the boot to fail loud on
+    # (docs decision 16).
+
+    SNAPSHOT_DB_NAME = "funicular"
+
+    # The boot wires the two databases in here. flush/wipe/persist need
+    # the RAW handle (serialize lives outside the guarded allowlist),
+    # which is exactly why this registry has no public getter.
+    def self.__register_database(role, raw_db, models)
+      validate_role(role)
+      registry = (@databases ||= {}) # steep:ignore UnannotatedEmptyCollection
+      registry[role] = [raw_db, models]
+      nil
+    end
+
+    def self.__registered_database(role)
+      registry = @databases
+      entry = registry ? registry[role] : nil
+      entry ? entry[0] : nil
+    end
+
+    # Every snapshot key derives from the namespace identity, resolved
+    # by the boot (docs decision 12).
+    def self.__set_snapshot_identity(identity)
+      @snapshot_identity = identity
+    end
+
+    def self.__set_snapshot_store(store)
+      # Installing a store (or resetting to nil in tests) also clears
+      # the sticky availability-failure mark below.
+      @snapshot_store_unavailable = false
+      @snapshot_store = store
+    end
+
+    def self.snapshot_store
+      @snapshot_store
+    end
+
+    # Open Funicular's snapshot store once. nil (after dropping to
+    # volatile) when the context has no storage BY DESIGN; anything
+    # else -- quota, version, blocked timeouts -- re-raises: storage
+    # exists but could not be used, and snapshots (including
+    # unrecoverable local data) may well be sitting in it.
+    def self.open_snapshot_store
+      store = @snapshot_store
+      return store if store
+      # An availability failure is sticky: nil alone cannot distinguish
+      # "not tried yet" from "classified volatile", and re-trying would
+      # log and fire on_persist_error again -- the announcement happens
+      # ONCE (docs decision 14).
+      return nil if @snapshot_store_unavailable
+      unless Object.const_defined?(:IndexedDB)
+        raise UnavailableError,
+          "IndexedDB does not exist in this environment; " \
+          "snapshots are wasm-only"
+      end
+      begin
+        @snapshot_store = IndexedDB::KVS.open(SNAPSHOT_DB_NAME,
+                                              fallback: false)
+      rescue IndexedDB::NotSupportedError,
+             IndexedDB::SecurityError,
+             IndexedDB::InvalidStateError => e
+        @snapshot_store_unavailable = true
+        __become_volatile(e)
+        nil
+      end
+    end
+
+    # Private mode or an exotic embedder: everything works, nothing
+    # persists. A held writer lock is released first -- release also
+    # steps @durability down, so volatile is claimed after.
+    def self.__become_volatile(error)
+      release_writer_lock
+      @durability = :volatile
+      puts "[Funicular] persistent storage is unavailable; this page " \
+           "runs volatile (everything works, nothing persists): " \
+           "#{error.class}: #{error.message}"
+      invoke_persist_error_hook(error)
+      nil
+    end
+
+    # Persistence failures are never silent (docs decision 11): always
+    # the log, plus the app's hook when registered.
+    def self.report_persist_error(error)
+      puts "[Funicular] snapshot persistence failed: " \
+           "#{error.class}: #{error.message}"
+      invoke_persist_error_hook(error)
+      nil
+    end
+
+    def self.invoke_persist_error_hook(error)
+      hook = config.on_persist_error
+      return nil unless hook
+      begin
+        hook.call(error)
+      rescue => e
+        puts "[Funicular] on_persist_error hook raised: " \
+             "#{e.class}: #{e.message}"
+      end
+      nil
+    end
+
+    # Advanced by wipe (docs decision 17): a snapshot captured under an
+    # older generation refuses to land.
+    def self.mutation_generation
+      @mutation_generation || 0
+    end
+
+    # Serialize one database into its namespaced snapshot key. Only the
+    # persistent_writer persists (docs decision 14); on any other state
+    # this is a quiet false. Returns true when the snapshot was
+    # written.
+    def self.persist_snapshot(role)
+      validate_role(role)
+      return false unless durability == :persistent_writer
+      db = __registered_database(role)
+      return false unless db
+      store = @snapshot_store
+      return false unless store
+      identity = @snapshot_identity
+      unless identity
+        raise Error,
+          "cannot persist: the namespace identity is not resolved"
+      end
+      # serialize copies the pager's CURRENT pages, uncommitted changes
+      # included -- and a transaction awaiting inside its block lets
+      # other Tasks run, so a debounce timer, the visibilitychange
+      # backstop, or an in-block flush CAN land here mid-transaction.
+      # A snapshot taken now could outlive a rollback and resurrect the
+      # rolled-back rows at the next boot. Defer instead: the
+      # commit/rollback settle re-arms the debounce (docs decision 11).
+      if db.transaction_active?
+        deferred = (@persist_deferred ||= {}) # steep:ignore UnannotatedEmptyCollection
+        deferred[role] = true
+        return false
+      end
+      generation = mutation_generation
+      begin
+        encoded = Base64.encode64(db.serialize)
+        # The store put suspends this Task; a wipe that advanced the
+        # generation since this image was captured must win over it.
+        return false unless mutation_generation == generation
+        store[snapshot_key(identity, role)] = encoded
+        true
+      rescue => e
+        report_persist_error(e)
+        false
+      end
+    end
+
+    # Deserialize a stored snapshot into the registered database.
+    # false when no snapshot exists (a first visit). Read errors
+    # propagate: the boot fails loud on top of unreadable storage
+    # (docs decision 16).
+    def self.restore_snapshot(role)
+      validate_role(role)
+      db = __registered_database(role)
+      unless db
+        raise Error, "no #{role} database is registered"
+      end
+      store = @snapshot_store
+      return false unless store
+      identity = @snapshot_identity
+      unless identity
+        raise Error,
+          "cannot restore: the namespace identity is not resolved"
+      end
+      encoded = store[snapshot_key(identity, role)]
+      return false if encoded.nil?
+      db.deserialize(Base64.decode64(encoded.to_s))
+      true
+    end
+
+    # ---- debounced auto-persist (docs decision 11) ----------------------
+    #
+    # Every post-commit change event also (re)arms that role's persist
+    # timer, so writes during the quiet window keep pushing the
+    # snapshot back and a burst costs one serialize. Riding the
+    # enqueue_delivery funnel means transactional writes schedule at
+    # COMMIT and a rollback schedules nothing.
+
+    def self.schedule_persist(role)
+      return nil unless durability == :persistent_writer
+      return nil unless @snapshot_store
+      return nil unless Object.const_defined?(:JS)
+      timers = (@persist_timers ||= {}) # steep:ignore UnannotatedEmptyCollection
+      existing = timers[role]
+      # @type var global: untyped
+      global = JS.global
+      global.clearTimeout(existing) if existing
+      # The clear can come too late: a timer whose JS deadline already
+      # passed has its callback QUEUED on the Ruby side, beyond
+      # clearTimeout's reach. Every (re)arm therefore bumps the role's
+      # token, and only the callback holding the current token acts.
+      tokens = (@persist_timer_tokens ||= {}) # steep:ignore UnannotatedEmptyCollection
+      token = (tokens[role] || 0) + 1
+      tokens[role] = token
+      cfg = config
+      ms = role == :local ? cfg.local_debounce_ms : cfg.replica_debounce_ms
+      timers[role] = global.setTimeout(ms) do
+        __persist_timer_fired(role, token)
+      end
+      nil
+    end
+
+    # The armed timer's landing point. A stale callback (its timer was
+    # re-armed or cancelled after the JS deadline passed) must neither
+    # drop the replacement timer's bookkeeping nor snapshot: it would
+    # cut the quiet window short and leave the replacement uncancelable.
+    def self.__persist_timer_fired(role, token)
+      tokens = @persist_timer_tokens
+      return nil unless tokens
+      return nil unless tokens[role] == token
+      timers = @persist_timers
+      timers.delete(role) if timers
+      persist_snapshot(role)
+      nil
+    end
+
+    # Test seam for the staleness protocol above.
+    def self.__persist_timer_token(role)
+      tokens = @persist_timer_tokens
+      tokens ? tokens[role] : nil
+    end
+
+    def self.cancel_persist_timers
+      # Cancelling covers parked persists too (a caller about to
+      # persist NOW, or wipe, wants no leftover re-arm at settle).
+      @persist_deferred = nil
+      # Invalidate the tokens IN PLACE first: a fired-but-not-yet-run
+      # callback already sits in the queue holding the current token,
+      # and clearTimeout cannot recall it.
+      tokens = @persist_timer_tokens
+      if tokens
+        keys = tokens.keys
+        keys_size = keys.size
+        i = 0
+        while i < keys_size
+          key = keys[i]
+          tokens[key] = tokens[key] + 1
+          i += 1
+        end
+      end
+      timers = @persist_timers
+      return nil unless timers
+      @persist_timers = {}
+      return nil unless Object.const_defined?(:JS)
+      # @type var global: untyped
+      global = JS.global
+      roles = timers.keys
+      roles_size = roles.size
+      i = 0
+      while i < roles_size
+        handle = timers[roles[i]]
+        global.clearTimeout(handle) if handle
+        i += 1
+      end
+      nil
+    end
+
+    # Immediate snapshot of both databases (docs decision 11). On a
+    # persistent_reader every persisting operation raises; volatile has
+    # no store to write, so flush is an honest no-op -- everything
+    # works, nothing persists. Inside an open transaction a database
+    # cannot be serialized (see persist_snapshot); its snapshot defers
+    # to the commit/rollback settle and flush reports false.
+    def self.flush
+      state = durability
+      if state == :persistent_reader
+        raise ReadOnlyTabError,
+          "flush requires the writer tab " \
+          "(this tab is a persistent_reader)"
+      end
+      return false unless state == :persistent_writer
+      cancel_persist_timers
+      wrote_replica = persist_snapshot(:replica)
+      wrote_local = persist_snapshot(:local)
+      wrote_replica || wrote_local
+    end
+
+    # The tab-hidden backstop (docs decision 11): debounce alone would
+    # lose the quiet-window tail when the user switches away and the
+    # browser freezes the page. Installed by the boot; false where no
+    # document exists (Node, SSR).
+    def self.__install_visibility_hook
+      return false if @visibility_hook_installed
+      return false unless Object.const_defined?(:JS)
+      # @type var global: untyped
+      global = JS.global
+      present = global.eval(
+        "typeof document === 'undefined' ? 'no' : 'yes'").to_s
+      return false unless present == "yes"
+      @visibility_hook_installed = true
+      # Not JS.document: it insists on a real DOM Element, and this
+      # hook only needs addEventListener (tests fake the document).
+      global[:document].addEventListener("visibilitychange") do
+        __visibility_flush
+      end
+      true
+    end
+
+    # Hidden -> persist NOW: the page may never come back.
+    def self.__visibility_flush
+      return nil unless durability == :persistent_writer
+      return nil unless Object.const_defined?(:JS)
+      # @type var global: untyped
+      global = JS.global
+      state = global.eval(
+        "typeof document === 'undefined' ? '' : " \
+        "String(document.visibilityState)").to_s
+      return nil unless state == "hidden"
+      cancel_persist_timers
+      persist_snapshot(:replica)
+      persist_snapshot(:local)
+      nil
+    end
+
+    # navigator.storage.persist() (docs decision 11): asked by the boot
+    # only when a storage :local model exists -- data actually worth
+    # protecting; replica-only apps never prompt. The browser has the
+    # final word, the result is informational. The __funicularStorageApi
+    # seam mirrors the locks shim: only `undefined` falls through to
+    # the real navigator.storage.
+    STORAGE_PERSIST_JS = <<~'FUNICULAR_STORAGE_JS'
+      (() => {
+        const injected = globalThis.__funicularStorageApi;
+        const storage = (injected === undefined)
+          ? (globalThis.navigator && globalThis.navigator.storage)
+          : injected;
+        if (!storage || !storage.persist) {
+          return Promise.resolve("unsupported");
+        }
+        try {
+          return Promise.resolve(storage.persist()).then(
+            (granted) => (granted ? "granted" : "denied"),
+            () => "error");
+        } catch (e) {
+          return Promise.resolve("error");
+        }
+      })()
+    FUNICULAR_STORAGE_JS
+
+    def self.request_persistent_storage
+      return :disabled unless config.request_persistent_storage
+      return :unsupported unless Object.const_defined?(:JS)
+      # @type var global: untyped
+      global = JS.global
+      result = global.eval(STORAGE_PERSIST_JS).await.to_s
+      if result == "granted"
+        :granted
+      elsif result == "denied"
+        :denied
+      elsif result == "error"
+        :error
+      else
+        :unsupported
+      end
     end
 
     # ---- replica tables: schema-derived DDL + fingerprint ---------------

--- a/mrblib/db.rb
+++ b/mrblib/db.rb
@@ -1,0 +1,226 @@
+# Funicular::DB is the client-side database engine behind the local
+# database layer (docs/local_database.md). This file holds the pieces the
+# query layer depends on: the error vocabulary and the shared value codec.
+#
+# SSR contract: this file only defines modules/classes at load time and
+# never touches SQLite3 or JS, so it is safe to load on CRuby.
+
+module Funicular
+  # Raised by Relation#find (and, on `storage :local` models, the bare-class
+  # alias) when no row matches. Named after the ActiveRecord counterpart.
+  class RecordNotFound < StandardError; end
+
+  module DB
+    class Error < StandardError; end
+
+    # `.local` on a `storage :ephemeral` model: there is no table behind it.
+    class NoTableError < Error; end
+
+    # Local write attempted on a tab that lost (or never ran) the writer
+    # election, or a destructive operation (flush/wipe/reset_local) there.
+    class ReadOnlyTabError < Error; end
+
+    # Local bulk write attempted on a replica table. The server owns replica
+    # rows; deletions reach the replica through write-through destroy.
+    class ReplicaWriteError < Error; end
+
+    # The persisted local schema is NEWER than the code's declarations
+    # (deploy rollback). The whole local DB fails loud; see the docs.
+    class SchemaTooNewError < Error; end
+
+    # A local query was materialized where no local database can exist
+    # (SSR) or before boot completed.
+    class UnavailableError < Error; end
+
+    # One shared codec for values crossing the Ruby/SQLite boundary.
+    # Applied identically to local writes, reads, condition binds, and REST
+    # response initialization, so both sides of a model return the same
+    # Ruby types for the same attribute.
+    #
+    #   boolean  true/false <-> INTEGER 1/0
+    #   datetime Time <-> ISO 8601 TEXT normalized to UTC at fixed
+    #            (second) precision -- arbitrary offsets or precisions
+    #            would not sort chronologically as strings
+    #
+    # Every other declared type passes through untouched.
+    module Codec
+      # Ruby value -> SQLite bind/storage value for a column of `type`.
+      def self.encode(type, value)
+        return nil if value.nil?
+        if type == :boolean
+          return 1 if value == true
+          return 0 if value == false
+          value
+        elsif type == :datetime
+          value.is_a?(Time) ? time_to_iso(value) : value
+        else
+          value
+        end
+      end
+
+      # SQLite value -> Ruby value for a column of `type`.
+      def self.decode(type, value)
+        return nil if value.nil?
+        if type == :boolean
+          return value unless value.is_a?(Integer)
+          value == 0 ? false : true
+        elsif type == :datetime
+          value.is_a?(String) ? iso_to_time(value) : value
+        else
+          value
+        end
+      end
+
+      # Type-less encoding for raw-SQL-fragment binds, where no column (and
+      # so no declared type) is known. Converts by value instead.
+      def self.encode_bind(value)
+        return 1 if value == true
+        return 0 if value == false
+        return time_to_iso(value) if value.is_a?(Time)
+        value
+      end
+
+      # Format a Time as UTC ISO 8601 at second precision. Derived from the
+      # epoch (Time#to_i), so the host's local time zone never leaks in.
+      def self.time_to_iso(time)
+        epoch = time.to_i
+        days = epoch / 86400
+        secs = epoch % 86400
+        civil = civil_from_days(days)
+        zpad(civil[0], 4) + "-" + zpad(civil[1], 2) + "-" + zpad(civil[2], 2) +
+          "T" + zpad(secs / 3600, 2) + ":" + zpad((secs % 3600) / 60, 2) +
+          ":" + zpad(secs % 60, 2) + "Z"
+      end
+
+      # Parse "YYYY-MM-DD[T ]HH:MM:SS[.fff][Z|+HH:MM|-HH:MM]" into a Time.
+      # Fractional seconds are truncated (the codec's fixed precision);
+      # a missing zone designator is read as UTC. Raises ArgumentError on
+      # anything malformed.
+      def self.iso_to_time(str)
+        len = str.length
+        if len < 19
+          raise ArgumentError, "invalid datetime: #{str.inspect}"
+        end
+        year = digits_at(str, 0, 4)
+        sep_at(str, 4, 45)   # '-'
+        mon = digits_at(str, 5, 2)
+        sep_at(str, 7, 45)   # '-'
+        day = digits_at(str, 8, 2)
+        t = str.getbyte(10)
+        unless t == 84 || t == 32 # 'T' or ' '
+          raise ArgumentError, "invalid datetime: #{str.inspect}"
+        end
+        hour = digits_at(str, 11, 2)
+        sep_at(str, 13, 58)  # ':'
+        min = digits_at(str, 14, 2)
+        sep_at(str, 16, 58)  # ':'
+        sec = digits_at(str, 17, 2)
+        if mon < 1 || 12 < mon || day < 1 || 31 < day ||
+           23 < hour || 59 < min || 60 < sec
+          raise ArgumentError, "invalid datetime: #{str.inspect}"
+        end
+        pos = 19
+        if str.getbyte(pos) == 46 # '.'
+          pos += 1
+          digit_seen = false
+          c = str.getbyte(pos)
+          while c && 48 <= c && c <= 57
+            digit_seen = true
+            pos += 1
+            c = str.getbyte(pos)
+          end
+          unless digit_seen
+            raise ArgumentError, "invalid datetime: #{str.inspect}"
+          end
+        end
+        offset = 0
+        zone = str.getbyte(pos)
+        if zone.nil?
+          # no designator: read as UTC
+        elsif zone == 90 || zone == 122 # 'Z' or 'z'
+          pos += 1
+        elsif zone == 43 # '+'
+          offset = zone_offset(str, pos)
+          pos += 6
+        elsif zone == 45 # '-'
+          offset = -zone_offset(str, pos)
+          pos += 6
+        else
+          raise ArgumentError, "invalid datetime: #{str.inspect}"
+        end
+        unless pos == len
+          raise ArgumentError, "invalid datetime: #{str.inspect}"
+        end
+        epoch = days_from_civil(year, mon, day) * 86400 +
+                hour * 3600 + min * 60 + sec - offset
+        Time.at(epoch)
+      end
+
+      # --- calendar arithmetic (Howard Hinnant's civil algorithms) --------
+
+      # Days since 1970-01-01 -> [year, month, day].
+      def self.civil_from_days(days)
+        z = days + 719468
+        era = (0 <= z ? z : z - 146096) / 146097
+        doe = z - era * 146097
+        yoe = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365
+        y = yoe + era * 400
+        doy = doe - (365 * yoe + yoe / 4 - yoe / 100)
+        mp = (5 * doy + 2) / 153
+        d = doy - (153 * mp + 2) / 5 + 1
+        m = mp < 10 ? mp + 3 : mp - 9
+        y += 1 if m <= 2
+        [y, m, d]
+      end
+
+      # [year, month, day] -> days since 1970-01-01.
+      def self.days_from_civil(y, m, d)
+        y -= 1 if m <= 2
+        era = (0 <= y ? y : y - 399) / 400
+        yoe = y - era * 400
+        doy = (153 * (m <= 2 ? m + 9 : m - 3) + 2) / 5 + d - 1
+        doe = yoe * 365 + yoe / 4 - yoe / 100 + doy
+        era * 146097 + doe - 719468
+      end
+
+      # Parse the "HH:MM" part of a "+HH:MM" zone tail starting at `pos`
+      # (the sign byte) and return it in seconds, always positive.
+      def self.zone_offset(str, pos)
+        oh = digits_at(str, pos + 1, 2)
+        sep_at(str, pos + 3, 58) # ':'
+        om = digits_at(str, pos + 4, 2)
+        oh * 3600 + om * 60
+      end
+
+      # Read `len` decimal digits at byte offset `pos` as an Integer.
+      def self.digits_at(str, pos, len)
+        v = 0
+        i = 0
+        while i < len
+          c = str.getbyte(pos + i)
+          if c.nil? || c < 48 || 57 < c
+            raise ArgumentError, "invalid datetime: #{str.inspect}"
+          end
+          v = v * 10 + (c - 48)
+          i += 1
+        end
+        v
+      end
+
+      # Assert the byte at `pos` is `code`.
+      def self.sep_at(str, pos, code)
+        unless str.getbyte(pos) == code
+          raise ArgumentError, "invalid datetime: #{str.inspect}"
+        end
+      end
+
+      def self.zpad(n, width)
+        s = n.to_s
+        while s.length < width
+          s = "0" + s
+        end
+        s
+      end
+    end
+  end
+end

--- a/mrblib/db.rb
+++ b/mrblib/db.rb
@@ -1755,8 +1755,10 @@ module Funicular
       # election is already won: a snapshot now would overwrite the
       # stored data with an empty image. The boot itself never
       # persists, so :booting refuses at this FINAL entry -- flush and
-      # the debounce path funnel through here.
+      # the debounce path funnel through here. A terminated session
+      # (docs decision 13) never persists again either.
       return false if boot_state == :booting
+      return false if session_terminated?
       return false unless durability == :persistent_writer
       db = __registered_database(role)
       return false unless db
@@ -1785,7 +1787,19 @@ module Funicular
         # The store put suspends this Task; a wipe that advanced the
         # generation since this image was captured must win over it.
         return false unless mutation_generation == generation
-        store[snapshot_key(identity, role)] = encoded
+        # Counted so a terminal step-down (docs decision 13) can wait
+        # for a put that already passed the checks above: the writer
+        # lock must not free the slot while an old-session image is
+        # still landing in the store.
+        @persist_inflight = persist_inflight + 1
+        begin
+          store[snapshot_key(identity, role)] = encoded
+        ensure
+          # Clamped: __reset_boot zeroes the counter while a test's
+          # put may still be in flight, and ITS decrement must not
+          # push the fresh state negative.
+          @persist_inflight = 0 < persist_inflight ? persist_inflight - 1 : 0
+        end
         true
       rescue => e
         report_persist_error(e)
@@ -1903,6 +1917,28 @@ module Funicular
         i += 1
       end
       nil
+    end
+
+    class << self
+      private def persist_inflight
+        @persist_inflight || 0
+      end
+
+      # Decision 13's "serialize with in-flight persist": a put that
+      # already passed persist_snapshot's checks keeps running inside
+      # the store across an await, beyond any flag's reach. A terminal
+      # step-down waits here BEFORE releasing the writer lock --
+      # otherwise a fresh tab could win the election and restore while
+      # the old session's image is still landing over its store.
+      private def await_inflight_persists
+        return nil unless Object.const_defined?(:JS)
+        while 0 < persist_inflight
+          # @type var global: untyped
+          global = JS.global
+          global.eval("new Promise((r) => setTimeout(r, 10))").await
+        end
+        nil
+      end
     end
 
     # Immediate snapshot of both databases (docs decision 11). On a
@@ -2030,6 +2066,9 @@ module Funicular
     # a persistent_reader); volatile is fine too -- the only tab, all
     # memory, no snapshots to delete.
     def self.wipe
+      # The terminal latch first: on a terminated volatile page the
+      # durability checks below would still let this raw path through.
+      ensure_session_not_terminated(:wipe)
       # Like reset_local, wipe reaches the RAW databases, so a
       # mid-boot wipe must be kept out (durability is already elected
       # then). :failed stays allowed: wiping from on_boot_error IS the
@@ -2110,6 +2149,18 @@ module Funicular
         @tick_order = []
         @tick_events = {}
         nil
+      end
+
+      # Decision 13's terminal latch is independent of durability: a
+      # terminated VOLATILE page keeps :volatile (only a writer steps
+      # down to :persistent_reader), so the raw rebuild paths -- wipe
+      # and reset_local -- need their own refusal on top of the
+      # read-only proxies.
+      private def ensure_session_not_terminated(operation)
+        return nil unless session_terminated?
+        raise ReadOnlyTabError,
+          "#{operation} refused: the session changed; this page is " \
+          "terminal (reload to continue)"
       end
 
       private def ensure_not_in_transaction(role)
@@ -2285,6 +2336,95 @@ module Funicular
       }
     end
 
+    # ---- session epoch: the terminal latch (docs decision 13) -----------
+    #
+    # The Rails side stamps X-Funicular-Epoch on every REST/schema
+    # response and rotates it when the session's user changes. A
+    # mismatch means this page belongs to a session that no longer
+    # exists: NOTHING may be applied, written, or persisted again for
+    # the life of the page.
+
+    # Test/boot seam; the boot fills it from the page metadata.
+    def self.__set_session_epoch(value)
+      @session_epoch = value
+    end
+
+    # Reads the page's epoch attribute ONCE and holds the result --
+    # nil included, so an epoch-less page never re-reads the DOM per
+    # response. The schema barrier calls this BEFORE its first request
+    # leaves, and __session_epoch_ok? latches lazily for everything
+    # else: pre-boot HTTP (an ephemeral model's REST call, a direct
+    # HTTP.get at app init) is epoch-checked too, not only traffic
+    # after DB.boot -- the boot alone would latch too late.
+    def self.__latch_page_epoch
+      epoch = @session_epoch
+      return epoch if epoch
+      return nil if @page_epoch_latched
+      @page_epoch_latched = true
+      @session_epoch = metadata_value(read_page_metadata, :epoch, nil)
+    end
+
+    def self.session_terminated?
+      !!@session_terminated
+    end
+
+    # The gate every Funicular::HTTP response passes through (http.rb):
+    # true = the response may be delivered and applied. No page epoch
+    # means the feature is off (no Rails integration yet). With one
+    # expected, a MISSING header counts as a mismatch too. The
+    # expected value latches lazily right here, so the very first
+    # response a page ever receives is already checked.
+    def self.__session_epoch_ok?(header)
+      expected = __latch_page_epoch
+      return true unless expected
+      return false if session_terminated?
+      unless header == expected
+        __terminate_session(header)
+        return false
+      end
+      true
+    end
+
+    # Irreversible. A writer steps down completely: no pending or new
+    # persist survives, the lock frees the writer slot for a fresh tab,
+    # and both connections remain only as a non-persistent read view.
+    def self.__terminate_session(header)
+      return nil if @session_terminated
+      @session_terminated = true
+      puts "[Funicular] session epoch mismatch (expected " \
+           "#{@session_epoch.inspect}, got #{header.inspect}): this " \
+           "page is terminal; reload to continue"
+      cancel_persist_timers
+      # The handles close BEFORE the wait below suspends this Task:
+      # nothing may write into the read view through that window.
+      handle = @local_handle
+      handle.__become_read_only if handle
+      handle = @replica_handle
+      handle.__become_read_only if handle
+      # A put that already passed persist_snapshot's terminal check
+      # keeps running inside the store; the lock frees the writer slot
+      # only once it landed (docs decision 13: a terminal writer
+      # serializes with the in-flight persist).
+      await_inflight_persists
+      release_writer_lock
+      hook = config.on_session_change
+      if hook
+        begin
+          hook.call
+        rescue => e
+          puts "[Funicular] on_session_change hook raised: " \
+               "#{e.class}: #{e.message}"
+        end
+      elsif Object.const_defined?(:JS)
+        # Default behavior: reload into the new session.
+        # @type var global: untyped
+        global = JS.global
+        global.eval(
+          "typeof location === 'undefined' ? null : location.reload()")
+      end
+      nil
+    end
+
     class << self
       private def __boot_steps(models, metadata)
         # @type var local_models: Array[untyped]
@@ -2312,15 +2452,25 @@ module Funicular
           local_models: !local_models.empty?)
         __set_snapshot_identity(identity)
         @session_epoch = metadata_value(metadata, :epoch, nil)
+        # A mismatch detected before the boot even started (the schema
+        # barrier latches the epoch first) must not boot a stale page.
+        ensure_boot_not_terminated
         elect_writer(lock_name(identity))
+        # The election suspended this Task: a response landing in that
+        # window found no lock and no handles to tear down, so the
+        # boot itself notices and aborts -- __fail_boot releases the
+        # lock the election acquired AFTER the termination.
+        ensure_boot_not_terminated
         # Availability errors drop to volatile inside; anything else
         # re-raises and fails the boot (docs decision 16).
         open_snapshot_store
+        ensure_boot_not_terminated
         local_db = SQLite3::Database.new(":memory:")
         replica_db = SQLite3::Database.new(":memory:")
         __register_database(:local, local_db, local_models)
         __register_database(:replica, replica_db, replica_models)
         restore_snapshot(:local)
+        ensure_boot_not_terminated
         begin
           i = 0
           local_size = local_models.size
@@ -2335,11 +2485,28 @@ module Funicular
           engage_schema_lockdown(local_db, e)
         end
         restore_snapshot(:replica)
+        ensure_boot_not_terminated
         build_replica_tables(replica_db, replica_models)
         __install_handles(local_db, replica_db)
         request_persistent_storage unless local_models.empty?
+        # The storage request was the last await before :ready; a
+        # termination inside it already closed the fresh handles, and
+        # the abort here keeps the page off :ready entirely.
+        ensure_boot_not_terminated
         __install_visibility_hook
         nil
+      end
+
+      # __boot_steps suspends at the election and at every storage
+      # await: an epoch mismatch detected by a response landing in one
+      # of those windows (docs decision 13) had nothing to tear down
+      # yet, so every suspension re-checks and aborts the boot through
+      # the ordinary failure funnel.
+      private def ensure_boot_not_terminated
+        return nil unless session_terminated?
+        raise Error,
+          "the session changed during boot; this page is terminal " \
+          "(reload to continue)"
       end
 
       private def metadata_value(metadata, key, default)
@@ -2379,14 +2546,20 @@ module Funicular
       end
 
       private def __install_handles(local_db, replica_db)
-        read_only = durability == :persistent_reader
+        # Defense in depth for decision 13: the boot aborts on a
+        # mid-boot termination before ever landing here, but if it DID
+        # land here terminal, the handles must come up as the
+        # non-persistent read view, never writable.
+        terminated = session_terminated?
+        read_only = durability == :persistent_reader || terminated
         # Belt (the proxy refuses at every execution entry) and braces
         # (SQLite itself refuses): docs decision 15. The replica handle
         # stays memory-writable even on a reader -- fetch-through
         # revalidation works there.
         local_db.execute("PRAGMA query_only = ON") if read_only
         @local_handle = GuardedDatabase.new(local_db, :local, read_only)
-        @replica_handle = GuardedDatabase.new(replica_db, :replica, false)
+        @replica_handle = GuardedDatabase.new(replica_db, :replica,
+                                              terminated)
         nil
       end
     end
@@ -2465,6 +2638,9 @@ module Funicular
     # per-table nuance, so the lockdown lifts only when every table
     # passes again.
     def self.reset_local_table(model)
+      # The terminal latch first: on a terminated volatile page the
+      # durability check below would still let this raw path through.
+      ensure_session_not_terminated(:reset_local)
       # Same :ready gate as the handles: this path reaches the RAW
       # database, so hiding the proxies alone would not keep a
       # mid-boot (or failed-boot) rebuild out.
@@ -2538,7 +2714,12 @@ module Funicular
       @replica_handle = nil
       @schema_lockdown = nil
       @session_epoch = nil
+      @page_epoch_latched = false
+      @session_terminated = false
       @databases = nil
+      # A put still in flight from the torn-down state must not make
+      # the next terminal step-down wait on it.
+      @persist_inflight = 0
       cancel_persist_timers
       __set_snapshot_store(nil)
       __set_snapshot_identity(nil)

--- a/mrblib/db.rb
+++ b/mrblib/db.rb
@@ -348,6 +348,18 @@ module Funicular
     # migration version per table (and, later, the replica fingerprint).
     META_TABLE = "funicular_meta"
 
+    # The metadata table belongs to the framework: no model -- local or
+    # replica -- may claim its name (SQLite table names are
+    # case-insensitive, so the check is too).
+    def self.guard_reserved_table(table)
+      if table.downcase == META_TABLE
+        raise ArgumentError,
+          "\"#{table}\" is reserved for framework metadata; pick " \
+          "another table_name"
+      end
+      table
+    end
+
     # SQL identifiers this layer interpolates (table and column names) must
     # be plain: ASCII letter or underscore first, then letters, digits,
     # underscores. Returns the name as a String.
@@ -431,7 +443,7 @@ module Funicular
       # them -- a broken declaration fails the same way everywhere.
       builders = collect_builders(model)
       fold_builders(builders, migrations, model)
-      table = validate_identifier(model.table_name)
+      table = guard_reserved_table(validate_identifier(model.table_name))
       baseline = migrations[baseline_index(migrations)][:version]
       max = migrations[migrations.size - 1][:version]
       stored = stored_table_version(db, table)
@@ -477,7 +489,7 @@ module Funicular
         builders = collect_builders(model)
         fold_builders(builders, migrations, model)
       end
-      table = validate_identifier(model.table_name)
+      table = guard_reserved_table(validate_identifier(model.table_name))
       max = migrations[migrations.size - 1][:version]
       db.transaction do
         db.execute("DROP TABLE IF EXISTS \"#{table}\"")
@@ -488,18 +500,27 @@ module Funicular
     end
 
     def self.stored_table_version(db, table)
-      ensure_meta_table(db)
-      rows = db.execute("SELECT value FROM \"#{META_TABLE}\" WHERE key = ?",
-                        ["table_version:#{table}"])
-      row = rows[0]
-      return 0 unless row
-      (row.is_a?(Hash) ? row.values[0] : row[0]).to_i
+      value = read_meta(db, "table_version:#{table}")
+      value ? value.to_i : 0
     end
 
     def self.store_table_version(db, table, version)
+      store_meta(db, "table_version:#{table}", version.to_s)
+    end
+
+    def self.read_meta(db, key)
+      ensure_meta_table(db)
+      rows = db.execute("SELECT value FROM \"#{META_TABLE}\" WHERE key = ?",
+                        [key])
+      row = rows[0]
+      return nil unless row
+      row.is_a?(Hash) ? row.values[0] : row[0]
+    end
+
+    def self.store_meta(db, key, value)
       ensure_meta_table(db)
       db.execute("INSERT OR REPLACE INTO \"#{META_TABLE}\" (key, value) " \
-                 "VALUES (?, ?)", ["table_version:#{table}", version.to_s])
+                 "VALUES (?, ?)", [key, value])
     end
 
     def self.ensure_meta_table(db)
@@ -715,6 +736,228 @@ module Funicular
 
     def self.index_name(table, columns)
       "index_#{table}_on_#{columns.join("_")}"
+    end
+
+    # ---- replica tables: schema-derived DDL + fingerprint ---------------
+    #
+    # Replica tables mirror server data; their shape is DERIVED from the
+    # server-delivered schema (docs decision 6), never migrated by hand.
+    # The fingerprint is the canonical schema JSON itself, stored in the
+    # meta table and compared by string equality.
+
+    REPLICA_FINGERPRINT_KEY = "replica_fingerprint"
+
+    # CREATE TABLE for one replica model. The id column type follows the
+    # server (:integer -> INTEGER, anything else -> TEXT for UUIDs); a
+    # schema without an id cannot be mirrored by row identity.
+    def self.replica_table_ddl(model)
+      columns = model.local_columns
+      id_type = columns["id"]
+      unless id_type
+        raise ArgumentError,
+          "#{model.table_name}: the server schema has no id attribute; " \
+          "rows cannot be mirrored -- declare storage :ephemeral"
+      end
+      table = validate_identifier(model.table_name)
+      # @type var defs: Array[String]
+      defs = ["\"id\" #{id_type == :integer ? "INTEGER" : "TEXT"} PRIMARY KEY"]
+      names = columns.keys
+      names_size = names.size
+      i = 0
+      while i < names_size
+        name = names[i]
+        unless name == "id"
+          defs << "\"#{validate_identifier(name)}\" " \
+                  "#{SQL_TYPES[columns[name]] || "TEXT"}"
+        end
+        i += 1
+      end
+      "CREATE TABLE \"#{table}\" (#{defs.join(", ")})"
+    end
+
+    # The canonical schema JSON: only DDL-affecting data (table names,
+    # column names and types, the id type), tables and columns sorted by
+    # name so hash ordering never leaks in. This string IS the
+    # fingerprint -- no digest (docs decision 6).
+    def self.canonical_replica_schema(models)
+      # @type var tables: Array[untyped]
+      tables = []
+      models_size = models.size
+      i = 0
+      while i < models_size
+        model = models[i]
+        columns = model.local_columns
+        names = columns.keys.sort
+        # @type var cols: Array[untyped]
+        cols = []
+        names_size = names.size
+        j = 0
+        while j < names_size
+          cols << [names[j], columns[names[j]].to_s]
+          j += 1
+        end
+        tables << [model.table_name, cols]
+        i += 1
+      end
+      # Plain array comparison: entries are [table_name, columns], so the
+      # sort is deterministic down to the column definitions without a
+      # comparator block.
+      tables.sort!
+      JSON.generate(["v1", tables])
+    end
+
+    # Bring the replica database to the declared schema. A matching
+    # fingerprint keeps every table and its data; a mismatch (or a fresh
+    # database) drops and recreates ALL replica tables EMPTY -- they
+    # refill on the app's next explicit fetch -- and stores the new
+    # fingerprint. One transaction. Returns true when tables were
+    # (re)built.
+    # The replica lives in its own database -- storage :local tables are
+    # in the OTHER database and can legitimately share names with
+    # replica tables (that is why notify_changed takes a database role).
+    # Only the framework's meta table needs shielding here.
+    def self.build_replica_tables(db, models)
+      # Duplicate checks compare ASCII-lowercased keys: SQLite table
+      # names are case-insensitive even when quoted. SQL statements keep
+      # the original validated spelling (the hash VALUES).
+      # @type var tables: Hash[String, String]
+      tables = {}
+      models_size = models.size
+      i = 0
+      while i < models_size
+        name = guard_reserved_table(validate_identifier(models[i].table_name))
+        key = name.downcase
+        if tables.has_key?(key)
+          raise ArgumentError,
+            "two replica models declare the table \"#{name}\" " \
+            "(SQLite table names are case-insensitive); give one of " \
+            "them another table_name"
+        end
+        tables[key] = name
+        i += 1
+      end
+      fingerprint = canonical_replica_schema(models)
+      stored = read_meta(db, REPLICA_FINGERPRINT_KEY)
+      return false if stored == fingerprint
+      # Drop the UNION of old and new table names: a model REMOVED from
+      # the declared set must not leave its stale table (and data)
+      # behind. The old names come from the stored fingerprint itself --
+      # it IS the canonical schema JSON.
+      old_names = stale_replica_tables(stored)
+      old_size = old_names.size
+      i = 0
+      while i < old_size
+        begin
+          # @type var old_name: String
+          old_name = validate_identifier(old_names[i])
+          # @type var old_key: String
+          old_key = old_name.downcase
+          unless old_key == META_TABLE || tables.has_key?(old_key)
+            tables[old_key] = old_name
+          end
+        rescue ArgumentError
+          # A corrupted meta row must not smuggle SQL into DROP TABLE.
+        end
+        i += 1
+      end
+      db.transaction do
+        keys = tables.keys
+        keys_size = keys.size
+        i = 0
+        while i < keys_size
+          db.execute("DROP TABLE IF EXISTS \"#{tables[keys[i]]}\"")
+          i += 1
+        end
+        i = 0
+        while i < models_size
+          db.execute(replica_table_ddl(models[i]))
+          i += 1
+        end
+        store_meta(db, REPLICA_FINGERPRINT_KEY, fingerprint)
+      end
+      true
+    end
+
+    # The table names recorded in a stored canonical fingerprint; empty
+    # when absent or unparsable (fail-safe: nothing extra to drop).
+    def self.stale_replica_tables(stored)
+      # @type var names: Array[String]
+      names = []
+      return names unless stored
+      begin
+        parsed = JSON.parse(stored)
+      rescue
+        return names
+      end
+      return names unless parsed.is_a?(Array)
+      list = parsed[1]
+      return names unless list.is_a?(Array)
+      list_size = list.size
+      i = 0
+      while i < list_size
+        entry = list[i]
+        names << entry[0].to_s if entry.is_a?(Array)
+        i += 1
+      end
+      names
+    end
+
+    # Apply one server-authoritative row: THE single write-through entry
+    # point (docs decision 5) -- fetch-through, create/update responses,
+    # and future Cable sync all land here. Whole-row INSERT OR REPLACE
+    # through the codec; keys absent from attrs store NULL (the server
+    # row is authoritative, there is no partial merge). Fires the
+    # model's change hook.
+    def self.replica_upsert(db, model, attrs)
+      columns = model.local_columns
+      table = validate_identifier(model.table_name)
+      names = columns.keys
+      # @type var cols: Array[String]
+      cols = []
+      # @type var marks: Array[String]
+      marks = []
+      # @type var binds: Array[untyped]
+      binds = []
+      id_present = false
+      names_size = names.size
+      i = 0
+      while i < names_size
+        name = names[i]
+        if attrs.has_key?(name)
+          value = attrs[name]
+        elsif attrs.has_key?(name.to_sym)
+          value = attrs[name.to_sym]
+        else
+          value = nil
+        end
+        id_present = true if name == "id" && !value.nil?
+        cols << "\"#{name}\""
+        marks << "?"
+        binds << Codec.encode(columns[name], value)
+        i += 1
+      end
+      unless id_present
+        raise ArgumentError,
+          "replica upsert into #{model.table_name} requires an id; " \
+          "the server row has none"
+      end
+      db.execute("INSERT OR REPLACE INTO \"#{table}\" " \
+                 "(#{cols.join(", ")}) VALUES (#{marks.join(", ")})", binds)
+      model.local_table_changed
+      true
+    end
+
+    # Remove one mirrored row (write-through destroy). Notifies only
+    # when the row existed; RETURNING keeps the check inside the one
+    # statement (no changes() race).
+    def self.replica_delete(db, model, id)
+      table = validate_identifier(model.table_name)
+      rows = db.execute(
+        "DELETE FROM \"#{table}\" WHERE \"id\" = ? RETURNING \"id\"",
+        [Codec.encode(model.local_columns["id"], id)])
+      deleted = !rows.empty?
+      model.local_table_changed if deleted
+      deleted
     end
 
     def self.quoted_list(columns)

--- a/mrblib/db.rb
+++ b/mrblib/db.rb
@@ -1012,11 +1012,16 @@ module Funicular
     # via Statement#readonly? -- a statement prepared while writable is
     # still refused once the handle went read-only.
 
+    TRANSACTION_CONTROL_WORDS = [
+      "begin", "commit", "end", "rollback", "savepoint", "release"
+    ].freeze
+
     # Statements that subvert framework control are rejected in every
-    # state: ATTACH/DETACH escape to other database files, and
-    # PRAGMA query_only would lift (or fake) the read-only lockdown.
-    # sqlite3_stmt_readonly classifies all three as read-only, so the
-    # statement-level check alone would let them through.
+    # state: ATTACH/DETACH escape to other database files, PRAGMA
+    # query_only would lift (or fake) the read-only lockdown, and
+    # transaction control would move the boundary the deferral hangs
+    # off. sqlite3_stmt_readonly classifies all of them as read-only,
+    # so the statement-level check alone would let them through.
     def self.guard_statement_sql(sql)
       s = sql.to_s
       i = skip_sql_blanks(s, 0)
@@ -1034,6 +1039,21 @@ module Funicular
         raise ArgumentError,
           "PRAGMA query_only is managed by the framework and cannot be " \
           "issued through the guarded database handle"
+      end
+      # Transaction control belongs to the handle's own transaction /
+      # commit / rollback, which pair every boundary with the event and
+      # persistence deferral (docs decisions 10/11). Issued as raw SQL
+      # the deferral is simply skipped: an execute("BEGIN") lets change
+      # events reach watchers before the commit, and an
+      # execute("ROLLBACK") neither discards the events an open
+      # deferral parked nor resumes the snapshot it postponed. END is
+      # SQLite's synonym for COMMIT, and the savepoint verbs open and
+      # close nested boundaries the same bookkeeping would miss.
+      if TRANSACTION_CONTROL_WORDS.include?(word)
+        raise ArgumentError,
+          "transaction control (#{word.upcase}) is managed by the " \
+          "framework; use the guarded handle's #transaction, #commit " \
+          "and #rollback so change events and snapshots settle with it"
       end
     end
 
@@ -1340,7 +1360,7 @@ module Funicular
         else
           raise ArgumentError, "invalid transaction mode #{mode.inspect}"
         end
-        execute("BEGIN #{mode_sql} TRANSACTION")
+        __execute_control("BEGIN #{mode_sql} TRANSACTION")
         # Deferral starts with the transaction ITSELF, block or not:
         # change events raised before COMMIT coalesce and fire only
         # after it -- or vanish with the rollback (docs decision 10).
@@ -1363,15 +1383,30 @@ module Funicular
       end
 
       def commit
-        execute("COMMIT TRANSACTION")
+        __execute_control("COMMIT TRANSACTION")
         DB.__commit_deferral(@role)
         true
       end
 
       def rollback
-        execute("ROLLBACK TRANSACTION")
+        __execute_control("ROLLBACK TRANSACTION")
         DB.__rollback_deferral(@role)
         true
+      end
+
+      # The framework's own transaction boundaries: the same guarded
+      # statement path #execute uses (read-only enforcement included),
+      # minus the guard that refuses these very statements to callers.
+      # Everything that moves a boundary funnels through here, so the
+      # deferral hooks above it always run.
+      private def __execute_control(sql)
+        stmt = GuardedStatement.new(@db.prepare(sql), self)
+        begin
+          stmt.execute
+        ensure
+          stmt.close unless stmt.closed?
+        end
+        nil
       end
     end
 

--- a/mrblib/db.rb
+++ b/mrblib/db.rb
@@ -742,6 +742,213 @@ module Funicular
       "index_#{table}_on_#{columns.join("_")}"
     end
 
+    # ---- change-event bus (docs decision 10) ----------------------------
+    #
+    # Framework writes announce themselves per [database role, table];
+    # watch and Model.on_change ride these events. They fire POST-COMMIT
+    # only: inside a guarded transaction block they coalesce (one event
+    # per [role, table]) and flush after COMMIT -- or vanish with the
+    # rollback. Delivery drains a queue iteratively, so an event raised
+    # BY a subscriber never nests delivery inside delivery, and a
+    # raising subscriber is isolated from the rest.
+
+    def self.subscribe(role, table, &handler)
+      unless handler
+        raise ArgumentError, "subscribe requires a block"
+      end
+      validate_role(role)
+      subs = (@subscriptions ||= {}) # steep:ignore UnannotatedEmptyCollection
+      serial = (@subscription_serial || 0) + 1
+      @subscription_serial = serial
+      subs[serial] = [role, table.to_s, handler]
+      serial
+    end
+
+    def self.unsubscribe(id)
+      subs = @subscriptions
+      subs.delete(id) if subs
+      nil
+    end
+
+    # The raw-SQL protocol (docs, "Querying"): after writing through a
+    # guarded handle yourself, tell the framework. Preferred form is the
+    # model class -- it knows both its database role and its table; the
+    # explicit (role, table) pair exists because a bare table name would
+    # be ambiguous between the two databases.
+    def self.notify_changed(target, table = nil)
+      if table.nil?
+        model = target
+        if model.ephemeral?
+          raise NoTableError,
+            "#{model.to_s} is storage :ephemeral; there is no table to " \
+            "notify about"
+        end
+        return notify_changed(model.local? ? :local : :replica,
+                              model.table_name)
+      end
+      role = validate_role(target)
+      name = table.to_s
+      # Defer only under an open transaction on the SAME database: local
+      # and replica are separate SQLite databases with independent
+      # transactions, so their pending events never mix.
+      if 0 < deferral_depth(role)
+        seen = pending_seen(role)
+        key = "#{role}:#{name}"
+        unless seen.has_key?(key)
+          seen[key] = true
+          pending_order(role) << [role, name]
+        end
+      else
+        enqueue_delivery(role, name)
+      end
+      nil
+    end
+
+    def self.validate_role(role)
+      return role if role == :local
+      return role if role == :replica
+      raise ArgumentError,
+        "role must be :local or :replica, got #{role.inspect}"
+    end
+
+    def self.deferral_depth(role)
+      depths = @deferral_depths
+      value = depths ? depths[role] : nil
+      value || 0
+    end
+
+    def self.pending_seen(role)
+      all = (@pending_seen ||= {}) # steep:ignore UnannotatedEmptyCollection
+      all[role] ||= {}
+    end
+
+    def self.pending_order(role)
+      all = (@pending_orders ||= {}) # steep:ignore UnannotatedEmptyCollection
+      all[role] ||= []
+    end
+
+    # Transaction hooks (GuardedDatabase), tracked PER ROLE: the local
+    # and replica databases transact independently. Only the outermost
+    # commit of a role flushes its pending events; a rollback at depth
+    # zero discards them.
+    def self.__begin_deferral(role)
+      depths = (@deferral_depths ||= {}) # steep:ignore UnannotatedEmptyCollection
+      depths[role] = deferral_depth(role) + 1
+    end
+
+    def self.__commit_deferral(role)
+      depths = (@deferral_depths ||= {}) # steep:ignore UnannotatedEmptyCollection
+      depth = deferral_depth(role)
+      depths[role] = depth - 1 if 0 < depth
+      return unless deferral_depth(role) == 0
+      order = pending_order(role)
+      clear_pending(role)
+      order_size = order.size
+      i = 0
+      while i < order_size
+        event = order[i]
+        enqueue_delivery(event[0], event[1])
+        i += 1
+      end
+    end
+
+    def self.__rollback_deferral(role)
+      depths = (@deferral_depths ||= {}) # steep:ignore UnannotatedEmptyCollection
+      depth = deferral_depth(role)
+      depths[role] = depth - 1 if 0 < depth
+      clear_pending(role) if deferral_depth(role) == 0
+    end
+
+    def self.clear_pending(role)
+      seen_all = @pending_seen
+      seen_all.delete(role) if seen_all
+      order_all = @pending_orders
+      order_all.delete(role) if order_all
+      nil
+    end
+
+    # Delivery belongs to the NEXT tick (docs decision 10): a write that
+    # happens during a component update must never patch watchers
+    # synchronously into that update. Until the scheduled drain runs,
+    # events collapse per [role, table]; the first event of a tick
+    # schedules exactly one drain.
+    def self.enqueue_delivery(role, table)
+      pending = (@tick_events ||= {}) # steep:ignore UnannotatedEmptyCollection
+      key = "#{role}:#{table}"
+      unless pending.has_key?(key)
+        pending[key] = true
+        order = (@tick_order ||= []) # steep:ignore UnannotatedEmptyCollection
+        order << [role, table]
+      end
+      return nil if @drain_scheduled
+      @drain_scheduled = true
+      schedule_drain
+      nil
+    end
+
+    # Boot/tests may install their own scheduler (it must eventually
+    # call __drain_events once). The default rides JS setTimeout(0); on
+    # CRuby (SSR, native tests) there is no JS event loop AND no
+    # component can be mid-update, so draining immediately is safe.
+    def self.__set_tick_scheduler(scheduler)
+      @tick_scheduler = scheduler
+    end
+
+    def self.schedule_drain
+      scheduler = @tick_scheduler
+      if scheduler
+        scheduler.call
+      elsif Object.const_defined?(:JS)
+        JS.global.setTimeout(0) do
+          __drain_events
+        end
+      else
+        __drain_events
+      end
+      nil
+    end
+
+    def self.__drain_events
+      # Un-schedule FIRST: events raised by the subscribers below belong
+      # to the next tick and must get a drain of their own.
+      @drain_scheduled = false
+      order = @tick_order
+      @tick_order = []
+      @tick_events = {}
+      return nil unless order
+      order_size = order.size
+      i = 0
+      while i < order_size
+        event = order[i]
+        deliver_event(event[0], event[1])
+        i += 1
+      end
+      nil
+    end
+
+    def self.deliver_event(role, table)
+      subs = @subscriptions
+      return unless subs
+      # Snapshot the ids: a handler may (un)subscribe during delivery.
+      ids = subs.keys
+      ids_size = ids.size
+      i = 0
+      while i < ids_size
+        entry = subs[ids[i]]
+        if entry && entry[0] == role && entry[1] == table
+          begin
+            entry[2].call(role, table)
+          rescue => e
+            # Subscriber isolation: one broken watcher must not starve
+            # the others (docs decision 10).
+            puts "[Funicular] change subscriber raised: " \
+                 "#{e.class}: #{e.message}"
+          end
+        end
+        i += 1
+      end
+    end
+
     # ---- guarded database handles (docs decision 15) --------------------
     #
     # Funicular::DB.local/.replica hand out these proxies, never raw
@@ -991,9 +1198,16 @@ module Funicular
     end
 
     class GuardedDatabase
-      def initialize(db, read_only = false)
+      def initialize(db, role = :local, read_only = false)
         @db = db
+        @role = DB.validate_role(role)
         @read_only = read_only
+      end
+
+      # Which database this handle fronts (:local or :replica); event
+      # deferral is tracked per role.
+      def role
+        @role
       end
 
       def read_only?
@@ -1072,6 +1286,13 @@ module Funicular
           raise ArgumentError, "invalid transaction mode #{mode.inspect}"
         end
         execute("BEGIN #{mode_sql} TRANSACTION")
+        # Deferral starts with the transaction ITSELF, block or not:
+        # change events raised before COMMIT coalesce and fire only
+        # after it -- or vanish with the rollback (docs decision 10).
+        # commit/rollback below settle it, so the raw blockless form
+        # (transaction / execute / notify_changed / rollback) honors the
+        # same contract.
+        DB.__begin_deferral(@role)
         return true unless block_given?
         aborting = false
         begin
@@ -1088,11 +1309,13 @@ module Funicular
 
       def commit
         execute("COMMIT TRANSACTION")
+        DB.__commit_deferral(@role)
         true
       end
 
       def rollback
         execute("ROLLBACK TRANSACTION")
+        DB.__rollback_deferral(@role)
         true
       end
     end

--- a/mrblib/db.rb
+++ b/mrblib/db.rb
@@ -931,6 +931,14 @@ module Funicular
       nil
     end
 
+    # Bumped by clear_tick_events: deliveries carrying an older
+    # generation are stale and stop, even MID-DRAIN -- a wipe called
+    # from inside a subscriber must silence the rest of the drain,
+    # which holds its events in a local the buffer clear cannot reach.
+    def self.tick_generation
+      @tick_generation || 0
+    end
+
     def self.__drain_events
       # Un-schedule FIRST: events raised by the subscribers below belong
       # to the next tick and must get a drain of their own.
@@ -939,17 +947,19 @@ module Funicular
       @tick_order = []
       @tick_events = {}
       return nil unless order
+      generation = tick_generation
       order_size = order.size
       i = 0
       while i < order_size
+        break unless tick_generation == generation
         event = order[i]
-        deliver_event(event[0], event[1])
+        deliver_event(event[0], event[1], generation)
         i += 1
       end
       nil
     end
 
-    def self.deliver_event(role, table)
+    def self.deliver_event(role, table, generation = nil)
       subs = @subscriptions
       return unless subs
       # Snapshot the ids: a handler may (un)subscribe during delivery.
@@ -957,6 +967,10 @@ module Funicular
       ids_size = ids.size
       i = 0
       while i < ids_size
+        # An earlier subscriber of this very event may have staled the
+        # delivery (wipe): the remaining subscribers hear only from the
+        # wipe's own notification.
+        break if generation && !(tick_generation == generation)
         entry = subs[ids[i]]
         if entry && entry[0] == role && entry[1] == table
           begin
@@ -1958,6 +1972,174 @@ module Funicular
       else
         :unsupported
       end
+    end
+
+    # ---- wipe (docs decision 17) ----------------------------------------
+    #
+    # The everything-nuke for logout and for discarding a corrupt local
+    # snapshot: both databases of the CURRENT namespace dropped and
+    # rebuilt empty, both snapshot keys deleted. Namespacing already
+    # isolates users by construction, so this is a cleanup tool, not a
+    # security requirement -- but it must be safe to call mid-flight.
+
+    # In-flight work issued before a wipe must be discarded, never
+    # applied: REST verbs capture the generation at issue time and
+    # check it at response time, and persist_snapshot re-checks it
+    # before the store put.
+    def self.stale_generation?(token)
+      !(token == mutation_generation)
+    end
+
+    def self.stale_response_error
+      Error.new(
+        "the local data was wiped while this request was in flight; " \
+        "the response was discarded")
+    end
+
+    # Writer-only like every destructive operation (ReadOnlyTabError on
+    # a persistent_reader); volatile is fine too -- the only tab, all
+    # memory, no snapshots to delete.
+    def self.wipe
+      state = durability
+      if state == :persistent_reader
+        raise ReadOnlyTabError,
+          "wipe requires the writer tab " \
+          "(this tab is a persistent_reader)"
+      end
+      unless state == :persistent_writer || state == :volatile
+        raise Error, "wipe requires a booted page (this tab is #{state})"
+      end
+      # A wipe is all-or-nothing. With a transaction open on either
+      # database the rebuild below would nest its transactions -- or be
+      # swallowed into the caller's and resurrected by its ROLLBACK --
+      # so refuse BEFORE any side effect: generation, snapshots, and
+      # tables stay untouched.
+      #
+      # ORDERING INVARIANT: from this check to the end of the rebuild,
+      # this Task never suspends -- everything in between is
+      # synchronous SQLite/C (timer and drain REGISTRATION included),
+      # so no other Task can slip a new transaction in behind the
+      # check. The snapshot deletes, the only awaiting operations,
+      # follow the rebuild, and the notifications come after THOSE.
+      ensure_not_in_transaction(:local)
+      ensure_not_in_transaction(:replica)
+      # 1. Advance the generation FIRST: from here on, in-flight REST
+      #    responses and already-captured snapshot images are stale.
+      @mutation_generation = mutation_generation + 1
+      # 2. No armed or parked persist survives (queued timer callbacks
+      #    go stale with their tokens), and change events queued BEFORE
+      #    the wipe are discarded: an already-scheduled drain would
+      #    deliver them during the snapshot deletes below, letting a
+      #    watcher observe the wiped tables before -- or without -- the
+      #    deletes succeeding. The wipe's own notifications (step 5)
+      #    are the only events that may tell of it.
+      cancel_persist_timers
+      clear_tick_events
+      # 3. Drop + rebuild both databases.
+      wipe_role(:local)
+      wipe_role(:replica)
+      # 4. Delete the snapshots. Running after the rebuild is safe: the
+      #    generation bump already made every pre-wipe image stale, and
+      #    a put issued before the wipe is overwritten by these deletes
+      #    (IndexedDB runs same-store readwrite transactions in issue
+      #    order). Nothing races them from our side either -- no
+      #    post-wipe persist is armed until the notifications below.
+      store = @snapshot_store
+      identity = @snapshot_identity
+      if store && identity
+        store.delete(snapshot_key(identity, :local))
+        store.delete(snapshot_key(identity, :replica))
+      end
+      # 5. Notify LAST -- the databases are queryable and the old
+      #    snapshots are really gone. A failing delete raises out of
+      #    wipe with no watcher told and no fresh persist armed:
+      #    components must never render a "wiped" state whose old
+      #    snapshot could still resurrect on reload.
+      notify_wiped(:local)
+      notify_wiped(:replica)
+      true
+    end
+
+    # Empty the next-tick delivery buffer AND stale a drain that is
+    # already running (it holds its events in a local; the generation
+    # bump is what reaches it). A drain merely scheduled stays
+    # scheduled and no-ops; the next enqueue schedules a fresh one.
+    def self.clear_tick_events
+      @tick_generation = tick_generation + 1
+      @tick_order = []
+      @tick_events = {}
+      nil
+    end
+
+    def self.ensure_not_in_transaction(role)
+      db = __registered_database(role)
+      return nil unless db
+      if db.transaction_active?
+        raise Error,
+          "cannot wipe: the #{role} database has an open transaction; " \
+          "settle it (commit or rollback) first"
+      end
+      nil
+    end
+
+    def self.wipe_role(role)
+      registry = @databases
+      entry = registry ? registry[role] : nil
+      return nil unless entry
+      db = entry[0]
+      return nil unless db
+      models = entry[1]
+      drop_all_tables(db)
+      models_size = models.size
+      if role == :local
+        i = 0
+        while i < models_size
+          # The meta table is gone, so every table reads as version 0
+          # and rebuilds from its baseline.
+          apply_local_migrations(db, models[i])
+          i += 1
+        end
+      else
+        # The stored fingerprint is gone too: the fresh-boot path
+        # recreates the declared tables and stores it again.
+        build_replica_tables(db, models)
+      end
+      nil
+    end
+
+    # One change event per wiped table, sent only from wipe's step 5 --
+    # strictly after the rebuild AND the snapshot deletes.
+    def self.notify_wiped(role)
+      registry = @databases
+      entry = registry ? registry[role] : nil
+      return nil unless entry
+      return nil unless entry[0]
+      models = entry[1]
+      models_size = models.size
+      i = 0
+      while i < models_size
+        notify_changed(role, models[i].table_name)
+        i += 1
+      end
+      nil
+    end
+
+    def self.drop_all_tables(db)
+      rows = db.execute(
+        "SELECT name FROM sqlite_master WHERE type = 'table' " \
+        "AND name NOT LIKE 'sqlite_%'")
+      rows_size = rows.size
+      i = 0
+      while i < rows_size
+        row = rows[i]
+        name = row.is_a?(Hash) ? row.values[0] : row[0]
+        # Unlike model-declared names, this comes from sqlite_master and
+        # may be any legal SQLite identifier. Double embedded quotes.
+        quoted_name = name.to_s.gsub('"', '""')
+        db.execute("DROP TABLE IF EXISTS \"#{quoted_name}\"")
+        i += 1
+      end
+      nil
     end
 
     # ---- replica tables: schema-derived DDL + fingerprint ---------------

--- a/mrblib/db.rb
+++ b/mrblib/db.rb
@@ -417,6 +417,12 @@ module Funicular
         raise ArgumentError,
           "#{model} has no migrate blocks (is it storage :local?)"
       end
+      # Validate the whole retained chain before any SQL runs: the fold
+      # catches errors SQLite itself would accept as plain DDL (renaming
+      # or removing the implicit id, most notably). Fold errors are
+      # ArgumentError, so the development auto-reset below never eats
+      # them -- a broken declaration fails the same way everywhere.
+      fold_local_columns(model)
       table = validate_identifier(model.table_name)
       baseline = migrations[baseline_index(migrations)][:version]
       max = migrations[migrations.size - 1][:version]
@@ -456,6 +462,9 @@ module Funicular
         raise ArgumentError,
           "#{model} has no migrate blocks (is it storage :local?)"
       end
+      # Same before-any-SQL fold validation as apply_local_migrations:
+      # rebuild is also entered directly (dev auto-reset, reset_local).
+      fold_local_columns(model)
       table = validate_identifier(model.table_name)
       max = migrations[migrations.size - 1][:version]
       db.transaction do

--- a/mrblib/db.rb
+++ b/mrblib/db.rb
@@ -390,10 +390,15 @@ module Funicular
     # usable before boot. Folding starts at the baseline, so a reset block
     # may redefine columns that also appear in the superseded history.
     def self.fold_local_columns(model)
+      fold_builders(collect_builders(model), model.local_migrations, model)
+    end
+
+    # The fold over ALREADY-collected builders: the migration runner
+    # evaluates each migrate block exactly once per run and feeds the same
+    # recorded operations to this validation and to the DDL.
+    def self.fold_builders(builders, migrations, model)
       # @type var columns: Hash[String, Symbol]
       columns = { "id" => :integer }
-      builders = collect_builders(model)
-      migrations = model.local_migrations
       i = migrations ? baseline_index(migrations) : 0
       while i < builders.size
         fold_ops(columns, builders[i].ops, model)
@@ -417,12 +422,15 @@ module Funicular
         raise ArgumentError,
           "#{model} has no migrate blocks (is it storage :local?)"
       end
-      # Validate the whole retained chain before any SQL runs: the fold
-      # catches errors SQLite itself would accept as plain DDL (renaming
-      # or removing the implicit id, most notably). Fold errors are
+      # Evaluate every migrate block exactly ONCE for this run, then
+      # validate the retained chain before any SQL: the fold catches
+      # errors SQLite itself would accept as plain DDL (renaming or
+      # removing the implicit id, most notably), and the very same
+      # recorded operations feed the DDL below. Fold errors are
       # ArgumentError, so the development auto-reset below never eats
       # them -- a broken declaration fails the same way everywhere.
-      fold_local_columns(model)
+      builders = collect_builders(model)
+      fold_builders(builders, migrations, model)
       table = validate_identifier(model.table_name)
       baseline = migrations[baseline_index(migrations)][:version]
       max = migrations[migrations.size - 1][:version]
@@ -435,11 +443,11 @@ module Funicular
       end
       return max if stored == max
       if stored < baseline
-        rebuild_local_table(db, model)
+        rebuild_local_table(db, model, builders)
       else
         begin
           db.transaction do
-            apply_blocks(db, model, stored)
+            apply_blocks(db, model, stored, builders)
             store_table_version(db, table, max)
           end
         rescue SQLite3::Exception => e
@@ -447,7 +455,7 @@ module Funicular
           # mruby VM (it raises a fresh empty RuntimeError).
           raise e unless Funicular.env.development?
           # Dev auto-reset: a dirty development table beats hand-repair.
-          rebuild_local_table(db, model)
+          rebuild_local_table(db, model, builders)
         end
       end
       max
@@ -456,20 +464,24 @@ module Funicular
     # Drop and rebuild from the baseline, in one transaction: the fresh
     # path, the below-baseline path, reset_local, and the dev auto-reset
     # all land here. Returns the resulting version.
-    def self.rebuild_local_table(db, model)
+    def self.rebuild_local_table(db, model, builders = nil)
       migrations = model.local_migrations
       unless migrations
         raise ArgumentError,
           "#{model} has no migrate blocks (is it storage :local?)"
       end
-      # Same before-any-SQL fold validation as apply_local_migrations:
-      # rebuild is also entered directly (dev auto-reset, reset_local).
-      fold_local_columns(model)
+      # When entered directly (reset_local; apply passes its builders in)
+      # evaluate the blocks once and validate before any SQL, exactly
+      # like apply_local_migrations.
+      unless builders
+        builders = collect_builders(model)
+        fold_builders(builders, migrations, model)
+      end
       table = validate_identifier(model.table_name)
       max = migrations[migrations.size - 1][:version]
       db.transaction do
         db.execute("DROP TABLE IF EXISTS \"#{table}\"")
-        apply_blocks(db, model, 0)
+        apply_blocks(db, model, 0, builders)
         store_table_version(db, table, max)
       end
       max
@@ -496,7 +508,9 @@ module Funicular
     end
 
     # Run every migrate block against a fresh TableBuilder, returning the
-    # recorded operations in declaration order.
+    # recorded operations in declaration order. The runner calls this
+    # exactly once per migration run; local_columns is the only other
+    # caller. Blocks should stay deterministic and side-effect free.
     def self.collect_builders(model)
       migrations = model.local_migrations
       unless migrations
@@ -568,12 +582,12 @@ module Funicular
     end
 
     # Apply every block at or after the baseline with version >
-    # from_version (pre-baseline history is never applied). The first
+    # from_version (pre-baseline history is never applied), using the
+    # builders the caller already collected and validated. The first
     # block applied onto a dropped/absent table runs in create mode (its
     # column ops become the CREATE TABLE); everything later alters.
-    def self.apply_blocks(db, model, from_version)
+    def self.apply_blocks(db, model, from_version, builders)
       migrations = model.local_migrations
-      builders = collect_builders(model)
       table = validate_identifier(model.table_name)
       i = baseline_index(migrations)
       creating = from_version < migrations[i][:version]

--- a/mrblib/db.rb
+++ b/mrblib/db.rb
@@ -1320,6 +1320,141 @@ module Funicular
       end
     end
 
+    # ---- writer election (docs decision 14) -----------------------------
+    #
+    # One tab per namespace persists. The election runs ONCE at boot
+    # with Web Locks' ifAvailable: granted makes this tab the
+    # persistent_writer (the lock is held by a promise resolved only at
+    # release), not granted makes it a persistent_reader for the LIFE of
+    # the page -- no promotion in v1, reload to write. No Web Locks API
+    # at all (or an API failure) means volatile: everything works,
+    # nothing persists.
+
+    # The JS side, installed once via eval. Tests (and exotic hosts) may
+    # inject their own Locks API as globalThis.__funicularLocksApi; the
+    # real navigator.locks is the fallback.
+    LOCK_SHIM_JS = <<~'FUNICULAR_LOCK_JS'
+      (() => {
+        if (globalThis.__funicularLocks) return;
+        globalThis.__funicularLocks = {
+          holds: {},
+          acquire(name) {
+            return new Promise((resolveAcquire) => {
+              // Injection seam: undefined falls through to the real
+              // navigator.locks; anything else (an object, or null to
+              // simulate ABSENCE even where the host has real locks --
+              // Node ships navigator.locks) is taken as-is.
+              const injected = globalThis.__funicularLocksApi;
+              const locks = (injected === undefined)
+                ? (globalThis.navigator && globalThis.navigator.locks)
+                : injected;
+              if (!locks || !locks.request) {
+                resolveAcquire("unsupported");
+                return;
+              }
+              try {
+                const requested = locks.request(
+                  name, { ifAvailable: true }, (lock) => {
+                    if (!lock) {
+                      resolveAcquire("busy");
+                      return null;
+                    }
+                    return new Promise((release) => {
+                      globalThis.__funicularLocks.holds[name] = release;
+                      resolveAcquire("acquired");
+                    });
+                  });
+                Promise.resolve(requested).catch(() => {
+                  resolveAcquire("error");
+                });
+              } catch (e) {
+                resolveAcquire("error");
+              }
+            });
+          },
+          release(name) {
+            const release = globalThis.__funicularLocks.holds[name];
+            if (!release) return false;
+            delete globalThis.__funicularLocks.holds[name];
+            release();
+            return true;
+          }
+        };
+      })()
+    FUNICULAR_LOCK_JS
+
+    # :unbooted -> :persistent_writer | :persistent_reader | :volatile.
+    # ("volatile" is deliberately distinct from storage :ephemeral.)
+    def self.durability
+      @durability || :unbooted
+    end
+
+    # Boot/test seam; election itself is one-shot.
+    def self.__set_durability(state)
+      @durability = state
+    end
+
+    def self.elect_writer(lock_name)
+      unless durability == :unbooted
+        raise Error,
+          "the writer election already ran (this tab is #{durability})"
+      end
+      # Claim the slot BEFORE awaiting: the await suspends this Task,
+      # and a concurrent elect_writer from another Task must fail the
+      # one-shot check meanwhile -- two elections could otherwise hold
+      # two locks with only one of them releasable.
+      @durability = :electing
+      begin
+        install_lock_shim
+        # @type var shim: untyped
+        shim = JS.global[:__funicularLocks]
+        result = shim.acquire(lock_name).await.to_s
+      rescue => e
+        @durability = :unbooted
+        # Explicit re-raise: a bare `raise` would not re-raise on the
+        # mruby VM.
+        raise e
+      end
+      state = if result == "acquired"
+        :persistent_writer
+      elsif result == "busy"
+        :persistent_reader
+      else
+        # "unsupported" (no Web Locks) or an API error: by-design
+        # absence drops the page to volatile (docs decision 14).
+        :volatile
+      end
+      @writer_lock_name = lock_name if state == :persistent_writer
+      @durability = state
+      state
+    end
+
+    def self.install_lock_shim
+      return if @lock_shim_installed
+      # @type var global: untyped
+      global = JS.global
+      global.eval(LOCK_SHIM_JS)
+      @lock_shim_installed = true
+    end
+
+    # Terminal step-down (docs decision 13) and teardown: resolving the
+    # holding promise lets a NEW tab win the next election. No-op unless
+    # this tab holds the lock.
+    def self.release_writer_lock
+      name = @writer_lock_name
+      return false unless name
+      @writer_lock_name = nil
+      # @type var shim: untyped
+      shim = JS.global[:__funicularLocks]
+      shim.release(name)
+      # Stepping down is one-way: another tab can win the lock from now
+      # on, so THIS tab must never persist again. It becomes a
+      # non-persisting reader, exactly like a tab that lost the
+      # election (docs decision 13).
+      @durability = :persistent_reader
+      true
+    end
+
     # ---- namespace identity (docs decisions 12/13) ----------------------
     #
     # One browser profile can hold data for several apps and several

--- a/mrblib/db.rb
+++ b/mrblib/db.rb
@@ -2207,11 +2207,12 @@ module Funicular
       @session_epoch
     end
 
-    # metadata comes from the page (picoruby_include_tag data
-    # attributes, read in a later change); tests and embedders pass it
-    # directly. Absent keys fall back to a replica-only anonymous
-    # default.
-    def self.boot(models:, metadata: {})
+    # metadata comes from the page (the picoruby_include_tag data
+    # attributes); tests and embedders may pass both arguments
+    # directly. Absent metadata falls back to a replica-only anonymous
+    # default; absent models fall back to every declared Model
+    # subclass.
+    def self.boot(models: nil, metadata: nil)
       if Funicular.server?
         raise UnavailableError,
           "Funicular::DB.boot does not run on the server (SSR renders " \
@@ -2222,23 +2223,66 @@ module Funicular
       end
       @boot_state = :booting
       begin
-        __boot_steps(models, metadata)
+        __boot_steps(models || Funicular::Model.__registered_models,
+                     metadata || read_page_metadata)
         @boot_state = :ready
         true
       rescue => e
-        @boot_state = :failed
-        # No partial boot: whatever was already wired up is torn back
-        # out of reach (the getters below also gate on :ready).
-        @local_handle = nil
-        @replica_handle = nil
-        report_boot_error([e])
-        # The hook above had its recovery chance (a wipe from it runs
-        # as the writer). A page that stays failed can do nothing with
-        # the writer slot except deny it to every other tab -- release
-        # it (no-op when the election never ran or was lost).
-        release_writer_lock
-        false
+        __fail_boot([e])
       end
+    end
+
+    # The one failure funnel (docs decision 16): boot's own rescue and
+    # the schema barrier (funicular.rb) land here. Fails loud, tears
+    # the partial boot out of reach, and -- once the hook had its
+    # recovery chance (a wipe from it runs as the writer) -- releases
+    # the writer slot: a page that stays failed must not deny it to
+    # every other tab. Always returns false.
+    def self.__fail_boot(errors)
+      @boot_state = :failed
+      @local_handle = nil
+      @replica_handle = nil
+      report_boot_error(errors)
+      release_writer_lock
+      false
+    end
+
+    # The picoruby_include_tag embeds the namespace identity and the
+    # session epoch as HTML-escaped data attributes (docs decision 12);
+    # the Rails side emits them in a later change, and this is the
+    # client half of that contract. No tag (or no document -- tests,
+    # exotic embedders) means the replica-only anonymous default.
+    PAGE_METADATA_JS = <<~'FUNICULAR_META_JS'
+      (() => {
+        if (typeof document === "undefined") return "null";
+        const el = document.querySelector("[data-funicular-application-id]");
+        if (!el) return "null";
+        const d = el.dataset;
+        return JSON.stringify({
+          application_id: d.funicularApplicationId,
+          user_key:
+            (d.funicularUserKey === undefined) ? null : d.funicularUserKey,
+          user_key_configured: d.funicularUserKeyConfigured === "true",
+          anonymous_only: d.funicularAnonymousOnly === "true",
+          epoch: (d.funicularEpoch === undefined) ? null : d.funicularEpoch,
+        });
+      })()
+    FUNICULAR_META_JS
+
+    def self.read_page_metadata
+      return {} unless Object.const_defined?(:JS)
+      # @type var global: untyped
+      global = JS.global
+      raw = global.eval(PAGE_METADATA_JS).to_s
+      return {} if raw == "null" || raw.empty?
+      data = JSON.parse(raw)
+      {
+        application_id: data["application_id"],
+        user_key: data["user_key"],
+        user_key_configured: !!data["user_key_configured"],
+        anonymous_only: !!data["anonymous_only"],
+        epoch: data["epoch"],
+      }
     end
 
     class << self

--- a/mrblib/funicular.rb
+++ b/mrblib/funicular.rb
@@ -104,10 +104,10 @@ module Funicular
   #   end
   # EVERY request settles its slot exactly once -- success, HTTP
   # error, or a schema that fails to apply -- so the barrier always
-  # completes. All green: the local database boots, and only then the
-  # completion block runs. Any failure: the block is NEVER invoked,
-  # the errors reach the console and config.on_boot_error, and the
-  # boot is marked failed so nothing can mount later.
+  # completes. All green: an opted-in local database boots before the
+  # completion block; a REST-only app runs the block directly. Any failure:
+  # the block is NEVER invoked and the errors reach the console and
+  # config.on_boot_error. Only an active DB lifecycle is marked failed.
   def self.load_schemas(models, &block)
     # On the server there is no fetch and no need for client-side schemas:
     # SSR injects plain data into component state directly. Just run the
@@ -121,7 +121,8 @@ module Funicular
     # responses are epoch-checked too (docs decision 13). The response
     # gate latches lazily on its own; the explicit call keeps the
     # whole barrier deterministically armed at issue time.
-    Funicular::DB.__latch_page_epoch
+    local_database = Funicular::DB.local_database_enabled?
+    Funicular::DB.__latch_page_epoch if local_database
 
     total = models.size
     settled = 0
@@ -189,18 +190,39 @@ module Funicular
   # only when the boot itself succeeded too), fail loud otherwise.
   def self.__settle_boot_barrier(errors, &block)
     if errors.empty?
-      block.call if Funicular::DB.boot && block
+      if Funicular::DB.local_database_enabled?
+        block.call if Funicular::DB.boot && block
+      else
+        block.call if block
+      end
     else
-      Funicular::DB.__fail_boot(errors)
+      if Funicular::DB.local_database_enabled?
+        Funicular::DB.__fail_boot(errors)
+      else
+        Funicular::DB.__report_boot_errors(errors)
+      end
     end
     nil
   end
 
   # Funicular.start's client-side gate (docs decision 19): apps with
-  # replica models boot inside the schema barrier above; local-only
-  # apps (no load_schemas call) boot right here. Either way nothing
-  # mounts unless the database came up.
+  # opted-in replica models boot inside the schema barrier above; opted-in
+  # local-only apps (no load_schemas call) boot right here. REST-only apps
+  # bypass DB boot, except that an explicit storage :local declaration fails.
   def self.__boot_for_start
+    unless Funicular::DB.local_database_enabled?
+      models = Funicular::Model.__registered_models
+      i = 0
+      models_size = models.size
+      while i < models_size
+        if models[i].local?
+          raise Funicular::DB::ConfigError,
+            "storage :local requires config.local_database = true"
+        end
+        i += 1
+      end
+      return true
+    end
     state = Funicular::DB.boot_state
     return true if state == :ready
     return false unless state == :unbooted
@@ -225,9 +247,9 @@ module Funicular
       return nil
     end
 
-    # The local database comes up before anything mounts (docs
-    # decision 19); a failed boot already reported itself, so start
-    # quietly refuses to mount on top of it.
+    # An opted-in local database comes up before anything mounts. A failed
+    # boot already reported itself, so start quietly refuses to mount on it;
+    # a REST-only application passes this gate without touching the DB.
     unless __boot_for_start
       puts "[Funicular] start aborted: the local database did not boot"
       return nil

--- a/mrblib/funicular.rb
+++ b/mrblib/funicular.rb
@@ -117,6 +117,12 @@ module Funicular
       return
     end
 
+    # Arm the page's epoch before the first request leaves: schema
+    # responses are epoch-checked too (docs decision 13). The response
+    # gate latches lazily on its own; the explicit call keeps the
+    # whole barrier deterministically armed at issue time.
+    Funicular::DB.__latch_page_epoch
+
     total = models.size
     settled = 0
     # @type var errors: Array[untyped]

--- a/mrblib/funicular.rb
+++ b/mrblib/funicular.rb
@@ -97,11 +97,17 @@ module Funicular
     child.is_a?(JS::Element) ? child : nil
   end
 
-  # Load schemas for models
+  # The schema boot barrier (docs decisions 6/19).
   # Usage:
   #   Funicular.load_schemas({ User => "user", Session => "session" }) do
   #     Funicular.start(container: 'app') { |router| ... }
   #   end
+  # EVERY request settles its slot exactly once -- success, HTTP
+  # error, or a schema that fails to apply -- so the barrier always
+  # completes. All green: the local database boots, and only then the
+  # completion block runs. Any failure: the block is NEVER invoked,
+  # the errors reach the console and config.on_boot_error, and the
+  # boot is marked failed so nothing can mount later.
   def self.load_schemas(models, &block)
     # On the server there is no fetch and no need for client-side schemas:
     # SSR injects plain data into component state directly. Just run the
@@ -111,28 +117,88 @@ module Funicular
       return
     end
 
-    schemas_loaded = 0
-    total_schemas = models.size
+    total = models.size
+    settled = 0
+    # @type var errors: Array[untyped]
+    errors = []
+    completed = false
 
-    check_completion = -> {
-      if schemas_loaded >= total_schemas
-        puts "[Funicular] All schemas loaded (#{schemas_loaded}/#{total_schemas})"
-        block.call if block
-      end
+    settle = -> {
+      settled += 1
+      # Exactly once, and only with every slot settled.
+      next if completed
+      next if settled < total
+      completed = true
+      __settle_boot_barrier(errors, &block)
     }
 
-    models.each do |model_class, schema_name|
-      HTTP.get("/api/schema/#{schema_name}") do |response|
-        if response.error?
-          puts "[Schema] Failed to load #{schema_name} schema: #{response.error_message}"
-        else
+    if total == 0
+      __settle_boot_barrier(errors, &block)
+      return
+    end
+
+    entries = models.to_a
+    entries_size = entries.size
+    i = 0
+    while i < entries_size
+      entry = entries[i]
+      # One request per method call: the response block must capture
+      # ITS model and name, and a while loop's shared locals would all
+      # resolve to the last pair by response time.
+      __request_schema(entry[0], entry[1], errors, settle)
+      i += 1
+    end
+  end
+
+  def self.__request_schema(model_class, schema_name, errors, settle)
+    HTTP.get("/api/schema/#{schema_name}") do |response|
+      if response.error?
+        # Status and model always; the body's message only when the
+        # server actually sent one (an empty or HTML error body has
+        # no error_message).
+        message = "schema #{schema_name} (#{model_class.to_s}): " \
+                  "HTTP #{response.status}"
+        detail = response.error_message
+        message = "#{message}: #{detail}" if detail
+        errors << Funicular::DB::Error.new(message)
+      else
+        begin
           model_class.load_schema(response.data)
           puts "[Schema] #{schema_name} model initialized"
-          schemas_loaded += 1
-          check_completion.call
+        rescue => e
+          # A schema that arrived but cannot be applied settles as a
+          # failure -- the barrier must never hang on it. Wrapped so
+          # on_boot_error can tell WHICH model broke among several.
+          errors << Funicular::DB::Error.new(
+            "schema #{schema_name} (#{model_class.to_s}): " \
+            "#{e.class}: #{e.message}")
         end
       end
+      settle.call
     end
+    nil
+  end
+
+  # The barrier settled: boot on all-green (the completion block runs
+  # only when the boot itself succeeded too), fail loud otherwise.
+  def self.__settle_boot_barrier(errors, &block)
+    if errors.empty?
+      block.call if Funicular::DB.boot && block
+    else
+      Funicular::DB.__fail_boot(errors)
+    end
+    nil
+  end
+
+  # Funicular.start's client-side gate (docs decision 19): apps with
+  # replica models boot inside the schema barrier above; local-only
+  # apps (no load_schemas call) boot right here. Either way nothing
+  # mounts unless the database came up.
+  def self.__boot_for_start
+    state = Funicular::DB.boot_state
+    return true if state == :ready
+    return false unless state == :unbooted
+    Funicular::DB.boot
   end
 
   # Start Funicular application
@@ -150,6 +216,14 @@ module Funicular
         block.call(router)
         return router
       end
+      return nil
+    end
+
+    # The local database comes up before anything mounts (docs
+    # decision 19); a failed boot already reported itself, so start
+    # quietly refuses to mount on top of it.
+    unless __boot_for_start
+      puts "[Funicular] start aborted: the local database did not boot"
       return nil
     end
 

--- a/mrblib/funicular.rb
+++ b/mrblib/funicular.rb
@@ -18,7 +18,7 @@ module Funicular
   # Guard against redefinition: when the mrblib runtime is loaded into a
   # CRuby/Rails process for SSR, lib/funicular/version.rb has already defined
   # VERSION for the CRuby gem. In the wasm build VERSION is undefined here.
-  VERSION = '0.4.0' unless Funicular.const_defined?(:VERSION)
+  VERSION = '0.5.0' unless Funicular.const_defined?(:VERSION)
 
   def self.version
     VERSION

--- a/mrblib/http.rb
+++ b/mrblib/http.rb
@@ -98,11 +98,18 @@ module Funicular
         settled = false
         begin
           JS.global.fetch(url, options) do |response|
-            status = response.status.to_i
-            json_text = response.to_binary
-            data = parse_response_body(json_text)
-            # @type var status: Integer
+            # The epoch decides BEFORE the body is touched. fetch
+            # resolves once the headers arrive -- which is all this
+            # check needs -- but to_binary can still fail on an
+            # interrupted body stream, and the rescue below would then
+            # settle with a network error without ever processing the
+            # mismatch: the page would stay non-terminal and free to
+            # issue another request under the NEW session.
             if Funicular::DB.__session_epoch_ok?(response_epoch(response))
+              # @type var status: Integer
+              status = response.status.to_i
+              json_text = response.to_binary
+              data = parse_response_body(json_text)
               http_response = Response.new(status, data)
             else
               # The session changed under this page (docs decision 13):

--- a/mrblib/http.rb
+++ b/mrblib/http.rb
@@ -68,6 +68,16 @@ module Funicular
       end
 
       def request(method, url, body, &block)
+        # A terminal page must not TALK to the server either (docs
+        # decision 13): discarding the response is not enough, because
+        # the request itself would already have executed under the NEW
+        # session's cookies -- an old screen's click could mutate
+        # another user's data. Refused BEFORE the fetch; the callback
+        # still settles exactly once.
+        if Funicular::DB.session_terminated?
+          block.call(session_changed_response) if block
+          return nil
+        end
         # @type var options: Hash[Symbol, String | Hash[String, String]]
         options = { method: method, credentials: "include" }
 
@@ -85,15 +95,57 @@ module Funicular
 
         options[:headers] = headers unless headers.empty?
 
-        JS.global.fetch(url, options) do |response|
-          status = response.status.to_i
-          json_text = response.to_binary
-          data = parse_response_body(json_text)
-          # @type var status: Integer
-          http_response = Response.new(status, data)
-
-          block.call(http_response) if block
+        settled = false
+        begin
+          JS.global.fetch(url, options) do |response|
+            status = response.status.to_i
+            json_text = response.to_binary
+            data = parse_response_body(json_text)
+            # @type var status: Integer
+            if Funicular::DB.__session_epoch_ok?(response_epoch(response))
+              http_response = Response.new(status, data)
+            else
+              # The session changed under this page (docs decision 13):
+              # the response is DISCARDED, and the caller settles with
+              # an error instead of applying stale-session data.
+              http_response = session_changed_response
+            end
+            settled = true
+            block.call(http_response) if block
+          end
+        rescue => e
+          # Exactly-once settle: a rejected fetch (network failure,
+          # invalid URL) must still deliver a response -- a hanging
+          # callback would hang the schema barrier and every REST
+          # caller. An exception out of the caller's OWN block must
+          # NOT settle a second time.
+          raise e if settled
+          settled = true
+          if block
+            block.call(Response.new(0,
+              { "error" => "network error: #{e.class}: #{e.message}" }))
+          end
         end
+      end
+
+      def session_changed_response
+        Response.new(0,
+          { "error" => "the session changed; this page is " \
+                       "terminal (reload to continue)" })
+      end
+
+      # The X-Funicular-Epoch response header, nil when absent (no
+      # headers surface, no such header, or a null value through the
+      # JS bridge).
+      def response_epoch(response)
+        # @type var raw: untyped
+        raw = response
+        value = raw[:headers].get("X-Funicular-Epoch").to_s
+        return nil if value.empty?
+        return nil if value == "null" || value == "undefined"
+        value
+      rescue
+        nil
       end
     end
   end

--- a/mrblib/http.rb
+++ b/mrblib/http.rb
@@ -1,10 +1,5 @@
 module Funicular
   module HTTP
-    CACHE_DB_NAME = 'funicular_http_cache'.freeze
-    CACHE_STORE = 'responses'.freeze
-
-    @cache = nil
-
     class Response
       attr_reader :data, :status, :ok
 
@@ -26,73 +21,23 @@ module Funicular
       end
     end
 
-    # Open (or reuse) the response cache store. Idempotent and safe to call
-    # multiple times. Falls back to the in-memory backing if browser
-    # IndexedDB is unavailable.
-    def self.cache_init!
-      cache = @cache
-      return cache if cache
-      @cache = IndexedDB::KVS.open(CACHE_DB_NAME, store: CACHE_STORE)
+    def self.get(url, &block)
+      request("GET", url, nil, &block)
     end
 
-    # Drop a single cached entry by URL key. No-op if the cache is not
-    # initialized.
-    def self.cache_purge(url)
-      cache = @cache
-      return nil unless cache
-      cache.delete(url)
-      nil
-    end
-
-    # Drop every cached entry. No-op if the cache is not initialized.
-    def self.cache_clear
-      cache = @cache
-      return nil unless cache
-      cache.clear
-      nil
-    end
-
-    # Internal: read the cache for *url*. Returns the parsed entry hash or
-    # nil. Lazily initializes the cache on first use so callers can pass
-    # `cache:` without booting the SPA shell first.
-    def self.cache_lookup(url)
-      cache_init! unless @cache
-      cache = @cache
-      return nil unless cache
-      cache[url]
-    end
-
-    # Internal: write *entry* (a Hash with status/data/cached_at) to the
-    # cache. Awaits one extra Promise so the next request reliably hits.
-    def self.cache_write(url, entry)
-      cache_init! unless @cache
-      cache = @cache
-      return nil unless cache
-      cache[url] = entry
-      nil
-    end
-
-    def self.get(url, cache: nil, &block)
-      request("GET", url, nil, cache: cache, &block)
-    end
-
-    def self.post(url, body = nil, cache: nil, &block)
-      warn_unsupported_cache("post") if cache
+    def self.post(url, body = nil, &block)
       request("POST", url, body, &block)
     end
 
-    def self.patch(url, body = nil, cache: nil, &block)
-      warn_unsupported_cache("patch") if cache
+    def self.patch(url, body = nil, &block)
       request("PATCH", url, body, &block)
     end
 
-    def self.delete(url, cache: nil, &block)
-      warn_unsupported_cache("delete") if cache
+    def self.delete(url, &block)
       request("DELETE", url, nil, &block)
     end
 
-    def self.put(url, body = nil, cache: nil, &block)
-      warn_unsupported_cache("put") if cache
+    def self.put(url, body = nil, &block)
       request("PUT", url, body, &block)
     end
 
@@ -111,29 +56,6 @@ module Funicular
     class << self
       private
 
-      def warn_unsupported_cache(verb)
-        puts "[Funicular::HTTP] cache: option is GET-only; ignoring on #{verb.upcase}"
-      end
-
-      def now_seconds
-        # JavaScript Date.now() returns ms since epoch
-        ms = JS.global[:Date].now # steep:ignore
-        (ms.to_i / 1000)
-      end
-
-      def cache_hit?(entry, ttl)
-        return false unless entry.is_a?(Hash)
-        cached_at = entry["cached_at"]
-        return false unless cached_at.is_a?(Integer)
-        (now_seconds - cached_at) <= ttl
-      end
-
-      def serve_from_cache(entry, &block)
-        status = entry["status"].to_i
-        data = entry["data"]
-        block.call(Response.new(status, data)) if block
-      end
-
       def parse_response_body(text)
         return nil if text.nil?
 
@@ -145,15 +67,7 @@ module Funicular
         body
       end
 
-      def request(method, url, body, cache: nil, &block)
-        if method == "GET" && cache.is_a?(Integer) && cache > 0
-          entry = cache_lookup(url)
-          if cache_hit?(entry, cache)
-            serve_from_cache(entry, &block)
-            return
-          end
-        end
-
+      def request(method, url, body, &block)
         # @type var options: Hash[Symbol, String | Hash[String, String]]
         options = { method: method, credentials: "include" }
 
@@ -177,14 +91,6 @@ module Funicular
           data = parse_response_body(json_text)
           # @type var status: Integer
           http_response = Response.new(status, data)
-
-          if method == "GET" && cache.is_a?(Integer) && cache > 0 && http_response.ok
-            cache_write(url, {
-              "status" => status,
-              "data" => data,
-              "cached_at" => now_seconds
-            })
-          end
 
           block.call(http_response) if block
         end

--- a/mrblib/model.rb
+++ b/mrblib/model.rb
@@ -288,6 +288,14 @@ module Funicular
         "#{to_s}: the local database is not booted"
     end
 
+    # The handle REST write-through applies replica rows to. DB.boot (a
+    # later change) overrides this with the guarded replica handle --
+    # raw connections are never exposed globally. While it returns nil,
+    # write-through stays inert and REST works standalone.
+    def self.replica_db
+      nil
+    end
+
     def self.build_from_local(attrs)
       record = new({})
       record.__hydrate_local(attrs)
@@ -299,6 +307,32 @@ module Funicular
     # delegates to the change-event bus and snapshot scheduling; until
     # then there is nobody to notify.
     def self.local_table_changed
+    end
+
+    # ---- write-through (docs decision 5) --------------------------------
+    # Successful REST responses mirror rows into the replica through the
+    # single apply entry point, BEFORE user callbacks run. Inert on
+    # non-replica models and until DB.boot installs the replica handle.
+
+    def self.__write_through_upsert(attrs)
+      return unless replica?
+      db = replica_db
+      return unless db
+      Funicular::DB.replica_upsert(db, self, attrs)
+    end
+
+    def self.__write_through_upsert_all(rows)
+      return unless replica?
+      db = replica_db
+      return unless db
+      Funicular::DB.replica_upsert_all(db, self, rows)
+    end
+
+    def self.__write_through_delete(id)
+      return unless replica?
+      db = replica_db
+      return unless db
+      Funicular::DB.replica_delete(db, self, id)
     end
 
     # Generate attribute readers/writers from the migrate fold, mirroring
@@ -466,11 +500,28 @@ module Funicular
           # already normalized.
           send("#{name}=", value)
         else
+          unless is_local || value.nil?
+            # REST values pass through the shared codec, so JSON strings
+            # and 1/0 become the same Ruby types local queries return
+            # (docs decision 8: Post.all and Post.local.find agree).
+            value = Funicular::DB::Codec.decode(
+              klass.rest_attribute_type(name), value)
+          end
           instance_variable_set("@#{name}", value)
         end
         i += 1
       end
       @provided_attributes = provided
+    end
+
+    # The schema-declared type of a REST attribute (nil when unknown);
+    # feeds the shared codec on the REST side.
+    def self.rest_attribute_type(name)
+      sch = @schema
+      return nil unless sch
+      config = sch[name]
+      return nil unless config
+      (config["type"] || "string").to_sym
     end
 
     # A record not yet in the local table (docs: "a new record is one
@@ -521,7 +572,19 @@ module Funicular
         if response.error?
           block.call(nil, response.error_message) if block
         else
-          instances = response.data.map { |attrs| new(attrs) }
+          rows = response.data
+          rows_size = rows.size
+          # Fetch-through (docs decision 5): the whole collection lands
+          # in the replica -- one transaction, one change event -- before
+          # anything else sees it.
+          __write_through_upsert_all(rows)
+          # @type var instances: Array[Model]
+          instances = []
+          i = 0
+          while i < rows_size
+            instances << new(rows[i])
+            i += 1
+          end
           block.call(instances, nil) if block
         end
       end
@@ -546,6 +609,7 @@ module Funicular
           block.call(nil, response.error_message) if block
         else
           klass = model_class || self
+          klass.__write_through_upsert(response.data)
           instance = klass.new(response.data)
           block.call(instance, nil) if block
         end
@@ -582,6 +646,7 @@ module Funicular
           block.call(nil, response.error_message) if block
         else
           klass = model_class || self
+          klass.__write_through_upsert(response.data)
           instance = klass.new(response.data)
           block.call(instance, nil) if block
         end
@@ -605,6 +670,7 @@ module Funicular
         if response.error?
           block.call(nil, response.error_message) if block
         else
+          __write_through_delete(id) unless id.nil?
           block.call(true, nil) if block
         end
       end
@@ -647,10 +713,25 @@ module Funicular
         if response.error?
           block.call(nil, response.error_message) if block
         else
+          data = response.data
+          # The replica holds the server's row before the callback runs
+          # (docs decision 4).
+          self.class.__write_through_upsert(data)
           # Apply the server's authoritative row (defaults, callbacks and
-          # normalizations included) before reporting success.
-          response.data.each do |key, value|
+          # normalizations included) through the codec before reporting
+          # success.
+          keys = data.keys
+          keys_size = keys.size
+          i = 0
+          while i < keys_size
+            key = keys[i]
+            value = data[key]
+            unless value.nil?
+              value = Funicular::DB::Codec.decode(
+                self.class.rest_attribute_type(key.to_s), value)
+            end
             instance_variable_set("@#{key}", value)
+            i += 1
           end
           @changed_attributes = {}
           block.call(self, nil) if block

--- a/mrblib/model.rb
+++ b/mrblib/model.rb
@@ -302,11 +302,32 @@ module Funicular
       record
     end
 
-    # Called by Relation#delete_all and the local CRUD writers after a
-    # framework-managed local write. Once Funicular::DB.boot lands this
-    # delegates to the change-event bus and snapshot scheduling; until
-    # then there is nobody to notify.
+    # Called by Relation#delete_all, the local CRUD writers, and the
+    # replica apply path after a framework-managed write: the change-
+    # event bus takes it from here (snapshot scheduling joins in at
+    # boot).
     def self.local_table_changed
+      Funicular::DB.notify_changed(self)
+    end
+
+    # The public change-subscription primitive (docs decision 10):
+    # watch's Relation-only contract covers lists; for hashes, counts,
+    # or raw-SQL-derived state, subscribe here and patch state in the
+    # handler. Returns a subscription for off_change.
+    def self.on_change(&block)
+      unless block
+        raise ArgumentError, "on_change requires a block"
+      end
+      if ephemeral?
+        raise Funicular::DB::NoTableError,
+          "#{to_s} is storage :ephemeral; it has no local table to watch"
+      end
+      Funicular::DB.subscribe(replica? ? :replica : :local,
+                              table_name, &block)
+    end
+
+    def self.off_change(subscription)
+      Funicular::DB.unsubscribe(subscription)
     end
 
     # ---- write-through (docs decision 5) --------------------------------

--- a/mrblib/model.rb
+++ b/mrblib/model.rb
@@ -589,8 +589,14 @@ module Funicular
         path = "#{path}?#{URI.encode_www_form(params)}"
       end
 
+      # A wipe between issue and response makes the response stale: it
+      # is discarded, never applied -- a logout can never resurrect the
+      # previous session's rows (docs decision 17).
+      generation = Funicular::DB.mutation_generation
       HTTP.get(path) do |response|
-        if response.error?
+        if Funicular::DB.stale_generation?(generation)
+          block.call(nil, Funicular::DB.stale_response_error) if block
+        elsif response.error?
           block.call(nil, response.error_message) if block
         else
           rows = response.data
@@ -625,8 +631,11 @@ module Funicular
       path = endpoint["path"]
       path = path.gsub(":id", id.to_s) if id
 
+      generation = Funicular::DB.mutation_generation
       HTTP.get(path) do |response|
-        if response.error?
+        if Funicular::DB.stale_generation?(generation)
+          block.call(nil, Funicular::DB.stale_response_error) if block
+        elsif response.error?
           block.call(nil, response.error_message) if block
         else
           klass = model_class || self
@@ -662,8 +671,11 @@ module Funicular
         return
       end
 
+      generation = Funicular::DB.mutation_generation
       HTTP.post(endpoint["path"], attrs) do |response|
-        if response.error?
+        if Funicular::DB.stale_generation?(generation)
+          block.call(nil, Funicular::DB.stale_response_error) if block
+        elsif response.error?
           block.call(nil, response.error_message) if block
         else
           klass = model_class || self
@@ -687,8 +699,11 @@ module Funicular
 
       path = id ? endpoint["path"].gsub(":id", id.to_s) : endpoint["path"]
 
+      generation = Funicular::DB.mutation_generation
       HTTP.delete(path) do |response|
-        if response.error?
+        if Funicular::DB.stale_generation?(generation)
+          block.call(nil, Funicular::DB.stale_response_error) if block
+        elsif response.error?
           block.call(nil, response.error_message) if block
         else
           __write_through_delete(id) unless id.nil?
@@ -730,8 +745,11 @@ module Funicular
       endpoint = self.class.endpoints["update"]
       path = endpoint["path"].gsub(":id", @id.to_s)
 
+      generation = Funicular::DB.mutation_generation
       HTTP.patch(path, json_attrs) do |response|
-        if response.error?
+        if Funicular::DB.stale_generation?(generation)
+          block.call(nil, Funicular::DB.stale_response_error) if block
+        elsif response.error?
           block.call(nil, response.error_message) if block
         else
           data = response.data

--- a/mrblib/model.rb
+++ b/mrblib/model.rb
@@ -15,6 +15,8 @@ module Funicular
     def self.load_schema(schema_data)
       @schema = schema_data["attributes"]
       @endpoints = schema_data["endpoints"]
+      # Replica column metadata derives from the schema; drop any cache.
+      @local_columns = nil
 
       # Generate attr_accessor dynamically based on schema
       @schema.each do |name, config|
@@ -64,6 +66,218 @@ module Funicular
       else
         opts
       end
+    end
+
+    # ---- local-database declaration DSL (docs/local_database.md) --------
+    #
+    #   storage :replica (default)  server data, mirrored into the replica
+    #   storage :ephemeral          REST only, no local table
+    #   storage :local do ... end   client-only table built by migrate blocks
+    #
+    # The migrate blocks are only RECORDED at class-definition time (their
+    # version rules validated); they execute against the local database at
+    # boot, in the migration runner.
+
+    def self.storage(kind, &block)
+      if kind == :local
+        unless block
+          raise ArgumentError,
+            "storage :local requires a block with migrate declarations"
+        end
+        @storage_kind = kind
+        @local_migrations = []
+        @collecting_migrations = true
+        begin
+          block.call
+        ensure
+          @collecting_migrations = false
+        end
+        validate_local_migrations
+      elsif kind == :replica || kind == :ephemeral
+        if block
+          raise ArgumentError, "only storage :local takes a block"
+        end
+        @storage_kind = kind
+      else
+        raise ArgumentError,
+          "storage must be :replica, :ephemeral, or :local, got #{kind.inspect}"
+      end
+      kind
+    end
+
+    def self.storage_kind
+      @storage_kind || :replica
+    end
+
+    def self.replica?
+      storage_kind == :replica
+    end
+
+    def self.ephemeral?
+      storage_kind == :ephemeral
+    end
+
+    def self.local?
+      storage_kind == :local
+    end
+
+    # Record one numbered migration block. Only valid inside storage :local.
+    def self.migrate(version, reset: false, &block)
+      migrations = @local_migrations
+      unless @collecting_migrations && migrations
+        raise ArgumentError,
+          "migrate must be declared inside a storage :local block"
+      end
+      unless version.is_a?(Integer) && 1 <= version
+        raise ArgumentError,
+          "migrate version must be a positive Integer, got #{version.inspect}"
+      end
+      unless block
+        raise ArgumentError, "migrate #{version} requires a block"
+      end
+      migrations << { version: version, reset: reset, block: block }
+    end
+
+    def self.local_migrations
+      @local_migrations
+    end
+
+    # Baseline rules (docs): the first retained block is version 1 unless
+    # it is `reset: true` (then any positive version); contiguous after
+    # that. A gap means a deleted non-baseline block -- fail at class eval.
+    def self.validate_local_migrations
+      migrations = @local_migrations
+      if migrations.nil? || migrations.empty?
+        raise ArgumentError, "storage :local requires at least one migrate block"
+      end
+      first = migrations[0]
+      unless first[:version] == 1 || first[:reset]
+        raise ArgumentError,
+          "the first migrate block must be version 1 (or reset: true), " \
+          "got #{first[:version]}"
+      end
+      i = 1
+      while i < migrations.size
+        expected = migrations[i - 1][:version] + 1
+        unless migrations[i][:version] == expected
+          raise ArgumentError,
+            "migrate versions must be contiguous: expected #{expected}, " \
+            "got #{migrations[i][:version]}"
+        end
+        i += 1
+      end
+    end
+
+    # v1 implements only the default :manual (freshness is explicit fetch);
+    # :auto and :live are reserved and rejected at class-definition time.
+    def self.refresh(mode)
+      if mode == :auto
+        raise NotImplementedError,
+          "refresh :auto is not yet supported (v1 is :manual only)"
+      end
+      if mode == :live
+        raise NotImplementedError,
+          "refresh :live is not yet supported (v1 is :manual only)"
+      end
+      unless mode == :manual
+        raise ArgumentError, "refresh must be :manual, got #{mode.inspect}"
+      end
+      @refresh_mode = mode
+    end
+
+    def self.refresh_mode
+      @refresh_mode || :manual
+    end
+
+    # Reader and override in one: `table_name` returns the table name
+    # (naive pluralization of the class name: +s, y->ies),
+    # `table_name "things"` overrides it.
+    def self.table_name(explicit = nil)
+      if explicit
+        @table_name = explicit.to_s
+      else
+        @table_name ||= derive_table_name
+      end
+    end
+
+    def self.derive_table_name
+      parts = to_s.split("::")
+      base = parts[parts.size - 1] || ""
+      snake = ""
+      i = 0
+      while i < base.length
+        c = base.getbyte(i)
+        if c && 65 <= c && c <= 90 # A-Z
+          snake += "_" unless i == 0
+          snake += (c + 32).chr
+        else
+          char = base[i]
+          snake += char if char
+        end
+        i += 1
+      end
+      if snake.end_with?("y")
+        "#{snake[0, snake.length - 1]}ies"
+      else
+        "#{snake}s"
+      end
+    end
+
+    # The marked local/cache view (source-of-truth contract): a Relation
+    # over the whole local table. Ephemeral models have no table behind it.
+    def self.local
+      if ephemeral?
+        raise Funicular::DB::NoTableError,
+          "#{to_s} is storage :ephemeral; it has no local table"
+      end
+      Relation.new(self)
+    end
+
+    # ---- Relation protocol (see mrblib/relation.rb) ---------------------
+
+    # Column name -> declared type. For replica models this derives from
+    # the server schema: binary attributes never reach the replica and the
+    # id type follows the server. Local models get their columns from the
+    # migrate fold once the migration runner lands.
+    def self.local_columns
+      if ephemeral?
+        raise Funicular::DB::NoTableError,
+          "#{to_s} is storage :ephemeral; it has no local table"
+      end
+      if local?
+        raise Funicular::DB::UnavailableError,
+          "#{to_s}: local tables are not built yet (migrations run at DB boot)"
+      end
+      cols = @local_columns
+      return cols if cols
+      sch = @schema
+      unless sch
+        raise Funicular::DB::UnavailableError,
+          "#{to_s}: no schema loaded; replica columns derive from the " \
+          "server schema at boot"
+      end
+      # @type var derived: Hash[String, Symbol]
+      derived = {}
+      names = sch.keys
+      i = 0
+      while i < names.size
+        attr_name = names[i]
+        type = (sch[attr_name]["type"] || "string").to_sym
+        derived[attr_name] = type unless type == :binary
+        i += 1
+      end
+      @local_columns = derived
+    end
+
+    # The handle local queries run against. Arrives with Funicular::DB.boot
+    # (a later change); until then every materializer fails loud.
+    def self.local_db
+      raise Funicular::DB::UnavailableError,
+        "#{to_s}: the local database is not booted"
+    end
+
+    def self.build_from_local(attrs)
+      new(attrs)
     end
 
     def initialize(attributes = {})

--- a/mrblib/model.rb
+++ b/mrblib/model.rb
@@ -98,6 +98,20 @@ module Funicular
     # boot, in the migration runner.
 
     def self.storage(kind, &block)
+      # refresh is a replica-only axis: a local table has no server to
+      # refresh from, and an ephemeral model has no table at all. The
+      # check lives in BOTH declarations because either can come
+      # first in the class body.
+      # The message reads the kind through an unnarrowed alias: inside
+      # the branch below the comparisons leave `kind` with no type
+      # steep will call #inspect on.
+      # @type var declared: Symbol
+      declared = kind
+      if @refresh_mode && (kind == :local || kind == :ephemeral)
+        raise ArgumentError,
+          "storage #{declared.inspect} cannot follow a refresh " \
+          "declaration (refresh applies to replica models only)"
+      end
       # A storage change invalidates cached column metadata.
       @local_columns = nil
       if kind == :local
@@ -192,6 +206,12 @@ module Funicular
     # v1 implements only the default :manual (freshness is explicit fetch);
     # :auto and :live are reserved and rejected at class-definition time.
     def self.refresh(mode)
+      kind = @storage_kind
+      if kind == :local || kind == :ephemeral
+        raise ArgumentError,
+          "refresh does not apply to storage #{storage_kind.inspect} " \
+          "(refresh applies to replica models only)"
+      end
       if mode == :auto
         raise NotImplementedError,
           "refresh :auto is not yet supported (v1 is :manual only)"

--- a/mrblib/model.rb
+++ b/mrblib/model.rb
@@ -356,6 +356,7 @@ module Funicular
         raise Funicular::DB::NoTableError,
           "#{to_s} is storage :ephemeral; it has no local table to watch"
       end
+      Funicular::DB.__ensure_local_database_enabled(:on_change)
       Funicular::DB.subscribe(replica? ? :replica : :local,
                               table_name, &block)
     end

--- a/mrblib/model.rb
+++ b/mrblib/model.rb
@@ -1,3 +1,7 @@
+# On the browser this is picoruby-uri; under CRuby SSR it is the stdlib URI.
+# Both encode_www_form the same way (space -> "+", byte-wise %XX).
+require 'uri'
+
 module Funicular
   class Model
     include Validations
@@ -82,7 +86,12 @@ module Funicular
       endpoint = @endpoints["all"]
       return unless endpoint
 
-      HTTP.get(endpoint["path"]) do |response|
+      path = endpoint["path"]
+      if params && !params.empty?
+        path = "#{path}?#{URI.encode_www_form(params)}"
+      end
+
+      HTTP.get(path) do |response|
         if response.error?
           block.call(nil, response.error_message) if block
         else

--- a/mrblib/model.rb
+++ b/mrblib/model.rb
@@ -64,9 +64,16 @@ module Funicular
 
     def initialize(attributes = {})
       @changed_attributes = {}
-      # Set attributes based on schema
+      # Set attributes based on schema. Key-presence lookups, not `||`:
+      # a string-keyed false (boolean columns) must not fall through to the
+      # symbol key and come back nil.
       self.class.schema.each do |name, config|
-        value = attributes[name] || attributes[name.to_sym]
+        value = if attributes.has_key?(name)
+          attributes[name]
+        else
+          sym = name.to_sym
+          attributes.has_key?(sym) ? attributes[sym] : nil
+        end
         instance_variable_set("@#{name}", value)
       end
     end
@@ -133,9 +140,9 @@ module Funicular
 
       HTTP.delete(path) do |response|
         if response.error?
-          block.call(false, response.error_message) if block
+          block.call(nil, response.error_message) if block
         else
-          block.call(true, response.data) if block
+          block.call(true, nil) if block
         end
       end
     end
@@ -147,32 +154,36 @@ module Funicular
 
       # Validate on the client before the request (mirrors ActiveRecord#save).
       unless valid?
-        block.call(false, errors) if block
+        block.call(nil, errors) if block
         return
       end
-
-      return if @changed_attributes.empty?
 
       json_attrs = @changed_attributes.reject do |name, value|
         schema = self.class.schema[name]
         schema && schema["type"] == "binary"
       end
 
-      return if json_attrs.empty?
+      # Nothing to send (no changes, or binary-only changes that travel via
+      # FileUpload): a successful no-op, reported like any success.
+      if json_attrs.empty?
+        block.call(self, nil) if block
+        return
+      end
 
       endpoint = self.class.endpoints["update"]
       path = endpoint["path"].gsub(":id", @id.to_s)
 
       HTTP.patch(path, json_attrs) do |response|
         if response.error?
-          block.call(false, response.error_message) if block
+          block.call(nil, response.error_message) if block
         else
-          # Update attributes with response data
+          # Apply the server's authoritative row (defaults, callbacks and
+          # normalizations included) before reporting success.
           response.data.each do |key, value|
             instance_variable_set("@#{key}", value)
           end
           @changed_attributes = {}
-          block.call(true, response.data) if block
+          block.call(self, nil) if block
         end
       end
     end

--- a/mrblib/model.rb
+++ b/mrblib/model.rb
@@ -12,6 +12,25 @@ module Funicular
       attr_accessor :schema, :endpoints
     end
 
+    # Every Model subclass registers itself at definition time: the
+    # boot (docs decision 19) needs the full declared set -- local
+    # models for migrations, replica models for the schema-derived
+    # DDL -- without asking the app to enumerate it.
+    def self.inherited(subclass)
+      Funicular::Model.__register_model(subclass)
+    end
+
+    def self.__register_model(subclass)
+      registry = (@registered_models ||= []) # steep:ignore UnannotatedEmptyCollection
+      registry << subclass
+      nil
+    end
+
+    def self.__registered_models
+      models = Funicular::Model.instance_variable_get(:@registered_models)
+      models || []
+    end
+
     def self.load_schema(schema_data)
       @schema = schema_data["attributes"]
       @endpoints = schema_data["endpoints"]

--- a/mrblib/model.rb
+++ b/mrblib/model.rb
@@ -280,6 +280,13 @@ module Funicular
       new(attrs)
     end
 
+    # Called by Relation#delete_all (and, later, the local CRUD writers)
+    # after a framework-managed local write. Once Funicular::DB.boot lands
+    # this delegates to the change-event bus and snapshot scheduling;
+    # until then there is nobody to notify.
+    def self.local_table_changed
+    end
+
     def initialize(attributes = {})
       @changed_attributes = {}
       # Set attributes based on schema. Key-presence lookups, not `||`:

--- a/mrblib/model.rb
+++ b/mrblib/model.rb
@@ -36,6 +36,7 @@ module Funicular
       @endpoints = schema_data["endpoints"]
       # Replica column metadata derives from the schema; drop any cache.
       @local_columns = nil
+      __assert_no_association_conflict(@schema.keys)
 
       # Generate attr_accessor dynamically based on schema
       @schema.each do |name, config|
@@ -230,6 +231,176 @@ module Funicular
       @refresh_mode || :manual
     end
 
+    # ---- associations (docs/local_database.md, "Associations") ----------
+    #
+    # Local-query sugar over the <name>_id convention, and nothing more:
+    #
+    #   post.user      -> User.local.find_by(id: post.user_id)
+    #   post.comments  -> Comment.local.where(post_id: post.id)
+    #
+    # Readers only. The foreign key is assigned the plain way
+    # (post.user_id = user.id), so there is no second, hidden path into
+    # the column and no dirty-tracking special case.
+
+    def self.belongs_to(name, class_name: nil, foreign_key: nil, **rest)
+      __reject_association_options(:belongs_to, name, rest)
+      key = name.to_sym
+      target = (class_name || __camelize(key.to_s)).to_s
+      fk = (foreign_key || "#{key}_id").to_s
+      __register_association(key)
+      define_method(key) do
+        # @type self: Model
+        value = send(fk)
+        if value.nil?
+          # No foreign key, no target row -- and no query to run.
+          nil
+        else
+          self.class.__association_target(key, target).local.find_by(id: value)
+        end
+      end
+      nil
+    end
+
+    def self.has_many(name, class_name: nil, foreign_key: nil, **rest)
+      __reject_association_options(:has_many, name, rest)
+      key = name.to_sym
+      target = (class_name || __camelize(__singularize(key.to_s))).to_s
+      fk = (foreign_key || "#{demodulized_snake_name}_id").to_s
+      __register_association(key)
+      define_method(key) do
+        # @type self: Model
+        # An unsaved parent owns nothing: the empty-array condition
+        # compiles to 1=0, where a nil would read as IS NULL and hand
+        # this record every orphan row in the table.
+        none = [] #: Array[untyped]
+        value = id.nil? ? none : id
+        self.class.__association_target(key, target).local.where(fk => value)
+      end
+      nil
+    end
+
+    def self.__reject_association_options(kind, name, rest)
+      return nil if rest.empty?
+      raise ArgumentError,
+        "#{kind} #{name.to_sym.inspect}: #{rest.keys.inspect} not supported " \
+        "in v1 (only class_name: and foreign_key:; through, eager loading, " \
+        "and polymorphic associations are not implemented)"
+    end
+
+    # The registry exists for two readers: the memoized target class,
+    # and the column/attribute collision guard.
+    def self.__register_association(key)
+      registry = (@associations ||= {}) # steep:ignore UnannotatedEmptyCollection
+      # Last-one-wins would be the same silent shrug as ignoring
+      # through:: the reader defined first is simply gone.
+      if registry.has_key?(key)
+        raise ArgumentError,
+          "#{self}: the association #{key.inspect} is already declared"
+      end
+      __assert_association_name_free(key)
+      registry[key] = { klass: nil }
+      nil
+    end
+
+    # Unlike every other generated accessor, an association reader is
+    # defined unconditionally -- so `has_many :errors` would replace
+    # Validations#errors, and valid? (which calls errors.clear) would
+    # die on a Relation, at neither declaration nor first read.
+    #
+    # The reserved set is Funicular::Model's OWN instance API: a
+    # subclass's column accessors live on the subclass, so they can
+    # never appear here, whenever they are generated. Subtracting
+    # Object's keeps generic names (hash, send) out of it. A method the
+    # model itself hand-wrote is deliberately NOT covered -- catching
+    # it would only work when the `def` precedes the declaration.
+    def self.__assert_association_name_free(key)
+      # One fixed set per process; the framework's API stops changing
+      # once mrblib is loaded, well before any app model declares.
+      reserved = Funicular::Model.instance_variable_get(:@reserved_names) ||
+        Funicular::Model.instance_variable_set(
+          :@reserved_names,
+          Funicular::Model.instance_methods - Object.instance_methods)
+      return nil unless reserved.include?(key)
+      raise ArgumentError,
+        "#{self}: the association #{key.inspect} would replace " \
+        "Funicular::Model##{key}; pick another name"
+    end
+
+    def self.__associations
+      @associations || {}
+    end
+
+    # Resolved lazily, at first read: model files load in sorted filename
+    # order, so `belongs_to :user` in post.rb must not demand the User
+    # constant while user.rb is still unloaded. Only successes are
+    # memoized -- a class that loads later still resolves.
+    def self.__association_target(key, class_name)
+      entry = __associations[key]
+      cached = entry && entry[:klass]
+      return cached if cached
+      klass = __resolve_association_constant(key, class_name)
+      entry[:klass] = klass if entry
+      klass
+    end
+
+    # Convention-derived target names never carry "::", so the walk is
+    # here for class_name: strings alone.
+    def self.__resolve_association_constant(key, class_name)
+      parts = class_name.split("::")
+      # @type var owner: untyped
+      owner = Object
+      i = 0
+      while i < parts.size
+        part = parts[i].to_sym
+        # inherit: false. A class used as a namespace inherits from
+        # Object, so the default lookup would answer "Admin::User" with
+        # the top-level ::User when Admin carries no User of its own --
+        # a typo resolving to a DIFFERENT model, in the one path whose
+        # job is to fail clearly. const_get takes no such argument here
+        # (picoruby: one argument only), but it does not need one: an
+        # own constant wins the lookup, and the check below is what
+        # decides whether there is one.
+        unless owner.is_a?(Module) && owner.const_defined?(part, false)
+          raise NameError, __unresolvable_association(key, class_name)
+        end
+        owner = owner.const_get(part)
+        i += 1
+      end
+      # A module or a plain value has no `.local` behind it; same
+      # verdict, same message.
+      unless owner.is_a?(Class)
+        raise NameError, __unresolvable_association(key, class_name)
+      end
+      owner
+    end
+
+    def self.__unresolvable_association(key, class_name)
+      "#{self}: association #{key.inspect} cannot resolve the model " \
+      "class #{class_name}; declare class_name:, or make sure the model " \
+      "is one the client carries"
+    end
+
+    # A column (or REST attribute) named like a declared association:
+    # the association reader would shadow it silently while the
+    # generated writer kept writing the column. Raised where the two
+    # first meet -- the accessor generation, which is the first instance
+    # path on local models and the schema load on the others.
+    def self.__assert_no_association_conflict(names)
+      registry = @associations
+      return nil unless registry
+      i = 0
+      while i < names.size
+        name = names[i]
+        if registry.has_key?(name.to_sym)
+          raise ArgumentError,
+            "#{self}: the association #{name.to_sym.inspect} and the " \
+            "attribute of the same name would shadow each other; rename one"
+        end
+        i += 1
+      end
+      nil
+    end
+
     # Reader and override in one: `table_name` returns the table name
     # (naive pluralization of the class name: +s, y->ies),
     # `table_name "things"` overrides it.
@@ -242,6 +413,12 @@ module Funicular
     end
 
     def self.derive_table_name
+      __pluralize(demodulized_snake_name)
+    end
+
+    # "Admin::BlogPost" -> "blog_post". The singular half of
+    # derive_table_name; has_many reuses it for the foreign key.
+    def self.demodulized_snake_name
       parts = to_s.split("::")
       base = parts[parts.size - 1] || ""
       snake = ""
@@ -257,11 +434,43 @@ module Funicular
         end
         i += 1
       end
-      if snake.end_with?("y")
-        "#{snake[0, snake.length - 1]}ies"
+      snake
+    end
+
+    def self.__pluralize(name)
+      if name.end_with?("y")
+        "#{name[0, name.length - 1]}ies"
       else
-        "#{snake}s"
+        "#{name}s"
       end
+    end
+
+    # The exact inverse of __pluralize. Irregular names are the caller's
+    # job, through class_name: -- the same deal table_name offers.
+    def self.__singularize(name)
+      if name.end_with?("ies")
+        "#{name[0, name.length - 3]}y"
+      elsif name.end_with?("s")
+        name[0, name.length - 1].to_s
+      else
+        name
+      end
+    end
+
+    def self.__camelize(name)
+      parts = name.split("_")
+      out = ""
+      i = 0
+      while i < parts.size
+        part = parts[i]
+        head = part[0]
+        if head
+          out += head.upcase
+          out += part[1, part.length - 1].to_s
+        end
+        i += 1
+      end
+      out
     end
 
     # The marked local/cache view (source-of-truth contract): a Relation
@@ -420,6 +629,7 @@ module Funicular
     def self.define_local_accessors(columns)
       existing = instance_methods
       names = columns.keys
+      __assert_no_association_conflict(names)
       names_size = names.size
       i = 0
       while i < names_size

--- a/mrblib/model.rb
+++ b/mrblib/model.rb
@@ -281,19 +281,34 @@ module Funicular
       derived
     end
 
-    # The handle local queries run against. Arrives with Funicular::DB.boot
-    # (a later change); until then every materializer fails loud.
+    # The handle local queries run against: the guarded local proxy
+    # installed by Funicular::DB.boot. Before the boot every
+    # materializer fails loud (UnavailableError -- SSR included), and
+    # a SchemaTooNew lockdown raises here, the funnel every
+    # model-level local operation passes through.
     def self.local_db
-      raise Funicular::DB::UnavailableError,
-        "#{to_s}: the local database is not booted"
+      Funicular::DB.__model_local_db(self)
     end
 
-    # The handle REST write-through applies replica rows to. DB.boot (a
-    # later change) overrides this with the guarded replica handle --
-    # raw connections are never exposed globally. While it returns nil,
-    # write-through stays inert and REST works standalone.
+    # The handle REST write-through applies replica rows to: the
+    # guarded replica proxy from DB.boot -- raw connections are never
+    # exposed globally. While it is nil (not booted), write-through
+    # stays inert and REST works standalone.
     def self.replica_db
-      nil
+      Funicular::DB.__model_replica_db
+    end
+
+    # Drop this table and rebuild it from its migrate baseline (docs
+    # decision 7): the programmatic reset for one client-only table.
+    # Writer (or volatile) tab only; lifts a SchemaTooNew lockdown
+    # when the whole declared set passes again afterwards.
+    def self.reset_local
+      unless local?
+        raise Funicular::DB::NoTableError,
+          "#{to_s} is not storage :local; reset_local rebuilds " \
+          "client-only tables"
+      end
+      Funicular::DB.reset_local_table(self)
     end
 
     def self.build_from_local(attrs)

--- a/mrblib/model.rb
+++ b/mrblib/model.rb
@@ -79,6 +79,8 @@ module Funicular
     # boot, in the migration runner.
 
     def self.storage(kind, &block)
+      # A storage change invalidates cached column metadata.
+      @local_columns = nil
       if kind == :local
         unless block
           raise ArgumentError,
@@ -237,19 +239,20 @@ module Funicular
 
     # Column name -> declared type. For replica models this derives from
     # the server schema: binary attributes never reach the replica and the
-    # id type follows the server. Local models get their columns from the
-    # migrate fold once the migration runner lands.
+    # id type follows the server. Local models fold their migrate blocks
+    # (pure metadata; works before boot).
     def self.local_columns
       if ephemeral?
         raise Funicular::DB::NoTableError,
           "#{to_s} is storage :ephemeral; it has no local table"
       end
-      if local?
-        raise Funicular::DB::UnavailableError,
-          "#{to_s}: local tables are not built yet (migrations run at DB boot)"
-      end
       cols = @local_columns
       return cols if cols
+      @local_columns = local? ? Funicular::DB.fold_local_columns(self)
+                              : derive_replica_columns
+    end
+
+    def self.derive_replica_columns
       sch = @schema
       unless sch
         raise Funicular::DB::UnavailableError,
@@ -266,7 +269,7 @@ module Funicular
         derived[attr_name] = type unless type == :binary
         i += 1
       end
-      @local_columns = derived
+      derived
     end
 
     # The handle local queries run against. Arrives with Funicular::DB.boot

--- a/mrblib/model.rb
+++ b/mrblib/model.rb
@@ -300,11 +300,11 @@ module Funicular
       derived
     end
 
-    # The handle local queries run against: the guarded local proxy
-    # installed by Funicular::DB.boot. Before the boot every
-    # materializer fails loud (UnavailableError -- SSR included), and
-    # a SchemaTooNew lockdown raises here, the funnel every
-    # model-level local operation passes through.
+    # The handle local queries run against: the guarded proxy for this
+    # model's storage role, installed by Funicular::DB.boot. Before the boot
+    # every materializer fails loud (UnavailableError -- SSR included).
+    # Storage-local models also encounter the SchemaTooNew lockdown here,
+    # the funnel every model-level local operation passes through.
     def self.local_db
       Funicular::DB.__model_local_db(self)
     end
@@ -463,6 +463,16 @@ module Funicular
     # models"): returns the instance -- persisted with its assigned id,
     # or unsaved (id nil) with errors when validation fails.
     def self.local_create(attrs = {})
+      unless local?
+        if replica?
+          raise Funicular::DB::ReplicaWriteError,
+            "#{to_s}.local_create is not available on replica models; " \
+            "the server owns replica rows (use #{to_s}.create)"
+        end
+        raise Funicular::DB::NoTableError,
+          "#{to_s} has no local table; local_create is available only on " \
+          "storage :local models"
+      end
       record = new(attrs)
       return record unless record.valid?
       record.__local_insert

--- a/mrblib/model.rb
+++ b/mrblib/model.rb
@@ -248,8 +248,17 @@ module Funicular
       end
       cols = @local_columns
       return cols if cols
-      @local_columns = local? ? Funicular::DB.fold_local_columns(self)
-                              : derive_replica_columns
+      if local?
+        # The fold runs HERE, lazily, not at class-definition time: the
+        # docs promise migrate blocks are only recorded at class eval.
+        # Any instance path (new/create/find) lands here first, so the
+        # accessors exist before they can be called.
+        folded = Funicular::DB.fold_local_columns(self)
+        define_local_accessors(folded)
+        @local_columns = folded
+      else
+        @local_columns = derive_replica_columns
+      end
     end
 
     def self.derive_replica_columns
@@ -280,33 +289,226 @@ module Funicular
     end
 
     def self.build_from_local(attrs)
-      new(attrs)
+      record = new({})
+      record.__hydrate_local(attrs)
+      record
     end
 
-    # Called by Relation#delete_all (and, later, the local CRUD writers)
-    # after a framework-managed local write. Once Funicular::DB.boot lands
-    # this delegates to the change-event bus and snapshot scheduling;
-    # until then there is nobody to notify.
+    # Called by Relation#delete_all and the local CRUD writers after a
+    # framework-managed local write. Once Funicular::DB.boot lands this
+    # delegates to the change-event bus and snapshot scheduling; until
+    # then there is nobody to notify.
     def self.local_table_changed
+    end
+
+    # Generate attribute readers/writers from the migrate fold, mirroring
+    # what load_schema does from the REST schema. Methods the model class
+    # ALREADY defines (a hand-written reader like `def title`) are
+    # preserved: only the missing half of each accessor pair is
+    # generated. The snapshot is taken before anything is generated, so
+    # our own accessors never mask a later regeneration.
+    def self.define_local_accessors(columns)
+      existing = instance_methods
+      names = columns.keys
+      names_size = names.size
+      i = 0
+      while i < names_size
+        name = names[i]
+        # One method call per column: the writer's closure must capture
+        # its own `name` binding. Creating it inside this while body
+        # would share ONE variable across every writer (unlike an each
+        # block parameter), leaving all of them bound to the last column.
+        define_local_accessor(name, existing) unless name == "id"
+        i += 1
+      end
+    end
+
+    # Writers track dirtiness against @local_baseline -- the values as
+    # last persisted/loaded -- not against the previous assignment, so
+    # assigning a value BACK cancels the change and the documented
+    # "update with no actual changes is a no-op" holds across
+    # intermediate assignments. A hand-written writer is kept and
+    # WRAPPED: it runs first, then the resulting ivar (its normalized
+    # value) feeds the same tracking -- otherwise custom writers would
+    # silently opt out of dirty tracking and update would no-op.
+    def self.define_local_accessor(name, existing)
+      attr_reader name.to_sym unless existing.include?(name.to_sym)
+      custom = "__custom_#{name}="
+      return if existing.include?(custom.to_sym)
+      if existing.include?("#{name}=".to_sym)
+        alias_method custom, "#{name}="
+        define_method("#{name}=") do |value|
+          # @type self: Model
+          old = instance_variable_get("@#{name}")
+          send(custom, value)
+          __track_local_change(name, instance_variable_get("@#{name}"), old)
+        end
+      else
+        define_method("#{name}=") do |value|
+          # @type self: Model
+          old = instance_variable_get("@#{name}")
+          instance_variable_set("@#{name}", value)
+          __track_local_change(name, value, old)
+        end
+      end
+    end
+
+    # Merge bare keywords over the positional attrs hash so a keyword
+    # wins per ATTRIBUTE, not per literal key: initialize reads string
+    # keys first, so the keyword's string-keyed twin must go away too.
+    def self.merge_keyword_attrs(attrs, kw)
+      return attrs if kw.empty?
+      merged = attrs.merge(kw)
+      keys = kw.keys
+      keys_size = keys.size
+      i = 0
+      while i < keys_size
+        merged.delete(keys[i].to_s)
+        i += 1
+      end
+      merged
+    end
+
+    # Synchronous, validated create for storage :local (docs, "Local
+    # models"): returns the instance -- persisted with its assigned id,
+    # or unsaved (id nil) with errors when validation fails.
+    def self.local_create(attrs = {})
+      record = new(attrs)
+      return record unless record.valid?
+      record.__local_insert
+      record
+    end
+
+    # ---- bare-class alias (source-of-truth contract) ---------------------
+    # On storage :local models the bare class IS the local view, so the
+    # ActiveRecord-style query methods hang off it directly. On other
+    # storage kinds they do not exist -- the error points at `.local`.
+
+    def self.local_query(method_name)
+      unless local?
+        raise NoMethodError,
+          "#{to_s}.#{method_name} only exists on storage :local models; " \
+          "the marked local view is #{to_s}.local.#{method_name}"
+      end
+      local
+    end
+
+    def self.where(conditions = nil, *binds)
+      local_query("where").where(conditions, *binds)
+    end
+
+    def self.order(*args)
+      local_query("order").order(*args)
+    end
+
+    def self.limit(n)
+      local_query("limit").limit(n)
+    end
+
+    def self.offset(n)
+      local_query("offset").offset(n)
+    end
+
+    def self.count
+      local_query("count").count
+    end
+
+    def self.first
+      local_query("first").first
+    end
+
+    def self.exists?
+      local_query("exists?").exists?
+    end
+
+    def self.find_by(conditions)
+      local_query("find_by").find_by(conditions)
+    end
+
+    def self.delete_all
+      local_query("delete_all").delete_all
     end
 
     def initialize(attributes = {})
       @changed_attributes = {}
-      # Set attributes based on schema. Key-presence lookups, not `||`:
-      # a string-keyed false (boolean columns) must not fall through to the
-      # symbol key and come back nil.
-      self.class.schema.each do |name, config|
-        value = if attributes.has_key?(name)
-          attributes[name]
+      # Attribute names come from the REST schema, or from the migrate
+      # fold on storage :local models (which have no REST schema).
+      # Key-presence lookups, not `||`: a string-keyed false (boolean
+      # columns) must not fall through to the symbol key and come back
+      # nil.
+      klass = self.class
+      is_local = klass.local?
+      names = is_local ? klass.local_columns.keys : klass.schema.keys
+      # Which attributes were EXPLICITLY given (even as nil) is recorded:
+      # the local INSERT path must distinguish "omitted, apply the SQL
+      # DEFAULT" from "explicit nil, bind NULL".
+      # @type var provided: Hash[String, bool]
+      provided = {}
+      names_size = names.size
+      i = 0
+      while i < names_size
+        name = names[i]
+        sym = name.to_sym
+        if attributes.has_key?(name)
+          value = attributes[name]
+          provided[name] = true
+        elsif attributes.has_key?(sym)
+          value = attributes[sym]
+          provided[name] = true
         else
-          sym = name.to_sym
-          attributes.has_key?(sym) ? attributes[sym] : nil
+          value = nil
         end
-        instance_variable_set("@#{name}", value)
+        if is_local && provided[name] && !(name == "id")
+          # User input goes through the writer, so a hand-written
+          # normalizing writer applies on create exactly as on update.
+          # Hydration from the database does NOT come through here (see
+          # build_from_local / __hydrate_local): stored values are
+          # already normalized.
+          send("#{name}=", value)
+        else
+          instance_variable_set("@#{name}", value)
+        end
+        i += 1
+      end
+      @provided_attributes = provided
+    end
+
+    # A record not yet in the local table (docs: "a new record is one
+    # whose id is nil; create assigns the id from the inserted row").
+    def new_record?
+      @id.nil?
+    end
+
+    # Shared dirty tracking behind every generated/wrapped local writer.
+    def __track_local_change(name, value, old)
+      @changed_attributes ||= {} # steep:ignore UnannotatedEmptyCollection
+      baseline = @local_baseline
+      if baseline && baseline.has_key?(name)
+        if value == baseline[name]
+          @changed_attributes.delete(name)
+        else
+          @changed_attributes[name] = value
+        end
+      elsif !(value == old)
+        # No baseline yet (a hand-built record): previous-value compare.
+        @changed_attributes[name] = value
       end
     end
 
     def self.all(params = {}, &block)
+      if local?
+        # The bare class is an alias for .local: Draft.all IS the
+        # whole-table Relation, and there is no REST side to call.
+        if block
+          raise ArgumentError,
+            "#{to_s}.all takes no block on storage :local (no REST side)"
+        end
+        unless params.nil? || params.empty?
+          raise ArgumentError,
+            "#{to_s}.all takes no params on storage :local (no REST side)"
+        end
+        return local
+      end
       endpoint = @endpoints["all"]
       return unless endpoint
 
@@ -326,6 +528,13 @@ module Funicular
     end
 
     def self.find(id = nil, endpoint_name: "find", model_class: nil, &block)
+      if local?
+        if block
+          raise ArgumentError,
+            "#{to_s}.find is synchronous on storage :local and takes no block"
+        end
+        return local.find(id)
+      end
       endpoint = @endpoints[endpoint_name]
       return unless endpoint
 
@@ -343,7 +552,21 @@ module Funicular
       end
     end
 
-    def self.create(attrs, model_class: nil, &block)
+    # attrs may be a braced Hash (arrives positionally), bare keywords,
+    # or both -- keywords are merged in and win on the same key. The
+    # model_class: keyword is reserved for REST models only; on
+    # storage :local it is an ordinary attribute, so a column may be
+    # named model_class.
+    def self.create(attrs = {}, **kw, &block)
+      if local?
+        if block
+          raise ArgumentError,
+            "#{to_s}.create is synchronous on storage :local and takes no block"
+        end
+        return local_create(merge_keyword_attrs(attrs, kw))
+      end
+      model_class = kw.delete(:model_class)
+      attrs = merge_keyword_attrs(attrs, kw)
       endpoint = @endpoints["create"]
       return unless endpoint
 
@@ -366,6 +589,13 @@ module Funicular
     end
 
     def self.destroy(id = nil, &block)
+      if local?
+        if block
+          raise ArgumentError,
+            "#{to_s}.destroy is synchronous on storage :local and takes no block"
+        end
+        return local.find(id).destroy
+      end
       endpoint = @endpoints["destroy"]
       return unless endpoint
 
@@ -381,6 +611,13 @@ module Funicular
     end
 
     def update(attrs = nil, &block)
+      if self.class.local?
+        if block
+          raise ArgumentError,
+            "update is synchronous on storage :local and takes no block"
+        end
+        return __local_update(attrs)
+      end
       if attrs
         attrs.each { |k, v| send("#{k}=", v) }
       end
@@ -422,10 +659,26 @@ module Funicular
     end
 
     def destroy(&block)
+      if self.class.local?
+        if block
+          raise ArgumentError,
+            "destroy is synchronous on storage :local and takes no block"
+        end
+        return __local_destroy
+      end
       self.class.destroy(@id, &block)
     end
 
     def reload(&block)
+      if self.class.local?
+        if block
+          raise ArgumentError,
+            "reload is synchronous on storage :local and takes no block"
+        end
+        __sync_from_row
+        @changed_attributes = {}
+        return self
+      end
       self.class.find(@id) do |instance, error|
         if instance
           instance.instance_variables.each do |var|
@@ -435,6 +688,249 @@ module Funicular
         end
         block.call(instance, error) if block
       end
+    end
+
+    # ---- storage :local write internals (framework use) ------------------
+    # All three writers notify local_table_changed, the hook the change-
+    # event bus and snapshot scheduling attach to at boot. SQLite
+    # constraint violations escape as SQLite3::Exception on purpose: they
+    # are bugs, not user-facing validation (docs, "Local models").
+
+    # INSERT this (validated) record. Columns that were never given (nil
+    # and not explicitly provided) are left out so SQL DEFAULTs apply; an
+    # EXPLICIT nil binds NULL and answers to NOT NULL like any write. The
+    # row is read back afterwards, so the instance reflects what the
+    # table actually stores.
+    def __local_insert
+      klass = self.class
+      columns = klass.local_columns
+      codec = Funicular::DB::Codec
+      now = Time.now
+      if columns.has_key?("created_at") && instance_variable_get("@created_at").nil?
+        instance_variable_set("@created_at", now)
+      end
+      if columns.has_key?("updated_at") && instance_variable_get("@updated_at").nil?
+        instance_variable_set("@updated_at", now)
+      end
+      names = columns.keys
+      # @type var cols: Array[String]
+      cols = []
+      # @type var marks: Array[String]
+      marks = []
+      # @type var binds: Array[untyped]
+      binds = []
+      provided = @provided_attributes
+      names_size = names.size
+      i = 0
+      while i < names_size
+        name = names[i]
+        unless name == "id"
+          value = instance_variable_get("@#{name}")
+          if !value.nil? || (provided && provided[name])
+            cols << "\"#{name}\""
+            marks << "?"
+            binds << codec.encode(columns[name], value)
+          end
+        end
+        i += 1
+      end
+      db = klass.local_db
+      # RETURNING makes the INSERT itself hand back the id. A separate
+      # SELECT last_insert_rowid() would read connection-global state:
+      # another Task inserting into the same database between the two
+      # statements would overwrite it, and this instance would adopt the
+      # other Task's id (and then sync from the other Task's row).
+      sql = if cols.empty?
+        "INSERT INTO \"#{klass.table_name}\" DEFAULT VALUES RETURNING \"id\""
+      else
+        "INSERT INTO \"#{klass.table_name}\" (#{cols.join(", ")}) " \
+          "VALUES (#{marks.join(", ")}) RETURNING \"id\""
+      end
+      row = db.execute(sql, binds)[0]
+      @id = row.is_a?(Hash) ? row.values[0] : row[0]
+      __sync_from_row
+      @changed_attributes = {}
+      klass.local_table_changed
+      self
+    end
+
+    # Validated, synchronous update: true/false. An update with no actual
+    # changes is a no-op that returns true and does not touch updated_at.
+    def __local_update(attrs)
+      if attrs
+        keys = attrs.keys
+        keys_size = keys.size
+        i = 0
+        while i < keys_size
+          send("#{keys[i]}=", attrs[keys[i]])
+          i += 1
+        end
+      end
+      if new_record?
+        raise ArgumentError,
+          "cannot update a record that is not in the local table; use create"
+      end
+      return false unless valid?
+      changed = @changed_attributes
+      return true if changed.empty?
+      klass = self.class
+      columns = klass.local_columns
+      codec = Funicular::DB::Codec
+      # The updated_at stamp is a FRAMEWORK change: remember what it
+      # replaced so a failed UPDATE can put it back -- otherwise a later,
+      # genuinely change-free update would write (and notify) for the
+      # leftover stamp alone. The USER's changes stay put on failure.
+      stamped = false
+      prev_stamp_ivar = nil
+      prev_stamp_changed = nil
+      had_stamp_changed = false
+      # The rescue below must already be armed while the stamp is set and
+      # the binds are encoded: Codec.encode raises ArgumentError on a
+      # malformed datetime, and that failure has to revert the stamp too.
+      begin
+        if columns.has_key?("updated_at")
+          stamped = true
+          prev_stamp_ivar = instance_variable_get("@updated_at")
+          had_stamp_changed = changed.has_key?("updated_at")
+          prev_stamp_changed = changed["updated_at"]
+          stamp = Time.now
+          instance_variable_set("@updated_at", stamp)
+          changed["updated_at"] = stamp
+        end
+        # @type var sets: Array[String]
+        sets = []
+        # @type var binds: Array[untyped]
+        binds = []
+        names = changed.keys
+        names_size = names.size
+        i = 0
+        while i < names_size
+          name = names[i]
+          sets << "\"#{name}\" = ?"
+          binds << codec.encode(columns[name], changed[name])
+          i += 1
+        end
+        binds << @id
+        # RETURNING answers "did the row exist?" inside the one UPDATE:
+        # checking afterwards (even via the read-back below) would race a
+        # concurrent delete + id-reusing re-create between the statements.
+        updated = klass.local_db.execute(
+          "UPDATE \"#{klass.table_name}\" SET #{sets.join(", ")} " \
+            "WHERE \"id\" = ? RETURNING \"id\"", binds)
+        if updated.empty?
+          raise Funicular::RecordNotFound,
+            "Couldn't find #{klass.to_s} with id=#{@id}"
+        end
+        # Re-read the row: the codec may have normalized what was written
+        # (offset datetime strings fold into UTC, fractional seconds
+        # truncate) and only the table knows the final values -- the
+        # instance and the dirty-tracking baseline must reflect them, so a
+        # re-fetch returns the same types this instance now carries.
+        __sync_from_row
+      rescue => e
+        if stamped
+          instance_variable_set("@updated_at", prev_stamp_ivar)
+          if had_stamp_changed
+            changed["updated_at"] = prev_stamp_changed
+          else
+            changed.delete("updated_at")
+          end
+        end
+        # Explicit re-raise: a bare `raise` would not re-raise on the
+        # mruby VM.
+        raise e
+      end
+      @changed_attributes = {}
+      klass.local_table_changed
+      true
+    end
+
+    def __local_destroy
+      if new_record?
+        raise ArgumentError,
+          "cannot destroy a record that is not in the local table"
+      end
+      klass = self.class
+      # RETURNING makes the DELETE itself report what it removed. A
+      # separate SELECT changes() would read connection-global state that
+      # another Task's write between the two statements overwrites --
+      # dropping (or fabricating) the change notification.
+      rows = klass.local_db.execute(
+        "DELETE FROM \"#{klass.table_name}\" WHERE \"id\" = ? " \
+          "RETURNING \"id\"", [@id])
+      klass.local_table_changed unless rows.empty?
+      true
+    end
+
+    # Re-read this record's row and decode it into the instance.
+    def __sync_from_row
+      klass = self.class
+      columns = klass.local_columns
+      codec = Funicular::DB::Codec
+      names = columns.keys
+      # @type var quoted: Array[String]
+      quoted = []
+      names_size = names.size
+      i = 0
+      while i < names_size
+        quoted << "\"#{names[i]}\""
+        i += 1
+      end
+      row = klass.local_db.execute(
+        "SELECT #{quoted.join(", ")} FROM \"#{klass.table_name}\" " \
+          "WHERE \"id\" = ?", [@id])[0]
+      unless row
+        # The row is gone (another instance's destroy, delete_all, ...):
+        # fail loud instead of keeping stale attributes. On the update
+        # path this fires BEFORE changes are cleared and before
+        # local_table_changed, so a 0-row UPDATE neither discards the
+        # pending changes nor notifies.
+        raise Funicular::RecordNotFound,
+          "Couldn't find #{klass.to_s} with id=#{@id}"
+      end
+      # @type var baseline: Hash[String, untyped]
+      baseline = {}
+      i = 0
+      while i < names_size
+        name = names[i]
+        raw = row.is_a?(Hash) ? row[name] : row[i]
+        decoded = codec.decode(columns[name], raw)
+        instance_variable_set("@#{name}", decoded)
+        baseline[name] = decoded
+        i += 1
+      end
+      @local_baseline = baseline
+    end
+
+    # Hydrate this record from an already-decoded row: ivars are set
+    # DIRECTLY (stored values are normalized; user writers must not run
+    # again), the row becomes the dirty-tracking baseline, and nothing
+    # is dirty.
+    def __hydrate_local(attrs)
+      keys = attrs.keys
+      keys_size = keys.size
+      i = 0
+      while i < keys_size
+        instance_variable_set("@#{keys[i]}", attrs[keys[i]])
+        i += 1
+      end
+      __set_local_baseline(attrs)
+      @changed_attributes = {}
+    end
+
+    # Install the dirty-tracking baseline (see define_local_accessor).
+    # Framework use: called with the decoded row a record was built from.
+    def __set_local_baseline(attrs)
+      # @type var baseline: Hash[String, untyped]
+      baseline = {}
+      keys = attrs.keys
+      keys_size = keys.size
+      i = 0
+      while i < keys_size
+        baseline[keys[i].to_s] = attrs[keys[i]]
+        i += 1
+      end
+      @local_baseline = baseline
     end
   end
 end

--- a/mrblib/relation.rb
+++ b/mrblib/relation.rb
@@ -180,10 +180,13 @@ module Funicular
         raise ArgumentError,
           "delete_all does not support order/limit/offset"
       end
-      db = @model.local_db
-      db.execute("DELETE FROM #{quoted_table}#{where_clause}", @where_binds)
-      row = db.execute("SELECT changes()")[0]
-      count = row.is_a?(Hash) ? row.values[0] : row[0]
+      # RETURNING counts the deletions inside the one statement; reading
+      # SELECT changes() afterwards would race other Tasks writing on the
+      # same connection between the two calls.
+      rows = @model.local_db.execute(
+        "DELETE FROM #{quoted_table}#{where_clause} RETURNING \"id\"",
+        @where_binds)
+      count = rows.size
       # Framework-managed writes must notify (docs, "Querying"); a delete
       # that removed nothing changed nothing.
       @model.local_table_changed if 0 < count

--- a/mrblib/relation.rb
+++ b/mrblib/relation.rb
@@ -1,0 +1,325 @@
+# A lazy, chainable query over one local table (docs/local_database.md,
+# "Querying"). Chain builders (where/order/limit/offset) each return a NEW
+# Relation; SQL executes once, in a materializer.
+#
+# The `model` handed to the constructor is the query's metadata + row
+# factory. Relation calls exactly these methods on it:
+#
+#   table_name       -> String
+#   local_columns    -> Hash[String => Symbol]  (column name -> declared type)
+#   local_db         -> handle responding to execute(sql, binds) -> rows
+#   replica?         -> bool (delete_all guard)
+#   build_from_local -> (Hash) -> model instance (attrs already decoded)
+#
+# Identifiers in hash conditions and order() are validated against
+# local_columns and double-quoted; values cross into SQL through
+# Funicular::DB::Codec. Raw SQL fragments pass through untouched, their
+# binds encoded by value (Codec.encode_bind).
+
+module Funicular
+  class Relation
+    # The trailing arguments are internal: chain builders use them to spawn
+    # derived relations. Application code passes only `model`.
+    def initialize(model, where_sql = [], where_binds = [], order_sql = [],
+                   limit = nil, offset = nil)
+      @model = model
+      @where_sql = where_sql
+      @where_binds = where_binds
+      @order_sql = order_sql
+      @limit = limit
+      @offset = offset
+    end
+
+    # ---- chain builders --------------------------------------------------
+
+    # where(title: "x")              equality (nil -> IS NULL)
+    # where(id: [1, 2])              IN (empty array -> WHERE 1=0)
+    # where(id: 1..9)                BETWEEN (exclusive end -> >= AND <)
+    # where("title LIKE ?", "a%")    raw fragment with placeholders
+    # Multiple where calls AND together.
+    def where(conditions = nil, *binds)
+      w = @where_sql.dup
+      b = @where_binds.dup
+      if conditions.is_a?(Hash)
+        keys = conditions.keys
+        i = 0
+        while i < keys.size
+          append_condition(w, b, keys[i], conditions[keys[i]])
+          i += 1
+        end
+      elsif conditions.is_a?(String)
+        w << "(#{conditions})"
+        i = 0
+        while i < binds.size
+          b << Funicular::DB::Codec.encode_bind(binds[i])
+          i += 1
+        end
+      else
+        raise ArgumentError,
+          "where expects a Hash or a SQL fragment String, got #{conditions.inspect}"
+      end
+      Relation.new(@model, w, b, @order_sql, @limit, @offset)
+    end
+
+    # order(:created_at)                 ASC
+    # order(created_at: :desc)
+    # order(:pinned, created_at: :desc)  multiple keys
+    def order(*args)
+      if args.empty?
+        raise ArgumentError, "order requires at least one column"
+      end
+      o = @order_sql.dup
+      i = 0
+      while i < args.size
+        arg = args[i]
+        if arg.is_a?(Hash)
+          keys = arg.keys
+          j = 0
+          while j < keys.size
+            o << order_term(keys[j], arg[keys[j]])
+            j += 1
+          end
+        else
+          o << order_term(arg, :asc)
+        end
+        i += 1
+      end
+      Relation.new(@model, @where_sql, @where_binds, o, @limit, @offset)
+    end
+
+    def limit(n)
+      Relation.new(@model, @where_sql, @where_binds, @order_sql,
+                   slice_arg(n, "limit"), @offset)
+    end
+
+    def offset(n)
+      Relation.new(@model, @where_sql, @where_binds, @order_sql,
+                   @limit, slice_arg(n, "offset"))
+    end
+
+    # ---- materializers ---------------------------------------------------
+
+    def to_a
+      rows = @model.local_db.execute(select_sql, @where_binds)
+      cols = @model.local_columns.keys
+      # @type var out: Array[untyped]
+      out = []
+      i = 0
+      while i < rows.size
+        out << @model.build_from_local(decode_row(cols, rows[i]))
+        i += 1
+      end
+      out
+    end
+
+    def each
+      list = to_a
+      i = 0
+      while i < list.size
+        yield list[i]
+        i += 1
+      end
+      list
+    end
+
+    # Instance or nil. Narrows the window to one row (never widens: a
+    # relation already limited to 0 stays empty).
+    def first
+      lim = @limit
+      lim = (lim.nil? || 1 <= lim) ? 1 : lim
+      Relation.new(@model, @where_sql, @where_binds, @order_sql,
+                   lim, @offset).to_a[0]
+    end
+
+    # SELECT COUNT(*); on a limited/offset relation it counts the window
+    # (COUNT over a subquery), matching ActiveRecord.
+    def count
+      sql = if @limit || @offset
+        "SELECT COUNT(*) FROM (#{select_sql})"
+      else
+        "SELECT COUNT(*) FROM #{quoted_table}#{where_clause}"
+      end
+      single_value(sql)
+    end
+
+    def exists?
+      if @limit || @offset
+        0 < count
+      else
+        sql = "SELECT 1 FROM #{quoted_table}#{where_clause} LIMIT 1"
+        !@model.local_db.execute(sql, @where_binds).empty?
+      end
+    end
+
+    def find(id)
+      record = find_by(id: id)
+      unless record
+        raise Funicular::RecordNotFound,
+          "Couldn't find #{model_label} with id=#{id}"
+      end
+      record
+    end
+
+    def find_by(conditions)
+      where(conditions).first
+    end
+
+    # Bulk delete, `storage :local` models only; returns the number of
+    # deleted rows. Raises on a relation carrying order/limit/offset (say
+    # what you mean with a plain condition).
+    def delete_all
+      if @model.replica?
+        raise Funicular::DB::ReplicaWriteError,
+          "delete_all is not available on replica models; the server owns " \
+          "replica rows (deletions reach the replica through destroy)"
+      end
+      if @limit || @offset || !@order_sql.empty?
+        raise ArgumentError,
+          "delete_all does not support order/limit/offset"
+      end
+      db = @model.local_db
+      db.execute("DELETE FROM #{quoted_table}#{where_clause}", @where_binds)
+      row = db.execute("SELECT changes()")[0]
+      row.is_a?(Hash) ? row.values[0] : row[0]
+    end
+
+    # The SELECT this relation will run (debugging aid; binds not inlined).
+    def to_sql
+      select_sql
+    end
+
+    # ---- internal --------------------------------------------------------
+
+    private
+
+    def append_condition(w, b, col, value)
+      name = validate_column(col)
+      q = quote(name)
+      type = @model.local_columns[name]
+      codec = Funicular::DB::Codec
+      if value.nil?
+        w << "#{q} IS NULL"
+      elsif value.is_a?(Array)
+        if value.empty?
+          w << "1=0"
+        else
+          # @type var marks: Array[String]
+          marks = []
+          i = 0
+          while i < value.size
+            marks << "?"
+            b << codec.encode(type, value[i])
+            i += 1
+          end
+          w << "#{q} IN (#{marks.join(", ")})"
+        end
+      elsif value.is_a?(Range)
+        b << codec.encode(type, value.begin)
+        b << codec.encode(type, value.end)
+        if value.exclude_end?
+          w << "(#{q} >= ? AND #{q} < ?)"
+        else
+          w << "#{q} BETWEEN ? AND ?"
+        end
+      else
+        w << "#{q} = ?"
+        b << codec.encode(type, value)
+      end
+    end
+
+    def order_term(col, dir)
+      d = dir.to_s.downcase
+      unless d == "asc" || d == "desc"
+        raise ArgumentError,
+          "order direction must be :asc or :desc, got #{dir.inspect}"
+      end
+      "#{quote(validate_column(col))} #{d == "asc" ? "ASC" : "DESC"}"
+    end
+
+    def validate_column(col)
+      name = col.to_s
+      unless @model.local_columns.has_key?(name)
+        raise ArgumentError,
+          "unknown column #{name.inspect} for table \"#{@model.table_name}\""
+      end
+      name
+    end
+
+    def quote(name)
+      "\"#{name}\""
+    end
+
+    def quoted_table
+      quote(@model.table_name)
+    end
+
+    def select_sql
+      cols = @model.local_columns.keys
+      # @type var quoted: Array[String]
+      quoted = []
+      i = 0
+      while i < cols.size
+        quoted << quote(cols[i])
+        i += 1
+      end
+      "SELECT #{quoted.join(", ")} FROM #{quoted_table}" \
+        "#{where_clause}#{order_clause}#{slice_clause}"
+    end
+
+    def where_clause
+      w = @where_sql
+      w.empty? ? "" : " WHERE #{w.join(" AND ")}"
+    end
+
+    def order_clause
+      o = @order_sql
+      o.empty? ? "" : " ORDER BY #{o.join(", ")}"
+    end
+
+    # LIMIT -1 OFFSET n is how SQLite spells offset-without-limit.
+    def slice_clause
+      lim = @limit
+      off = @offset
+      if lim
+        off ? " LIMIT #{lim} OFFSET #{off}" : " LIMIT #{lim}"
+      elsif off
+        " LIMIT -1 OFFSET #{off}"
+      else
+        ""
+      end
+    end
+
+    def slice_arg(n, label)
+      return nil if n.nil?
+      unless n.is_a?(Integer) && 0 <= n
+        raise ArgumentError, "#{label} must be a non-negative Integer, got #{n.inspect}"
+      end
+      n
+    end
+
+    def decode_row(cols, row)
+      codec = Funicular::DB::Codec
+      columns = @model.local_columns
+      # @type var attrs: Hash[String, untyped]
+      attrs = {}
+      i = 0
+      while i < cols.size
+        name = cols[i]
+        raw = row.is_a?(Hash) ? row[name] : row[i]
+        attrs[name] = codec.decode(columns[name], raw)
+        i += 1
+      end
+      attrs
+    end
+
+    def single_value(sql)
+      row = @model.local_db.execute(sql, @where_binds)[0]
+      row.is_a?(Hash) ? row.values[0] : row[0]
+    end
+
+    def model_label
+      m = @model
+      m.respond_to?(:name) ? m.name : m.table_name
+    end
+  end
+end

--- a/mrblib/relation.rb
+++ b/mrblib/relation.rb
@@ -198,6 +198,13 @@ module Funicular
       select_sql
     end
 
+    # Internal (Component#watch): where change events for this
+    # relation's rows come from, as [role, table].
+    def __event_source
+      m = @model
+      [m.replica? ? :replica : :local, m.table_name]
+    end
+
     # ---- internal --------------------------------------------------------
 
     private

--- a/mrblib/relation.rb
+++ b/mrblib/relation.rb
@@ -5,11 +5,14 @@
 # The `model` handed to the constructor is the query's metadata + row
 # factory. Relation calls exactly these methods on it:
 #
-#   table_name       -> String
-#   local_columns    -> Hash[String => Symbol]  (column name -> declared type)
-#   local_db         -> handle responding to execute(sql, binds) -> rows
-#   replica?         -> bool (delete_all guard)
-#   build_from_local -> (Hash) -> model instance (attrs already decoded)
+#   table_name          -> String
+#   local_columns       -> Hash[String => Symbol]  (column name -> declared type)
+#   local_db            -> handle responding to execute(sql, binds) -> rows
+#   replica?            -> bool (delete_all guard)
+#   build_from_local    -> (Hash) -> model instance (attrs already decoded)
+#   local_table_changed -> void; called after a framework-managed write
+#                          (delete_all here) so the model can fire change
+#                          events and schedule snapshot persistence
 #
 # Identifiers in hash conditions and order() are validated against
 # local_columns and double-quoted; values cross into SQL through
@@ -180,7 +183,11 @@ module Funicular
       db = @model.local_db
       db.execute("DELETE FROM #{quoted_table}#{where_clause}", @where_binds)
       row = db.execute("SELECT changes()")[0]
-      row.is_a?(Hash) ? row.values[0] : row[0]
+      count = row.is_a?(Hash) ? row.values[0] : row[0]
+      # Framework-managed writes must notify (docs, "Querying"); a delete
+      # that removed nothing changed nothing.
+      @model.local_table_changed if 0 < count
+      count
     end
 
     # The SELECT this relation will run (debugging aid; binds not inlined).

--- a/sig/component.rbs
+++ b/sig/component.rbs
@@ -47,6 +47,11 @@ module Funicular
     def initialize_state: () -> Hash[Symbol, untyped]
     def seed_state: (Hash[untyped, untyped]? state_hash) -> self
 
+    @__watches: Hash[Symbol, Integer]?
+    def watch: (Symbol key) { () -> untyped } -> nil
+    def evaluate_watch: (Symbol key, untyped block) -> nil
+    def cleanup_watches: () -> nil
+
     def load_suspense_data: () -> void
     def load_single_suspense: (Symbol name, ?suspense_definition? definition) -> void
     def reload_suspense: (Symbol name) -> void

--- a/sig/db.rbs
+++ b/sig/db.rbs
@@ -61,6 +61,7 @@ module Funicular
 
     SQL_TYPES: Hash[Symbol, String]
     META_TABLE: String
+    self.@reserved_column_names: Array[Symbol]?
 
     def self.validate_identifier: (untyped name) -> String
     def self.baseline_index: (untyped migrations) -> Integer
@@ -74,6 +75,7 @@ module Funicular
     def self.collect_builders: (untyped model) -> Array[TableBuilder]
     def self.fold_ops: (Hash[String, Symbol] columns, Array[untyped] ops, untyped model) -> void
     def self.guard_id: (String name, untyped model) -> void
+    def self.guard_reserved_column: (String name, untyped model) -> void
     def self.apply_blocks: (untyped db, untyped model, Integer from_version, Array[TableBuilder] builders) -> void
     def self.run_block: (untyped db, String table, TableBuilder builder, bool create_mode) -> void
     def self.run_alter_op: (untyped db, String table, Array[untyped] op) -> void

--- a/sig/db.rbs
+++ b/sig/db.rbs
@@ -61,9 +61,11 @@ module Funicular
 
     SQL_TYPES: Hash[Symbol, String]
     META_TABLE: String
+    REPLICA_FINGERPRINT_KEY: String
     self.@reserved_column_names: Array[Symbol]?
 
     def self.validate_identifier: (untyped name) -> String
+    def self.guard_reserved_table: (String table) -> String
     def self.baseline_index: (untyped migrations) -> Integer
     def self.fold_local_columns: (untyped model) -> Hash[String, Symbol]
     def self.fold_builders: (Array[TableBuilder] builders, untyped migrations, untyped model) -> Hash[String, Symbol]
@@ -71,7 +73,15 @@ module Funicular
     def self.rebuild_local_table: (untyped db, untyped model, ?Array[TableBuilder]? builders) -> Integer
     def self.stored_table_version: (untyped db, String table) -> Integer
     def self.store_table_version: (untyped db, String table, Integer version) -> void
+    def self.read_meta: (untyped db, String key) -> String?
+    def self.store_meta: (untyped db, String key, String value) -> void
     def self.ensure_meta_table: (untyped db) -> void
+    def self.replica_table_ddl: (untyped model) -> String
+    def self.canonical_replica_schema: (Array[untyped] models) -> String
+    def self.build_replica_tables: (untyped db, Array[untyped] models) -> bool
+    def self.stale_replica_tables: (String? stored) -> Array[String]
+    def self.replica_upsert: (untyped db, untyped model, Hash[untyped, untyped] attrs) -> bool
+    def self.replica_delete: (untyped db, untyped model, untyped id) -> bool
     def self.collect_builders: (untyped model) -> Array[TableBuilder]
     def self.fold_ops: (Hash[String, Symbol] columns, Array[untyped] ops, untyped model) -> void
     def self.guard_id: (String name, untyped model) -> void

--- a/sig/db.rbs
+++ b/sig/db.rbs
@@ -81,6 +81,8 @@ module Funicular
     def self.build_replica_tables: (untyped db, Array[untyped] models) -> bool
     def self.stale_replica_tables: (String? stored) -> Array[String]
     def self.replica_upsert: (untyped db, untyped model, Hash[untyped, untyped] attrs) -> bool
+    def self.replica_upsert_all: (untyped db, untyped model, Array[untyped] rows) -> bool
+    private def self.replica_upsert_row: (untyped db, untyped model, Hash[untyped, untyped] attrs) -> void
     def self.replica_delete: (untyped db, untyped model, untyped id) -> bool
     def self.collect_builders: (untyped model) -> Array[TableBuilder]
     def self.fold_ops: (Hash[String, Symbol] columns, Array[untyped] ops, untyped model) -> void

--- a/sig/db.rbs
+++ b/sig/db.rbs
@@ -189,6 +189,10 @@ module Funicular
 
     self.@boot_state: Symbol?
     self.@session_epoch: untyped
+    self.@page_metadata: Hash[Symbol, untyped]?
+    self.@page_metadata_latched: bool?
+    self.@local_database_enabled: bool?
+    self.@local_database_latched: bool?
     self.@local_handle: GuardedDatabase?
     self.@replica_handle: GuardedDatabase?
     self.@schema_lockdown: untyped
@@ -200,7 +204,12 @@ module Funicular
 
     def self.boot: (?models: Array[untyped]?, ?metadata: Hash[Symbol, untyped]?) -> bool
     def self.__fail_boot: (Array[untyped] errors) -> bool
+    def self.__report_boot_errors: (Array[untyped] errors) -> bool
     def self.read_page_metadata: () -> Hash[Symbol, untyped]
+    def self.__page_metadata: () -> Hash[Symbol, untyped]
+    def self.local_database_enabled?: () -> bool
+    def self.__set_local_database_enabled: (untyped value) -> bool
+    def self.__ensure_local_database_enabled: (untyped operation) -> bool
 
     self.@session_terminated: bool?
     self.@page_epoch_latched: bool?
@@ -235,7 +244,7 @@ module Funicular
     private def self.drop_all_tables: (untyped db) -> nil
 
     def self.namespace_identity: (untyped application_id, untyped user_key, bool anonymous) -> String
-    def self.resolve_namespace: (application_id: untyped, user_key: untyped, user_key_configured: bool, anonymous_only: bool, local_models: bool) -> String
+    def self.resolve_namespace: (application_id: untyped, user_key: untyped, user_key_configured: bool, anonymous_only: bool) -> String
     def self.snapshot_key: (String identity, Symbol role) -> String
     def self.lock_name: (String identity) -> String
 

--- a/sig/db.rbs
+++ b/sig/db.rbs
@@ -124,6 +124,63 @@ module Funicular
     def self.install_lock_shim: () -> void
     def self.release_writer_lock: () -> bool
 
+    class Config
+      @replica_debounce_ms: Integer
+      @local_debounce_ms: Integer
+      @request_persistent_storage: bool
+      @on_persist_error: Proc?
+      @on_boot_error: Proc?
+      @on_session_change: Proc?
+
+      attr_accessor replica_debounce_ms: Integer
+      attr_accessor local_debounce_ms: Integer
+      attr_accessor request_persistent_storage: bool
+      attr_accessor on_persist_error: Proc?
+      attr_accessor on_boot_error: Proc?
+      attr_accessor on_session_change: Proc?
+
+      def initialize: () -> void
+    end
+
+    self.@config: Config?
+    self.@databases: Hash[Symbol, [untyped, Array[untyped]]]?
+    self.@snapshot_identity: String?
+    self.@snapshot_store: untyped
+    self.@snapshot_store_unavailable: bool?
+    self.@persist_timers: Hash[Symbol, untyped]?
+    self.@persist_timer_tokens: Hash[Symbol, Integer]?
+    self.@persist_deferred: Hash[Symbol, bool]?
+    self.@mutation_generation: Integer?
+    self.@visibility_hook_installed: bool?
+
+    SNAPSHOT_DB_NAME: String
+    STORAGE_PERSIST_JS: String
+
+    def self.config: () -> Config
+    def self.configure: () { () -> void } -> nil
+    def self.__reset_config: () -> nil
+    def self.__register_database: (Symbol role, untyped raw_db, Array[untyped] models) -> nil
+    def self.__registered_database: (Symbol role) -> untyped
+    def self.__set_snapshot_identity: (String? identity) -> String?
+    def self.__set_snapshot_store: (untyped store) -> untyped
+    def self.snapshot_store: () -> untyped
+    def self.open_snapshot_store: () -> untyped
+    def self.__become_volatile: (untyped error) -> nil
+    def self.report_persist_error: (untyped error) -> nil
+    def self.invoke_persist_error_hook: (untyped error) -> nil
+    def self.mutation_generation: () -> Integer
+    def self.persist_snapshot: (Symbol role) -> bool
+    def self.restore_snapshot: (Symbol role) -> bool
+    def self.schedule_persist: (Symbol role) -> nil
+    def self.__persist_timer_fired: (Symbol role, Integer? token) -> nil
+    def self.__persist_timer_token: (Symbol role) -> Integer?
+    def self.resume_deferred_persist: (Symbol role) -> nil
+    def self.cancel_persist_timers: () -> nil
+    def self.flush: () -> bool
+    def self.__install_visibility_hook: () -> bool
+    def self.__visibility_flush: () -> nil
+    def self.request_persistent_storage: () -> Symbol
+
     def self.namespace_identity: (untyped application_id, untyped user_key, bool anonymous) -> String
     def self.resolve_namespace: (application_id: untyped, user_key: untyped, user_key_configured: bool, anonymous_only: bool, local_models: bool) -> String
     def self.snapshot_key: (String identity, Symbol role) -> String

--- a/sig/db.rbs
+++ b/sig/db.rbs
@@ -113,6 +113,17 @@ module Funicular
     def self.skip_sql_blanks: (String s, Integer i) -> Integer
     def self.read_sql_word: (String s, Integer i) -> [String, Integer]
     def self.read_sql_token: (String s, Integer i) -> [String, Integer]
+    LOCK_SHIM_JS: String
+    self.@durability: Symbol?
+    self.@writer_lock_name: String?
+    self.@lock_shim_installed: bool?
+
+    def self.durability: () -> Symbol
+    def self.__set_durability: (Symbol state) -> Symbol
+    def self.elect_writer: (String lock_name) -> Symbol
+    def self.install_lock_shim: () -> void
+    def self.release_writer_lock: () -> bool
+
     def self.namespace_identity: (untyped application_id, untyped user_key, bool anonymous) -> String
     def self.resolve_namespace: (application_id: untyped, user_key: untyped, user_key_configured: bool, anonymous_only: bool, local_models: bool) -> String
     def self.snapshot_key: (String identity, Symbol role) -> String

--- a/sig/db.rbs
+++ b/sig/db.rbs
@@ -21,6 +21,14 @@ module Funicular
     class UnavailableError < Error
     end
 
+    class ConfigError < Error
+    end
+
+    def self.namespace_identity: (untyped application_id, untyped user_key, bool anonymous) -> String
+    def self.resolve_namespace: (application_id: untyped, user_key: untyped, user_key_configured: bool, anonymous_only: bool, local_models: bool) -> String
+    def self.snapshot_key: (String identity, Symbol role) -> String
+    def self.lock_name: (String identity) -> String
+
     module Codec
       def self.encode: (Symbol? `type`, untyped value) -> untyped
       def self.decode: (Symbol? `type`, untyped value) -> untyped

--- a/sig/db.rbs
+++ b/sig/db.rbs
@@ -39,18 +39,18 @@ module Funicular
     def self.unsubscribe: (Integer id) -> nil
     def self.notify_changed: (untyped target, ?untyped table) -> nil
     def self.validate_role: (untyped role) -> Symbol
-    def self.deferral_depth: (Symbol role) -> Integer
-    def self.pending_seen: (Symbol role) -> Hash[String, bool]
-    def self.pending_order: (Symbol role) -> Array[[Symbol, String]]
+    private def self.deferral_depth: (Symbol role) -> Integer
+    private def self.pending_seen: (Symbol role) -> Hash[String, bool]
+    private def self.pending_order: (Symbol role) -> Array[[Symbol, String]]
     def self.__begin_deferral: (Symbol role) -> void
     def self.__commit_deferral: (Symbol role) -> void
     def self.__rollback_deferral: (Symbol role) -> void
-    def self.clear_pending: (Symbol role) -> nil
-    def self.enqueue_delivery: (Symbol role, String table) -> nil
+    private def self.clear_pending: (Symbol role) -> nil
+    private def self.enqueue_delivery: (Symbol role, String table) -> nil
     def self.__set_tick_scheduler: (Proc? scheduler) -> Proc?
-    def self.schedule_drain: () -> nil
+    private def self.schedule_drain: () -> nil
     def self.__drain_events: () -> nil
-    def self.deliver_event: (Symbol role, String table, ?Integer? generation) -> void
+    private def self.deliver_event: (Symbol role, String table, ?Integer? generation) -> void
 
     class GuardedStatement
       @stmt: untyped
@@ -109,11 +109,11 @@ module Funicular
     end
 
     def self.guard_statement_sql: (untyped sql) -> void
-    def self.statement_head: (untyped sql) -> String
-    def self.pragma_name: (String s, Integer pos) -> String
-    def self.skip_sql_blanks: (String s, Integer i) -> Integer
-    def self.read_sql_word: (String s, Integer i) -> [String, Integer]
-    def self.read_sql_token: (String s, Integer i) -> [String, Integer]
+    private def self.statement_head: (untyped sql) -> String
+    private def self.pragma_name: (String s, Integer pos) -> String
+    private def self.skip_sql_blanks: (String s, Integer i) -> Integer
+    private def self.read_sql_word: (String s, Integer i) -> [String, Integer]
+    private def self.read_sql_token: (String s, Integer i) -> [String, Integer]
     LOCK_SHIM_JS: String
     self.@durability: Symbol?
     self.@writer_lock_name: String?
@@ -122,7 +122,7 @@ module Funicular
     def self.durability: () -> Symbol
     def self.__set_durability: (Symbol state) -> Symbol
     def self.elect_writer: (String lock_name) -> Symbol
-    def self.install_lock_shim: () -> void
+    private def self.install_lock_shim: () -> void
     def self.release_writer_lock: () -> bool
 
     class Config
@@ -166,16 +166,16 @@ module Funicular
     def self.__set_snapshot_store: (untyped store) -> untyped
     def self.snapshot_store: () -> untyped
     def self.open_snapshot_store: () -> untyped
-    def self.__become_volatile: (untyped error) -> nil
-    def self.report_persist_error: (untyped error) -> nil
-    def self.invoke_persist_error_hook: (untyped error) -> nil
+    private def self.__become_volatile: (untyped error) -> nil
+    private def self.report_persist_error: (untyped error) -> nil
+    private def self.invoke_persist_error_hook: (untyped error) -> nil
     def self.mutation_generation: () -> Integer
     def self.persist_snapshot: (Symbol role) -> bool
     def self.restore_snapshot: (Symbol role) -> bool
-    def self.schedule_persist: (Symbol role) -> nil
+    private def self.schedule_persist: (Symbol role) -> nil
     def self.__persist_timer_fired: (Symbol role, Integer? token) -> nil
     def self.__persist_timer_token: (Symbol role) -> Integer?
-    def self.resume_deferred_persist: (Symbol role) -> nil
+    private def self.resume_deferred_persist: (Symbol role) -> nil
     def self.cancel_persist_timers: () -> nil
     def self.flush: () -> bool
     def self.__install_visibility_hook: () -> bool
@@ -183,13 +183,38 @@ module Funicular
     def self.request_persistent_storage: () -> Symbol
     def self.stale_generation?: (Integer token) -> bool
     def self.stale_response_error: () -> Error
+
+    self.@boot_state: Symbol?
+    self.@session_epoch: untyped
+    self.@local_handle: GuardedDatabase?
+    self.@replica_handle: GuardedDatabase?
+    self.@schema_lockdown: untyped
+
+    def self.boot_state: () -> Symbol
+    def self.__set_boot_state: (Symbol state) -> Symbol
+    def self.session_epoch: () -> untyped
+    def self.boot: (models: Array[untyped], ?metadata: Hash[Symbol, untyped]) -> bool
+    private def self.__boot_steps: (Array[untyped] models, Hash[Symbol, untyped] metadata) -> nil
+    private def self.metadata_value: (Hash[Symbol, untyped]? metadata, Symbol key, untyped default) -> untyped
+    private def self.report_boot_error: (Array[untyped] errors) -> nil
+    private def self.__install_handles: (untyped local_db, untyped replica_db) -> nil
+    def self.local: () -> GuardedDatabase
+    def self.replica: () -> GuardedDatabase
+    def self.__model_local_db: (untyped model) -> GuardedDatabase
+    def self.__model_replica_db: () -> GuardedDatabase?
+    private def self.engage_schema_lockdown: (untyped db, untyped error) -> nil
+    def self.schema_lockdown: () -> untyped
+    private def self.__check_schema_lockdown: (String context) -> nil
+    def self.reset_local_table: (untyped model) -> bool
+    private def self.revalidate_schema_lockdown: (untyped db) -> nil
+    def self.__reset_boot: () -> nil
     def self.wipe: () -> bool
-    def self.tick_generation: () -> Integer
-    def self.clear_tick_events: () -> nil
-    def self.ensure_not_in_transaction: (Symbol role) -> nil
-    def self.wipe_role: (Symbol role) -> nil
-    def self.notify_wiped: (Symbol role) -> nil
-    def self.drop_all_tables: (untyped db) -> nil
+    private def self.tick_generation: () -> Integer
+    private def self.clear_tick_events: () -> nil
+    private def self.ensure_not_in_transaction: (Symbol role) -> nil
+    private def self.wipe_role: (Symbol role) -> nil
+    private def self.notify_wiped: (Symbol role) -> nil
+    private def self.drop_all_tables: (untyped db) -> nil
 
     def self.namespace_identity: (untyped application_id, untyped user_key, bool anonymous) -> String
     def self.resolve_namespace: (application_id: untyped, user_key: untyped, user_key_configured: bool, anonymous_only: bool, local_models: bool) -> String
@@ -240,35 +265,35 @@ module Funicular
     self.@reserved_column_names: Array[Symbol]?
 
     def self.validate_identifier: (untyped name) -> String
-    def self.guard_reserved_table: (String table) -> String
-    def self.baseline_index: (untyped migrations) -> Integer
+    private def self.guard_reserved_table: (String table) -> String
+    private def self.baseline_index: (untyped migrations) -> Integer
     def self.fold_local_columns: (untyped model) -> Hash[String, Symbol]
-    def self.fold_builders: (Array[TableBuilder] builders, untyped migrations, untyped model) -> Hash[String, Symbol]
+    private def self.fold_builders: (Array[TableBuilder] builders, untyped migrations, untyped model) -> Hash[String, Symbol]
     def self.apply_local_migrations: (untyped db, untyped model) -> Integer
     def self.rebuild_local_table: (untyped db, untyped model, ?Array[TableBuilder]? builders) -> Integer
     def self.stored_table_version: (untyped db, String table) -> Integer
     def self.store_table_version: (untyped db, String table, Integer version) -> void
     def self.read_meta: (untyped db, String key) -> String?
     def self.store_meta: (untyped db, String key, String value) -> void
-    def self.ensure_meta_table: (untyped db) -> void
+    private def self.ensure_meta_table: (untyped db) -> void
     def self.replica_table_ddl: (untyped model) -> String
     def self.canonical_replica_schema: (Array[untyped] models) -> String
     def self.build_replica_tables: (untyped db, Array[untyped] models) -> bool
-    def self.stale_replica_tables: (String? stored) -> Array[String]
+    private def self.stale_replica_tables: (String? stored) -> Array[String]
     def self.replica_upsert: (untyped db, untyped model, Hash[untyped, untyped] attrs) -> bool
     def self.replica_upsert_all: (untyped db, untyped model, Array[untyped] rows) -> bool
     private def self.replica_upsert_row: (untyped db, untyped model, Hash[untyped, untyped] attrs) -> void
     def self.replica_delete: (untyped db, untyped model, untyped id) -> bool
-    def self.collect_builders: (untyped model) -> Array[TableBuilder]
-    def self.fold_ops: (Hash[String, Symbol] columns, Array[untyped] ops, untyped model) -> void
-    def self.guard_id: (String name, untyped model) -> void
-    def self.guard_reserved_column: (String name, untyped model) -> void
-    def self.apply_blocks: (untyped db, untyped model, Integer from_version, Array[TableBuilder] builders) -> void
-    def self.run_block: (untyped db, String table, TableBuilder builder, bool create_mode) -> void
-    def self.run_alter_op: (untyped db, String table, Array[untyped] op) -> void
-    def self.column_ddl: (Array[untyped] op) -> String
-    def self.default_literal: (Symbol `type`, untyped value) -> String
-    def self.index_name: (String table, Array[String] columns) -> String
-    def self.quoted_list: (Array[String] columns) -> String
+    private def self.collect_builders: (untyped model) -> Array[TableBuilder]
+    private def self.fold_ops: (Hash[String, Symbol] columns, Array[untyped] ops, untyped model) -> void
+    private def self.guard_id: (String name, untyped model) -> void
+    private def self.guard_reserved_column: (String name, untyped model) -> void
+    private def self.apply_blocks: (untyped db, untyped model, Integer from_version, Array[TableBuilder] builders) -> void
+    private def self.run_block: (untyped db, String table, TableBuilder builder, bool create_mode) -> void
+    private def self.run_alter_op: (untyped db, String table, Array[untyped] op) -> void
+    private def self.column_ddl: (Array[untyped] op) -> String
+    private def self.default_literal: (Symbol `type`, untyped value) -> String
+    private def self.index_name: (String table, Array[String] columns) -> String
+    private def self.quoted_list: (Array[String] columns) -> String
   end
 end

--- a/sig/db.rbs
+++ b/sig/db.rbs
@@ -151,6 +151,7 @@ module Funicular
     self.@persist_timers: Hash[Symbol, untyped]?
     self.@persist_timer_tokens: Hash[Symbol, Integer]?
     self.@persist_deferred: Hash[Symbol, bool]?
+    self.@persist_inflight: Integer?
     self.@mutation_generation: Integer?
     self.@visibility_hook_installed: bool?
 
@@ -177,6 +178,8 @@ module Funicular
     def self.__persist_timer_token: (Symbol role) -> Integer?
     private def self.resume_deferred_persist: (Symbol role) -> nil
     def self.cancel_persist_timers: () -> nil
+    private def self.persist_inflight: () -> Integer
+    private def self.await_inflight_persists: () -> nil
     def self.flush: () -> bool
     def self.__install_visibility_hook: () -> bool
     def self.__visibility_flush: () -> nil
@@ -198,7 +201,17 @@ module Funicular
     def self.boot: (?models: Array[untyped]?, ?metadata: Hash[Symbol, untyped]?) -> bool
     def self.__fail_boot: (Array[untyped] errors) -> bool
     def self.read_page_metadata: () -> Hash[Symbol, untyped]
+
+    self.@session_terminated: bool?
+    self.@page_epoch_latched: bool?
+
+    def self.__set_session_epoch: (untyped value) -> untyped
+    def self.__latch_page_epoch: () -> untyped
+    def self.session_terminated?: () -> bool
+    def self.__session_epoch_ok?: (String? header) -> bool
+    def self.__terminate_session: (String? header) -> nil
     private def self.__boot_steps: (Array[untyped] models, Hash[Symbol, untyped] metadata) -> nil
+    private def self.ensure_boot_not_terminated: () -> nil
     private def self.metadata_value: (Hash[Symbol, untyped]? metadata, Symbol key, untyped default) -> untyped
     private def self.report_boot_error: (Array[untyped] errors) -> nil
     private def self.__install_handles: (untyped local_db, untyped replica_db) -> nil
@@ -215,6 +228,7 @@ module Funicular
     def self.wipe: () -> bool
     private def self.tick_generation: () -> Integer
     private def self.clear_tick_events: () -> nil
+    private def self.ensure_session_not_terminated: (Symbol operation) -> nil
     private def self.ensure_not_in_transaction: (Symbol role) -> nil
     private def self.wipe_role: (Symbol role) -> nil
     private def self.notify_wiped: (Symbol role) -> nil

--- a/sig/db.rbs
+++ b/sig/db.rbs
@@ -35,5 +35,49 @@ module Funicular
       def self.sep_at: (String str, Integer pos, Integer code) -> void
       def self.zpad: (Integer n, Integer width) -> String
     end
+
+    class TableBuilder
+      @ops: Array[untyped]
+
+      attr_reader ops: Array[untyped]
+
+      def initialize: () -> void
+      def string: (untyped name, ?default: untyped, ?null: bool) -> void
+      def text: (untyped name, ?default: untyped, ?null: bool) -> void
+      def integer: (untyped name, ?default: untyped, ?null: bool) -> void
+      def float: (untyped name, ?default: untyped, ?null: bool) -> void
+      def boolean: (untyped name, ?default: untyped, ?null: bool) -> void
+      def datetime: (untyped name, ?default: untyped, ?null: bool) -> void
+      def timestamps: () -> void
+      def index: (*untyped columns) -> void
+      def remove_index: (*untyped columns) -> void
+      def rename: (untyped old_name, untyped new_name) -> void
+      def remove: (untyped name) -> void
+      def execute: (String sql) -> void
+
+      private def add_column: (Symbol `type`, untyped name, untyped default, bool null) -> void
+      private def identifier_list: (Array[untyped] columns) -> Array[String]
+    end
+
+    SQL_TYPES: Hash[Symbol, String]
+    META_TABLE: String
+
+    def self.validate_identifier: (untyped name) -> String
+    def self.fold_local_columns: (untyped model) -> Hash[String, Symbol]
+    def self.apply_local_migrations: (untyped db, untyped model) -> Integer
+    def self.rebuild_local_table: (untyped db, untyped model) -> Integer
+    def self.stored_table_version: (untyped db, String table) -> Integer
+    def self.store_table_version: (untyped db, String table, Integer version) -> void
+    def self.ensure_meta_table: (untyped db) -> void
+    def self.collect_builders: (untyped model) -> Array[TableBuilder]
+    def self.fold_ops: (Hash[String, Symbol] columns, Array[untyped] ops, untyped model) -> void
+    def self.guard_id: (String name, untyped model) -> void
+    def self.apply_blocks: (untyped db, untyped model, Integer from_version) -> void
+    def self.run_block: (untyped db, String table, TableBuilder builder, bool create_mode) -> void
+    def self.run_alter_op: (untyped db, String table, Array[untyped] op) -> void
+    def self.column_ddl: (Array[untyped] op) -> String
+    def self.default_literal: (Symbol `type`, untyped value) -> String
+    def self.index_name: (String table, Array[String] columns) -> String
+    def self.quoted_list: (Array[String] columns) -> String
   end
 end

--- a/sig/db.rbs
+++ b/sig/db.rbs
@@ -65,15 +65,16 @@ module Funicular
     def self.validate_identifier: (untyped name) -> String
     def self.baseline_index: (untyped migrations) -> Integer
     def self.fold_local_columns: (untyped model) -> Hash[String, Symbol]
+    def self.fold_builders: (Array[TableBuilder] builders, untyped migrations, untyped model) -> Hash[String, Symbol]
     def self.apply_local_migrations: (untyped db, untyped model) -> Integer
-    def self.rebuild_local_table: (untyped db, untyped model) -> Integer
+    def self.rebuild_local_table: (untyped db, untyped model, ?Array[TableBuilder]? builders) -> Integer
     def self.stored_table_version: (untyped db, String table) -> Integer
     def self.store_table_version: (untyped db, String table, Integer version) -> void
     def self.ensure_meta_table: (untyped db) -> void
     def self.collect_builders: (untyped model) -> Array[TableBuilder]
     def self.fold_ops: (Hash[String, Symbol] columns, Array[untyped] ops, untyped model) -> void
     def self.guard_id: (String name, untyped model) -> void
-    def self.apply_blocks: (untyped db, untyped model, Integer from_version) -> void
+    def self.apply_blocks: (untyped db, untyped model, Integer from_version, Array[TableBuilder] builders) -> void
     def self.run_block: (untyped db, String table, TableBuilder builder, bool create_mode) -> void
     def self.run_alter_op: (untyped db, String table, Array[untyped] op) -> void
     def self.column_ddl: (Array[untyped] op) -> String

--- a/sig/db.rbs
+++ b/sig/db.rbs
@@ -63,6 +63,7 @@ module Funicular
     META_TABLE: String
 
     def self.validate_identifier: (untyped name) -> String
+    def self.baseline_index: (untyped migrations) -> Integer
     def self.fold_local_columns: (untyped model) -> Hash[String, Symbol]
     def self.apply_local_migrations: (untyped db, untyped model) -> Integer
     def self.rebuild_local_table: (untyped db, untyped model) -> Integer

--- a/sig/db.rbs
+++ b/sig/db.rbs
@@ -1,0 +1,38 @@
+module Funicular
+  class RecordNotFound < StandardError
+  end
+
+  module DB
+    class Error < StandardError
+    end
+
+    class NoTableError < Error
+    end
+
+    class ReadOnlyTabError < Error
+    end
+
+    class ReplicaWriteError < Error
+    end
+
+    class SchemaTooNewError < Error
+    end
+
+    class UnavailableError < Error
+    end
+
+    module Codec
+      def self.encode: (Symbol? `type`, untyped value) -> untyped
+      def self.decode: (Symbol? `type`, untyped value) -> untyped
+      def self.encode_bind: (untyped value) -> untyped
+      def self.time_to_iso: (Time time) -> String
+      def self.iso_to_time: (String str) -> Time
+      def self.civil_from_days: (Integer days) -> Array[Integer]
+      def self.days_from_civil: (Integer y, Integer m, Integer d) -> Integer
+      def self.zone_offset: (String str, Integer pos) -> Integer
+      def self.digits_at: (String str, Integer pos, Integer len) -> Integer
+      def self.sep_at: (String str, Integer pos, Integer code) -> void
+      def self.zpad: (Integer n, Integer width) -> String
+    end
+  end
+end

--- a/sig/db.rbs
+++ b/sig/db.rbs
@@ -24,6 +24,33 @@ module Funicular
     class ConfigError < Error
     end
 
+    self.@subscriptions: Hash[Integer, [Symbol, String, Proc]]?
+    self.@subscription_serial: Integer?
+    self.@deferral_depths: Hash[Symbol, Integer]?
+    self.@pending_seen: Hash[Symbol, Hash[String, bool]]?
+    self.@pending_orders: Hash[Symbol, Array[[Symbol, String]]]?
+    self.@tick_events: Hash[String, bool]?
+    self.@tick_order: Array[[Symbol, String]]?
+    self.@drain_scheduled: bool?
+    self.@tick_scheduler: Proc?
+
+    def self.subscribe: (Symbol role, untyped table) { (Symbol role, String table) -> void } -> Integer
+    def self.unsubscribe: (Integer id) -> nil
+    def self.notify_changed: (untyped target, ?untyped table) -> nil
+    def self.validate_role: (untyped role) -> Symbol
+    def self.deferral_depth: (Symbol role) -> Integer
+    def self.pending_seen: (Symbol role) -> Hash[String, bool]
+    def self.pending_order: (Symbol role) -> Array[[Symbol, String]]
+    def self.__begin_deferral: (Symbol role) -> void
+    def self.__commit_deferral: (Symbol role) -> void
+    def self.__rollback_deferral: (Symbol role) -> void
+    def self.clear_pending: (Symbol role) -> nil
+    def self.enqueue_delivery: (Symbol role, String table) -> nil
+    def self.__set_tick_scheduler: (Proc? scheduler) -> Proc?
+    def self.schedule_drain: () -> nil
+    def self.__drain_events: () -> nil
+    def self.deliver_event: (Symbol role, String table) -> void
+
     class GuardedStatement
       @stmt: untyped
       @guard: GuardedDatabase
@@ -63,9 +90,11 @@ module Funicular
 
     class GuardedDatabase
       @db: untyped
+      @role: Symbol
       @read_only: bool
 
-      def initialize: (untyped db, ?bool read_only) -> void
+      def initialize: (untyped db, ?Symbol role, ?bool read_only) -> void
+      def role: () -> Symbol
       def read_only?: () -> bool
       def __become_read_only: () -> void
       def execute: (String sql, ?Array[untyped] bind_vars) ?{ (untyped row) -> void } -> untyped

--- a/sig/db.rbs
+++ b/sig/db.rbs
@@ -31,6 +31,7 @@ module Funicular
     self.@pending_orders: Hash[Symbol, Array[[Symbol, String]]]?
     self.@tick_events: Hash[String, bool]?
     self.@tick_order: Array[[Symbol, String]]?
+    self.@tick_generation: Integer?
     self.@drain_scheduled: bool?
     self.@tick_scheduler: Proc?
 
@@ -49,7 +50,7 @@ module Funicular
     def self.__set_tick_scheduler: (Proc? scheduler) -> Proc?
     def self.schedule_drain: () -> nil
     def self.__drain_events: () -> nil
-    def self.deliver_event: (Symbol role, String table) -> void
+    def self.deliver_event: (Symbol role, String table, ?Integer? generation) -> void
 
     class GuardedStatement
       @stmt: untyped
@@ -180,6 +181,15 @@ module Funicular
     def self.__install_visibility_hook: () -> bool
     def self.__visibility_flush: () -> nil
     def self.request_persistent_storage: () -> Symbol
+    def self.stale_generation?: (Integer token) -> bool
+    def self.stale_response_error: () -> Error
+    def self.wipe: () -> bool
+    def self.tick_generation: () -> Integer
+    def self.clear_tick_events: () -> nil
+    def self.ensure_not_in_transaction: (Symbol role) -> nil
+    def self.wipe_role: (Symbol role) -> nil
+    def self.notify_wiped: (Symbol role) -> nil
+    def self.drop_all_tables: (untyped db) -> nil
 
     def self.namespace_identity: (untyped application_id, untyped user_key, bool anonymous) -> String
     def self.resolve_namespace: (application_id: untyped, user_key: untyped, user_key_configured: bool, anonymous_only: bool, local_models: bool) -> String

--- a/sig/db.rbs
+++ b/sig/db.rbs
@@ -29,6 +29,7 @@ module Funicular
       def self.iso_to_time: (String str) -> Time
       def self.civil_from_days: (Integer days) -> Array[Integer]
       def self.days_from_civil: (Integer y, Integer m, Integer d) -> Integer
+      def self.days_in_month: (Integer year, Integer mon) -> Integer
       def self.zone_offset: (String str, Integer pos) -> Integer
       def self.digits_at: (String str, Integer pos, Integer len) -> Integer
       def self.sep_at: (String str, Integer pos, Integer code) -> void

--- a/sig/db.rbs
+++ b/sig/db.rbs
@@ -106,8 +106,10 @@ module Funicular
       def transaction: (?Symbol mode) ?{ (GuardedDatabase proxy) -> untyped } -> untyped
       def commit: () -> bool
       def rollback: () -> bool
+      private def __execute_control: (String sql) -> nil
     end
 
+    TRANSACTION_CONTROL_WORDS: Array[String]
     def self.guard_statement_sql: (untyped sql) -> void
     private def self.statement_head: (untyped sql) -> String
     private def self.pragma_name: (String s, Integer pos) -> String

--- a/sig/db.rbs
+++ b/sig/db.rbs
@@ -193,7 +193,11 @@ module Funicular
     def self.boot_state: () -> Symbol
     def self.__set_boot_state: (Symbol state) -> Symbol
     def self.session_epoch: () -> untyped
-    def self.boot: (models: Array[untyped], ?metadata: Hash[Symbol, untyped]) -> bool
+    PAGE_METADATA_JS: String
+
+    def self.boot: (?models: Array[untyped]?, ?metadata: Hash[Symbol, untyped]?) -> bool
+    def self.__fail_boot: (Array[untyped] errors) -> bool
+    def self.read_page_metadata: () -> Hash[Symbol, untyped]
     private def self.__boot_steps: (Array[untyped] models, Hash[Symbol, untyped] metadata) -> nil
     private def self.metadata_value: (Hash[Symbol, untyped]? metadata, Symbol key, untyped default) -> untyped
     private def self.report_boot_error: (Array[untyped] errors) -> nil

--- a/sig/db.rbs
+++ b/sig/db.rbs
@@ -24,6 +24,66 @@ module Funicular
     class ConfigError < Error
     end
 
+    class GuardedStatement
+      @stmt: untyped
+      @guard: GuardedDatabase
+
+      def initialize: (untyped stmt, GuardedDatabase guard) -> void
+      def bind_params: (*untyped bind_vars) -> untyped
+      def readonly?: () -> bool
+      def columns: () -> untyped
+      def close: () -> untyped
+      def closed?: () -> bool
+      def execute: (*untyped bind_vars) -> Array[untyped]
+      def step: () -> untyped
+
+      private def check_writable: () -> void
+    end
+
+    class GuardedResultSet
+      @rs: untyped
+      @stmt: untyped
+      @guard: GuardedDatabase
+
+      def initialize: (untyped rs, untyped stmt, GuardedDatabase guard) -> void
+      def next: () -> untyped
+      def each: () { (untyped row) -> void } -> GuardedResultSet
+      def to_a: () -> Array[untyped]
+      def reset: (*untyped bind_params) -> untyped
+      def eof?: () -> bool
+      def close: () -> untyped
+      def closed?: () -> bool
+      def columns: () -> untyped
+      def types: () -> untyped
+
+      private def check_writable: () -> void
+    end
+
+    def self.enforce_read_only: (bool read_only, untyped raw_stmt) -> void
+
+    class GuardedDatabase
+      @db: untyped
+      @read_only: bool
+
+      def initialize: (untyped db, ?bool read_only) -> void
+      def read_only?: () -> bool
+      def __become_read_only: () -> void
+      def execute: (String sql, ?Array[untyped] bind_vars) ?{ (untyped row) -> void } -> untyped
+      def prepare: (String sql) ?{ (GuardedStatement stmt) -> untyped } -> untyped
+      def query: (String sql, ?Array[untyped] bind_vars) ?{ (GuardedResultSet result) -> untyped } -> untyped
+      def get_first_row: (String sql, ?Array[untyped] bind_vars) -> untyped
+      def get_first_value: (String sql, ?Array[untyped] bind_vars) -> untyped
+      def transaction: (?Symbol mode) ?{ (GuardedDatabase proxy) -> untyped } -> untyped
+      def commit: () -> bool
+      def rollback: () -> bool
+    end
+
+    def self.guard_statement_sql: (untyped sql) -> void
+    def self.statement_head: (untyped sql) -> String
+    def self.pragma_name: (String s, Integer pos) -> String
+    def self.skip_sql_blanks: (String s, Integer i) -> Integer
+    def self.read_sql_word: (String s, Integer i) -> [String, Integer]
+    def self.read_sql_token: (String s, Integer i) -> [String, Integer]
     def self.namespace_identity: (untyped application_id, untyped user_key, bool anonymous) -> String
     def self.resolve_namespace: (application_id: untyped, user_key: untyped, user_key_configured: bool, anonymous_only: bool, local_models: bool) -> String
     def self.snapshot_key: (String identity, Symbol role) -> String

--- a/sig/funicular.rbs
+++ b/sig/funicular.rbs
@@ -17,6 +17,9 @@ module Funicular
   def self.first_element_child: (JS::Element container_element) -> JS::Element?
 
   def self.load_schemas: (Hash[singleton(Model), String] models) ?{ () -> void } -> void
+  def self.__request_schema: (untyped model_class, String schema_name, Array[untyped] errors, Proc settle) -> nil
+  def self.__settle_boot_barrier: (Array[untyped] errors) ?{ () -> void } -> nil
+  def self.__boot_for_start: () -> bool
   def self.start: (?singleton(Component)? component_class, ?container: String | JS::Element, ?props: Hash[Symbol, untyped], ?hydrate: bool) ?{ (Router router) -> void } -> (Component | Router | nil)
   def self.configure_forms: () ?{ (Hash[Symbol, String]) -> void } -> void
   def self.form_builder_config: () -> Hash[Symbol, String]?

--- a/sig/http.rbs
+++ b/sig/http.rbs
@@ -19,5 +19,7 @@ module Funicular
 
     private def self.parse_response_body: (untyped text) -> untyped
     private def self.request: (String method, String url, Hash[untyped, untyped]? body) { (Response) -> void } -> void
+    private def self.session_changed_response: () -> Response
+    private def self.response_epoch: (untyped response) -> String?
   end
 end

--- a/sig/http.rbs
+++ b/sig/http.rbs
@@ -1,10 +1,5 @@
 module Funicular
   module HTTP
-    CACHE_DB_NAME: String
-    CACHE_STORE: String
-
-    self.@cache: IndexedDB::KVS?
-
     class Response
       attr_reader data: untyped
       attr_reader status: Integer
@@ -15,24 +10,14 @@ module Funicular
       def error_message: () -> String?
     end
 
-    def self.cache_init!: () -> IndexedDB::KVS
-    def self.cache_purge: (String url) -> nil
-    def self.cache_clear: () -> nil
-    def self.cache_lookup: (String url) -> untyped
-    def self.cache_write: (String url, Hash[String, untyped] entry) -> nil
-
-    def self.get: (String url, ?cache: Integer?) { (Response) -> void } -> void
-    def self.post: (String url, ?Hash[untyped, untyped]? body, ?cache: Integer?) { (Response) -> void } -> void
-    def self.patch: (String url, ?Hash[untyped, untyped]? body, ?cache: Integer?) { (Response) -> void } -> void
-    def self.delete: (String url, ?cache: Integer?) { (Response) -> void } -> void
-    def self.put: (String url, ?Hash[untyped, untyped]? body, ?cache: Integer?) { (Response) -> void } -> void
+    def self.get: (String url) { (Response) -> void } -> void
+    def self.post: (String url, ?Hash[untyped, untyped]? body) { (Response) -> void } -> void
+    def self.patch: (String url, ?Hash[untyped, untyped]? body) { (Response) -> void } -> void
+    def self.delete: (String url) { (Response) -> void } -> void
+    def self.put: (String url, ?Hash[untyped, untyped]? body) { (Response) -> void } -> void
     def self.csrf_token: () -> String?
 
-    private def self.warn_unsupported_cache: (String verb) -> void
-    private def self.now_seconds: () -> Integer
-    private def self.cache_hit?: (untyped entry, Integer ttl) -> bool
-    private def self.serve_from_cache: (Hash[String, untyped] entry) { (Response) -> void } -> void
     private def self.parse_response_body: (untyped text) -> untyped
-    private def self.request: (String method, String url, Hash[untyped, untyped]? body, ?cache: Integer?) { (Response) -> void } -> void
+    private def self.request: (String method, String url, Hash[untyped, untyped]? body) { (Response) -> void } -> void
   end
 end

--- a/sig/model.rbs
+++ b/sig/model.rbs
@@ -60,14 +60,14 @@ module Funicular
     # nil; on failure `result` is nil. destroy's success payload is `true`.
     # On storage :local models these methods are synchronous instead
     # (bare-class alias): no blocks, direct return values.
-    def self.all: (?Hash[untyped, untyped] params) ?{ (Array[Model]? instances, String? error) -> void } -> untyped
-    def self.find: (?untyped id, ?endpoint_name: String, ?model_class: singleton(Model)) ?{ (Model? instance, String? error) -> void } -> untyped
+    def self.all: (?Hash[untyped, untyped] params) ?{ (Array[Model]? instances, untyped error) -> void } -> untyped
+    def self.find: (?untyped id, ?endpoint_name: String, ?model_class: singleton(Model)) ?{ (Model? instance, untyped error) -> void } -> untyped
     def self.create: (?Hash[untyped, untyped] attrs, **untyped kw) ?{ (Model? instance, untyped error) -> void } -> untyped
     def self.destroy: (?untyped id) ?{ (bool? success, untyped error) -> void } -> untyped
 
     def update: (?Hash[untyped, untyped]? attrs) ?{ (Model? instance, untyped error) -> void } -> untyped
     def destroy: () ?{ (bool? success, untyped error) -> void } -> untyped
-    def reload: () ?{ (Model? instance, String? error) -> void } -> untyped
+    def reload: () ?{ (Model? instance, untyped error) -> void } -> untyped
 
     # storage :local CRUD and the bare-class alias
     def self.define_local_accessors: (Hash[String, Symbol] columns) -> void

--- a/sig/model.rbs
+++ b/sig/model.rbs
@@ -74,6 +74,7 @@ module Funicular
     def self.define_local_accessor: (String name, Array[Symbol] existing) -> void
     def self.merge_keyword_attrs: (Hash[untyped, untyped] attrs, Hash[Symbol, untyped] kw) -> Hash[untyped, untyped]
     def self.local_create: (?Hash[untyped, untyped] attrs) -> Model
+    def self.reset_local: () -> bool
     def self.local_query: (String method_name) -> Relation
     def self.where: (?Hash[untyped, untyped] | String | nil conditions, *untyped binds) -> Relation
     def self.order: (*untyped args) -> Relation

--- a/sig/model.rbs
+++ b/sig/model.rbs
@@ -43,6 +43,7 @@ module Funicular
     def self.local_columns: () -> Hash[String, Symbol]
     def self.local_db: () -> untyped
     def self.build_from_local: (Hash[untyped, untyped] attrs) -> Model
+    def self.local_table_changed: () -> void
 
     # Unified callback contract (0.5.0): every REST callback is
     # (result, error). On success `result` is the payload and `error` is

--- a/sig/model.rbs
+++ b/sig/model.rbs
@@ -6,6 +6,13 @@ module Funicular
     attr_reader id: untyped
     @changed_attributes: Hash[String, untyped]
 
+    self.@storage_kind: Symbol?
+    self.@local_migrations: Array[Hash[Symbol, untyped]]?
+    self.@collecting_migrations: bool?
+    self.@refresh_mode: Symbol?
+    self.@table_name: String?
+    self.@local_columns: Hash[String, Symbol]?
+
     def self.schema: () -> Hash[String, Hash[String, untyped]]
     def self.schema=: (Hash[String, Hash[String, untyped]] schema) -> Hash[String, Hash[String, untyped]]
     def self.endpoints: () -> Hash[String, Hash[String, String]]
@@ -15,6 +22,27 @@ module Funicular
     def self.load_schema: (Hash[String, untyped] schema_data) -> void
     def self.register_schema_validations: (untyped validations) -> void
     def self.normalize_validation_options: (Symbol | String kind, untyped opts) -> untyped
+
+    # Local-database declaration DSL (docs/local_database.md). Migrate
+    # blocks are recorded at class eval and executed at DB boot.
+    def self.storage: (Symbol kind) ?{ () -> void } -> Symbol
+    def self.storage_kind: () -> Symbol
+    def self.replica?: () -> bool
+    def self.ephemeral?: () -> bool
+    def self.local?: () -> bool
+    def self.migrate: (Integer version, ?reset: bool) { (untyped t) -> void } -> void
+    def self.local_migrations: () -> Array[Hash[Symbol, untyped]]?
+    def self.validate_local_migrations: () -> void
+    def self.refresh: (Symbol mode) -> Symbol
+    def self.refresh_mode: () -> Symbol
+    def self.table_name: (?(String | Symbol)? explicit) -> String
+    def self.derive_table_name: () -> String
+    def self.local: () -> Relation
+
+    # Relation protocol (mrblib/relation.rb)
+    def self.local_columns: () -> Hash[String, Symbol]
+    def self.local_db: () -> untyped
+    def self.build_from_local: (Hash[untyped, untyped] attrs) -> Model
 
     # Unified callback contract (0.5.0): every REST callback is
     # (result, error). On success `result` is the payload and `error` is

--- a/sig/model.rbs
+++ b/sig/model.rbs
@@ -41,6 +41,7 @@ module Funicular
 
     # Relation protocol (mrblib/relation.rb)
     def self.local_columns: () -> Hash[String, Symbol]
+    def self.derive_replica_columns: () -> Hash[String, Symbol]
     def self.local_db: () -> untyped
     def self.build_from_local: (Hash[untyped, untyped] attrs) -> Model
     def self.local_table_changed: () -> void

--- a/sig/model.rbs
+++ b/sig/model.rbs
@@ -45,8 +45,13 @@ module Funicular
     def self.local_columns: () -> Hash[String, Symbol]
     def self.derive_replica_columns: () -> Hash[String, Symbol]
     def self.local_db: () -> untyped
+    def self.replica_db: () -> untyped
     def self.build_from_local: (Hash[untyped, untyped] attrs) -> Model
     def self.local_table_changed: () -> void
+    def self.rest_attribute_type: (String name) -> Symbol?
+    def self.__write_through_upsert: (untyped attrs) -> void
+    def self.__write_through_upsert_all: (untyped rows) -> void
+    def self.__write_through_delete: (untyped id) -> void
 
     # Unified callback contract (0.5.0): every REST callback is
     # (result, error). On success `result` is the payload and `error` is

--- a/sig/model.rbs
+++ b/sig/model.rbs
@@ -48,6 +48,8 @@ module Funicular
     def self.replica_db: () -> untyped
     def self.build_from_local: (Hash[untyped, untyped] attrs) -> Model
     def self.local_table_changed: () -> void
+    def self.on_change: () { (Symbol role, String table) -> void } -> Integer
+    def self.off_change: (Integer subscription) -> nil
     def self.rest_attribute_type: (String name) -> Symbol?
     def self.__write_through_upsert: (untyped attrs) -> void
     def self.__write_through_upsert_all: (untyped rows) -> void

--- a/sig/model.rbs
+++ b/sig/model.rbs
@@ -16,13 +16,16 @@ module Funicular
     def self.register_schema_validations: (untyped validations) -> void
     def self.normalize_validation_options: (Symbol | String kind, untyped opts) -> untyped
 
+    # Unified callback contract (0.5.0): every REST callback is
+    # (result, error). On success `result` is the payload and `error` is
+    # nil; on failure `result` is nil. destroy's success payload is `true`.
     def self.all: (?Hash[untyped, untyped] params) ?{ (Array[Model]? instances, String? error) -> void } -> void
     def self.find: (?untyped id, ?endpoint_name: String, ?model_class: singleton(Model)) ?{ (Model? instance, String? error) -> void } -> void
     def self.create: (Hash[untyped, untyped] attrs, ?model_class: singleton(Model)) ?{ (Model? instance, untyped error) -> void } -> void
-    def self.destroy: (?untyped id) ?{ (bool success, untyped result) -> void } -> void
+    def self.destroy: (?untyped id) ?{ (bool? success, untyped error) -> void } -> void
 
-    def update: (?Hash[untyped, untyped]? attrs) ?{ (bool success, untyped result) -> void } -> void
-    def destroy: () ?{ (bool success, untyped result) -> void } -> void
+    def update: (?Hash[untyped, untyped]? attrs) ?{ (Model? instance, untyped error) -> void } -> void
+    def destroy: () ?{ (bool? success, untyped error) -> void } -> void
     def reload: () ?{ (Model? instance, String? error) -> void } -> void
   end
 end

--- a/sig/model.rbs
+++ b/sig/model.rbs
@@ -5,6 +5,8 @@ module Funicular
 
     attr_reader id: untyped
     @changed_attributes: Hash[String, untyped]
+    @local_baseline: Hash[String, untyped]?
+    @provided_attributes: Hash[String, bool]?
 
     self.@storage_kind: Symbol?
     self.@local_migrations: Array[Hash[Symbol, untyped]]?
@@ -49,13 +51,40 @@ module Funicular
     # Unified callback contract (0.5.0): every REST callback is
     # (result, error). On success `result` is the payload and `error` is
     # nil; on failure `result` is nil. destroy's success payload is `true`.
-    def self.all: (?Hash[untyped, untyped] params) ?{ (Array[Model]? instances, String? error) -> void } -> void
-    def self.find: (?untyped id, ?endpoint_name: String, ?model_class: singleton(Model)) ?{ (Model? instance, String? error) -> void } -> void
-    def self.create: (Hash[untyped, untyped] attrs, ?model_class: singleton(Model)) ?{ (Model? instance, untyped error) -> void } -> void
-    def self.destroy: (?untyped id) ?{ (bool? success, untyped error) -> void } -> void
+    # On storage :local models these methods are synchronous instead
+    # (bare-class alias): no blocks, direct return values.
+    def self.all: (?Hash[untyped, untyped] params) ?{ (Array[Model]? instances, String? error) -> void } -> untyped
+    def self.find: (?untyped id, ?endpoint_name: String, ?model_class: singleton(Model)) ?{ (Model? instance, String? error) -> void } -> untyped
+    def self.create: (?Hash[untyped, untyped] attrs, **untyped kw) ?{ (Model? instance, untyped error) -> void } -> untyped
+    def self.destroy: (?untyped id) ?{ (bool? success, untyped error) -> void } -> untyped
 
-    def update: (?Hash[untyped, untyped]? attrs) ?{ (Model? instance, untyped error) -> void } -> void
-    def destroy: () ?{ (bool? success, untyped error) -> void } -> void
-    def reload: () ?{ (Model? instance, String? error) -> void } -> void
+    def update: (?Hash[untyped, untyped]? attrs) ?{ (Model? instance, untyped error) -> void } -> untyped
+    def destroy: () ?{ (bool? success, untyped error) -> void } -> untyped
+    def reload: () ?{ (Model? instance, String? error) -> void } -> untyped
+
+    # storage :local CRUD and the bare-class alias
+    def self.define_local_accessors: (Hash[String, Symbol] columns) -> void
+    def self.define_local_accessor: (String name, Array[Symbol] existing) -> void
+    def self.merge_keyword_attrs: (Hash[untyped, untyped] attrs, Hash[Symbol, untyped] kw) -> Hash[untyped, untyped]
+    def self.local_create: (?Hash[untyped, untyped] attrs) -> Model
+    def self.local_query: (String method_name) -> Relation
+    def self.where: (?Hash[untyped, untyped] | String | nil conditions, *untyped binds) -> Relation
+    def self.order: (*untyped args) -> Relation
+    def self.limit: (Integer? n) -> Relation
+    def self.offset: (Integer? n) -> Relation
+    def self.count: () -> Integer
+    def self.first: () -> untyped
+    def self.exists?: () -> bool
+    def self.find_by: (Hash[untyped, untyped] conditions) -> untyped
+    def self.delete_all: () -> Integer
+
+    def new_record?: () -> bool
+    def __track_local_change: (String name, untyped value, untyped old) -> void
+    def __local_insert: () -> Model
+    def __local_update: (Hash[untyped, untyped]? attrs) -> bool
+    def __local_destroy: () -> bool
+    def __sync_from_row: () -> void
+    def __hydrate_local: (Hash[untyped, untyped] attrs) -> void
+    def __set_local_baseline: (Hash[untyped, untyped] attrs) -> void
   end
 end

--- a/sig/model.rbs
+++ b/sig/model.rbs
@@ -14,6 +14,7 @@ module Funicular
     self.@collecting_migrations: bool?
     self.@refresh_mode: Symbol?
     self.@table_name: String?
+    self.@associations: Hash[Symbol, Hash[Symbol, untyped]]?
     self.@local_columns: Hash[String, Symbol]?
 
     def self.schema: () -> Hash[String, Hash[String, untyped]]
@@ -42,8 +43,26 @@ module Funicular
     def self.validate_local_migrations: () -> void
     def self.refresh: (Symbol mode) -> Symbol
     def self.refresh_mode: () -> Symbol
+
+    # Associations: declaration-time metadata plus lazily resolved
+    # targets. The generated readers are dynamic, like the accessors.
+    def self.belongs_to: (Symbol | String name, ?class_name: (String | Symbol)?, ?foreign_key: (String | Symbol)?, **untyped rest) -> nil
+    def self.has_many: (Symbol | String name, ?class_name: (String | Symbol)?, ?foreign_key: (String | Symbol)?, **untyped rest) -> nil
+    def self.__reject_association_options: (Symbol kind, Symbol | String name, Hash[Symbol, untyped] rest) -> nil
+    def self.__register_association: (Symbol key) -> nil
+    def self.__assert_association_name_free: (Symbol key) -> nil
+    def self.__associations: () -> Hash[Symbol, Hash[Symbol, untyped]]
+    def self.__association_target: (Symbol key, String class_name) -> untyped
+    def self.__resolve_association_constant: (Symbol key, String class_name) -> untyped
+    def self.__unresolvable_association: (Symbol key, String class_name) -> String
+    def self.__assert_no_association_conflict: (Array[String] names) -> nil
+
     def self.table_name: (?(String | Symbol)? explicit) -> String
     def self.derive_table_name: () -> String
+    def self.demodulized_snake_name: () -> String
+    def self.__pluralize: (String name) -> String
+    def self.__singularize: (String name) -> String
+    def self.__camelize: (String name) -> String
     def self.local: () -> Relation
 
     # Relation protocol (mrblib/relation.rb)

--- a/sig/model.rbs
+++ b/sig/model.rbs
@@ -8,6 +8,7 @@ module Funicular
     @local_baseline: Hash[String, untyped]?
     @provided_attributes: Hash[String, bool]?
 
+    self.@registered_models: Array[untyped]?
     self.@storage_kind: Symbol?
     self.@local_migrations: Array[Hash[Symbol, untyped]]?
     self.@collecting_migrations: bool?
@@ -19,6 +20,10 @@ module Funicular
     def self.schema=: (Hash[String, Hash[String, untyped]] schema) -> Hash[String, Hash[String, untyped]]
     def self.endpoints: () -> Hash[String, Hash[String, String]]
     def self.endpoints=: (Hash[String, Hash[String, String]] endpoints) -> Hash[String, Hash[String, String]]
+
+    def self.inherited: (untyped subclass) -> void
+    def self.__register_model: (untyped subclass) -> nil
+    def self.__registered_models: () -> Array[untyped]
 
     def initialize: (?Hash[untyped, untyped] attributes) -> void
     def self.load_schema: (Hash[String, untyped] schema_data) -> void

--- a/sig/relation.rbs
+++ b/sig/relation.rbs
@@ -25,6 +25,7 @@ module Funicular
     def find_by: (Hash[untyped, untyped] conditions) -> untyped
     def delete_all: () -> Integer
     def to_sql: () -> String
+    def __event_source: () -> [Symbol, String]
 
     private def append_condition: (Array[String] w, Array[untyped] b, untyped col, untyped value) -> void
     private def order_term: (untyped col, untyped dir) -> String

--- a/sig/relation.rbs
+++ b/sig/relation.rbs
@@ -1,0 +1,43 @@
+module Funicular
+  class Relation
+    @model: untyped
+    @where_sql: Array[String]
+    @where_binds: Array[untyped]
+    @order_sql: Array[String]
+    @limit: Integer?
+    @offset: Integer?
+
+    def initialize: (untyped model, ?Array[String] where_sql,
+                     ?Array[untyped] where_binds, ?Array[String] order_sql,
+                     ?Integer? limit, ?Integer? offset) -> void
+
+    def where: (?Hash[untyped, untyped] | String | nil conditions, *untyped binds) -> Relation
+    def order: (*untyped args) -> Relation
+    def limit: (Integer? n) -> Relation
+    def offset: (Integer? n) -> Relation
+
+    def to_a: () -> Array[untyped]
+    def each: () { (untyped record) -> void } -> Array[untyped]
+    def first: () -> untyped
+    def count: () -> Integer
+    def exists?: () -> bool
+    def find: (untyped id) -> untyped
+    def find_by: (Hash[untyped, untyped] conditions) -> untyped
+    def delete_all: () -> Integer
+    def to_sql: () -> String
+
+    private def append_condition: (Array[String] w, Array[untyped] b, untyped col, untyped value) -> void
+    private def order_term: (untyped col, untyped dir) -> String
+    private def validate_column: (untyped col) -> String
+    private def quote: (String name) -> String
+    private def quoted_table: () -> String
+    private def select_sql: () -> String
+    private def where_clause: () -> String
+    private def order_clause: () -> String
+    private def slice_clause: () -> String
+    private def slice_arg: (Integer? n, String label) -> Integer?
+    private def decode_row: (Array[String] cols, untyped row) -> Hash[String, untyped]
+    private def single_value: (String sql) -> untyped
+    private def model_label: () -> untyped
+  end
+end

--- a/test/association_test.rb
+++ b/test/association_test.rb
@@ -1,0 +1,382 @@
+# Tests for belongs_to / has_many (docs/local_database.md,
+# "Associations"): the <name>_id convention, the class_name: and
+# foreign_key: overrides, lazy target resolution, and the guards around
+# both. The model names here are the documentation's own (Post, User,
+# Comment), so the derived names -- user_id, post_id, comments ->
+# Comment -- are exactly what the docs promise.
+
+class AssociationTest < Picotest::Test
+  def setup
+    $assoc_db = SQLite3::Database.new(":memory:")
+    define_models
+    Funicular::DB.apply_local_migrations($assoc_db, User)
+    Funicular::DB.apply_local_migrations($assoc_db, Post)
+    Funicular::DB.apply_local_migrations($assoc_db, Comment)
+    Funicular::DB.apply_local_migrations($assoc_db, Editor)
+    Funicular::DB.apply_local_migrations($assoc_db, AssocNs::Note)
+    Funicular::DB.apply_local_migrations($assoc_db, AssocDecoy)
+  end
+
+  def teardown
+    $assoc_db.close
+  end
+
+  def define_models
+    return if Object.const_defined?(:Post)
+
+    Object.const_set(:Post, Class.new(Funicular::Model))
+    Post.class_eval do
+      storage :local do
+        migrate 1 do |t|
+          t.string :title
+          t.integer :user_id
+          t.integer :editor_id
+          t.integer :ghost_id
+          t.integer :note_id
+          t.integer :decoy_id
+        end
+      end
+      belongs_to :user
+      has_many :comments
+      # Declared BEFORE the target exists (Editor is defined at the
+      # bottom of this method): resolution must wait until first read.
+      belongs_to :editor, class_name: "Editor", foreign_key: :editor_id
+      belongs_to :ghost
+      # A namespaced target, the only reason the "::" walk exists.
+      belongs_to :note, class_name: "AssocNs::Note", foreign_key: :note_id
+      # AssocNs carries no AssocDecoy of its own -- but ::AssocDecoy
+      # does exist, and AssocNs (a class) inherits from Object.
+      belongs_to :decoy, class_name: "AssocNs::AssocDecoy",
+                         foreign_key: :decoy_id
+      # Resolves to something that is not a model class.
+      belongs_to :bare_module, class_name: "AssocBare", foreign_key: :decoy_id
+
+      def self.local_db
+        $assoc_db
+      end
+
+      def self.local_table_changed
+        nil
+      end
+    end
+
+    Object.const_set(:User, Class.new(Funicular::Model))
+    User.class_eval do
+      storage :local do
+        migrate 1 do |t|
+          t.string :name
+        end
+      end
+      has_many :posts
+      # Both halves overridden: the target is not the singularized
+      # association name, and the key is not derived from User.
+      has_many :written_comments, class_name: "Comment",
+                                  foreign_key: :author_id
+
+      def self.local_db
+        $assoc_db
+      end
+
+      def self.local_table_changed
+        nil
+      end
+    end
+
+    Object.const_set(:Comment, Class.new(Funicular::Model))
+    Comment.class_eval do
+      storage :local do
+        migrate 1 do |t|
+          t.string :body
+          t.integer :post_id
+          t.integer :author_id
+        end
+      end
+
+      def self.local_db
+        $assoc_db
+      end
+
+      def self.local_table_changed
+        nil
+      end
+    end
+
+    # A CLASS used as a namespace: unlike a module, it inherits from
+    # Object, which is exactly how a nested miss can fall through to a
+    # top-level constant.
+    Object.const_set(:AssocNs, Class.new)
+    AssocNs.const_set(:Note, Class.new(Funicular::Model))
+    AssocNs::Note.class_eval do
+      table_name "assoc_notes"
+      storage :local do
+        migrate 1 do |t|
+          t.string :body
+        end
+      end
+
+      def self.local_db
+        $assoc_db
+      end
+
+      def self.local_table_changed
+        nil
+      end
+    end
+
+    # The decoy the fall-through would find: a real, queryable model.
+    Object.const_set(:AssocDecoy, Class.new(Funicular::Model))
+    AssocDecoy.class_eval do
+      storage :local do
+        migrate 1 do |t|
+          t.string :body
+        end
+      end
+
+      def self.local_db
+        $assoc_db
+      end
+
+      def self.local_table_changed
+        nil
+      end
+    end
+
+    Object.const_set(:AssocBare, Module.new)
+
+    Object.const_set(:Editor, Class.new(Funicular::Model))
+    Editor.class_eval do
+      table_name "editors"
+      storage :local do
+        migrate 1 do |t|
+          t.string :name
+        end
+      end
+
+      def self.local_db
+        $assoc_db
+      end
+
+      def self.local_table_changed
+        nil
+      end
+    end
+  end
+
+  # ---- belongs_to ----
+
+  def test_belongs_to_reads_the_target_through_the_id_convention
+    user = User.local_create(name: "ada")
+    post = Post.local_create(title: "hello", user_id: user.id)
+    assert_equal(user.id, post.user.id)
+    assert_equal("ada", post.user.name)
+  end
+
+  def test_belongs_to_returns_nil_without_a_foreign_key
+    post = Post.local_create(title: "orphan")
+    assert_nil(post.user)
+  end
+
+  def test_belongs_to_returns_nil_when_the_row_is_gone
+    post = Post.local_create(title: "dangling", user_id: 999)
+    assert_nil(post.user)
+  end
+
+  def test_belongs_to_honours_class_name_and_foreign_key
+    editor = Editor.local_create(name: "grace")
+    post = Post.local_create(title: "edited", editor_id: editor.id)
+    assert_equal(editor.id, post.editor.id)
+  end
+
+  # ---- has_many ----
+
+  def test_has_many_returns_a_chainable_relation
+    post = Post.local_create(title: "thread")
+    other = Post.local_create(title: "elsewhere")
+    Comment.local_create(body: "first", post_id: post.id)
+    Comment.local_create(body: "second", post_id: post.id)
+    Comment.local_create(body: "unrelated", post_id: other.id)
+
+    assert_equal(true, post.comments.is_a?(Funicular::Relation))
+    assert_equal(2, post.comments.count)
+    # The documented chain: post.comments.order(...).limit(...)
+    bodies = post.comments.order(:id).limit(1).to_a.map { |c| c.body }
+    assert_equal(["first"], bodies)
+  end
+
+  def test_has_many_derives_the_foreign_key_from_the_declaring_class
+    user = User.local_create(name: "ada")
+    Post.local_create(title: "mine", user_id: user.id)
+    Post.local_create(title: "theirs")
+    assert_equal(1, user.posts.count)
+    assert_equal("mine", user.posts.first.title)
+  end
+
+  def test_has_many_honours_class_name_and_foreign_key
+    user = User.local_create(name: "ada")
+    Comment.local_create(body: "hers", author_id: user.id)
+    Comment.local_create(body: "someone else's", author_id: user.id + 1)
+    # Neither the conventional target (WrittenComment) nor the
+    # conventional key (user_id) is involved.
+    assert_equal(1, user.written_comments.count)
+    assert_equal("hers", user.written_comments.first.body)
+  end
+
+  def test_has_many_on_an_unsaved_parent_is_empty
+    # A nil id must not read as IS NULL and adopt every orphan row.
+    Comment.local_create(body: "orphan")
+    post = Post.new(title: "unsaved")
+    assert_nil(post.id)
+    assert_equal(0, post.comments.count)
+  end
+
+  def test_has_many_relation_watches_the_target_table
+    # All watch needs from a relation is its event source: the role and
+    # table the change events for these rows carry.
+    post = Post.local_create(title: "watched")
+    assert_equal([:local, "comments"], post.comments.__event_source)
+  end
+
+  # ---- target resolution ----
+
+  def test_the_target_resolves_lazily_at_first_read
+    # Post's class body declared `belongs_to :editor` (and :ghost) while
+    # neither constant existed: eager resolution would have raised in
+    # setup, before any of these tests ran. Editor exists by now, so
+    # the first READ is what resolves it.
+    editor = Editor.local_create(name: "grace")
+    post = Post.local_create(title: "late", editor_id: editor.id)
+    assert_equal("grace", post.editor.name)
+  end
+
+  def test_an_unresolvable_target_raises_at_first_read
+    post = Post.local_create(title: "spooky", ghost_id: 1)
+    error = nil
+    begin
+      post.ghost
+    rescue => e
+      error = e
+    end
+    assert_equal(NameError, error.class)
+    # The message names the association and the constant it looked for.
+    assert_equal(true, error.message.include?("ghost"))
+    assert_equal(true, error.message.include?("Ghost"))
+  end
+
+  def test_a_namespaced_class_name_resolves_through_the_walk
+    note = AssocNs::Note.local_create(body: "nested")
+    post = Post.local_create(title: "namespaced", note_id: note.id)
+    found = post.note
+    assert_equal(AssocNs::Note, found.class)
+    assert_equal("nested", found.body)
+  end
+
+  def test_a_nested_miss_never_falls_through_to_the_top_level
+    # AssocNs has no AssocDecoy; ::AssocDecoy does, and AssocNs inherits from
+    # Object. Resolving to that decoy would query a different model's
+    # table under the name the app asked for.
+    AssocDecoy.local_create(body: "wrong model")
+    post = Post.local_create(title: "misnamed", decoy_id: 1)
+    error = nil
+    begin
+      post.decoy
+    rescue => e
+      error = e
+    end
+    assert_equal(NameError, error.class)
+    assert_equal(true, error.message.include?("AssocNs::AssocDecoy"))
+  end
+
+  def test_a_target_that_is_not_a_model_class_is_refused
+    post = Post.local_create(title: "module", decoy_id: 1)
+    error = nil
+    begin
+      post.bare_module
+    rescue => e
+      error = e
+    end
+    assert_equal(NameError, error.class)
+    assert_equal(true, error.message.include?("AssocBare"))
+  end
+
+  # ---- declaration guards ----
+
+  def test_unsupported_options_are_refused_at_declaration
+    assert_raise(ArgumentError) do
+      Class.new(Funicular::Model) { has_many :comments, through: :posts }
+    end
+    assert_raise(ArgumentError) do
+      Class.new(Funicular::Model) { belongs_to :owner, polymorphic: true }
+    end
+  end
+
+  def test_an_association_colliding_with_a_column_raises
+    klass = Class.new(Funicular::Model) do
+      table_name "collisions"
+      storage :local do
+        migrate 1 do |t|
+          t.string :comments
+        end
+      end
+      has_many :comments
+    end
+    # The declaration alone is fine; the accessor generation is where
+    # the column and the association first meet.
+    error = nil
+    begin
+      klass.local_columns
+    rescue => e
+      error = e
+    end
+    assert_equal(ArgumentError, error.class)
+    assert_equal(true, error.message.include?("comments"))
+  end
+
+  def test_a_schema_attribute_colliding_with_an_association_raises
+    # The replica half of the same guard: these accessors come from the
+    # REST schema, so the collision surfaces at the boot-time load.
+    klass = Class.new(Funicular::Model) do
+      belongs_to :author
+    end
+    error = nil
+    begin
+      klass.load_schema(
+        { "attributes" => { "author" => { "type" => "string" } } })
+    rescue => e
+      error = e
+    end
+    assert_equal(ArgumentError, error.class)
+    assert_equal(true, error.message.include?("author"))
+  end
+
+  def test_an_association_named_after_a_framework_method_raises
+    # has_many :errors would replace Validations#errors, and valid?
+    # (which calls errors.clear) would then die on a Relation -- with
+    # nothing said at declaration or at first read.
+    error = nil
+    begin
+      Class.new(Funicular::Model) { has_many :errors }
+    rescue => e
+      error = e
+    end
+    assert_equal(ArgumentError, error.class)
+    assert_equal(true, error.message.include?("errors"))
+    # Only the framework's own API is reserved; ordinary names pass.
+    klass = Class.new(Funicular::Model) { has_many :comments }
+    assert_equal(true, klass.__associations.has_key?(:comments))
+  end
+
+  def test_declaring_the_same_association_twice_raises
+    # Last-one-wins would drop the first reader without a word.
+    error = nil
+    begin
+      Class.new(Funicular::Model) do
+        has_many :comments
+        has_many :comments, foreign_key: :other_id
+      end
+    rescue => e
+      error = e
+    end
+    assert_equal(ArgumentError, error.class)
+    assert_equal(true, error.message.include?("comments"))
+  end
+end

--- a/test/boot_barrier_test.rb
+++ b/test/boot_barrier_test.rb
@@ -9,6 +9,10 @@ module Funicular
   module HTTP
     class << self
       def get(url, &block)
+        # Recorded at ISSUE time: the epoch must already be latched
+        # when the first schema request leaves.
+        log = $bar_epoch_log
+        log << Funicular::DB.session_epoch if log
         $bar_pending << [url, block]
       end
     end
@@ -50,6 +54,7 @@ class BootBarrierTest < Picotest::Test
   def setup
     JS.global.eval(FAKE_JS)
     $bar_pending = []
+    $bar_epoch_log = []
     define_models
   end
 
@@ -206,6 +211,23 @@ class BootBarrierTest < Picotest::Test
     assert_equal(:ready, Funicular::DB.boot_state)
     # Already booted: the gate is a cheap true, not a second boot.
     assert_equal(true, Funicular.__boot_for_start)
+  end
+
+  def test_page_epoch_is_latched_before_schema_requests
+    # A session rotated DURING schema loading must not slip past the
+    # check just because DB.boot (the usual latch point) has not run
+    # yet: the barrier arms the page's epoch first.
+    Funicular.load_schemas({ BarUser => "bar_user" }) { }
+    assert_equal(["epoch-7"], $bar_epoch_log)
+    # A page WITHOUT an epoch latches nothing -- the checks stay off,
+    # which is distinct from "merely not booted yet".
+    Funicular::DB.__reset_boot
+    JS.global.eval(
+      "globalThis.document = { querySelector: (s) => ({ dataset: {" \
+      "  funicularApplicationId: 'bar_app'," \
+      "  funicularAnonymousOnly: 'true' } }) }")
+    Funicular.load_schemas({ BarUser => "bar_user" }) { }
+    assert_equal(["epoch-7", nil], $bar_epoch_log)
   end
 
   def test_read_page_metadata_contract

--- a/test/boot_barrier_test.rb
+++ b/test/boot_barrier_test.rb
@@ -1,0 +1,240 @@
+# Tests for the schema boot barrier + start gate (docs decision 19,
+# wiring half): every request settles exactly once (HTTP errors and
+# unappliable schemas included), all-green boots the database and only
+# then runs the completion block, any failure marks the boot failed
+# and mounts nothing. Page metadata rides a fake document; HTTP
+# responses are deferred so the barrier's async nature is real.
+
+module Funicular
+  module HTTP
+    class << self
+      def get(url, &block)
+        $bar_pending << [url, block]
+      end
+    end
+  end
+end
+
+class BootBarrierTest < Picotest::Test
+  FAKE_JS = <<~'FUNICULAR_BARRIER_FAKE'
+    globalThis.__funicularLocksApi = {
+      request(name, opts, cb) {
+        const held = cb({ name: name });
+        return Promise.resolve(held);
+      }
+    };
+    globalThis.__funicularStorageApi = null;
+    globalThis.document = {
+      querySelector(sel) {
+        return {
+          dataset: {
+            funicularApplicationId: "bar_app",
+            funicularAnonymousOnly: "true",
+            funicularEpoch: "epoch-7",
+          }
+        };
+      },
+      addEventListener(type, fn) {},
+      visibilityState: "visible",
+    };
+  FUNICULAR_BARRIER_FAKE
+
+  USER_SCHEMA = {
+    "attributes" => {
+      "id" => { "readonly" => true, "type" => "integer" },
+      "name" => { "type" => "string" },
+    },
+    "endpoints" => {},
+  }
+
+  def setup
+    JS.global.eval(FAKE_JS)
+    $bar_pending = []
+    define_models
+  end
+
+  def teardown
+    Funicular::DB.__reset_boot
+    Funicular::DB.__reset_config
+    JS.global.eval(FAKE_JS)
+  end
+
+  def define_models
+    return if Object.const_defined?(:BarUser)
+
+    Object.const_set(:BarUser, Class.new(Funicular::Model))
+    BarUser.class_eval do
+      table_name "bar_users"
+    end
+
+    Object.const_set(:BarPost, Class.new(Funicular::Model))
+    BarPost.class_eval do
+      table_name "bar_posts"
+    end
+
+    Object.const_set(:BarDraft, Class.new(Funicular::Model))
+    BarDraft.class_eval do
+      table_name "bar_drafts"
+      storage :local do
+        migrate 1 do |t|
+          t.string :title
+        end
+      end
+    end
+  end
+
+  def respond(url, response)
+    i = 0
+    pending_size = $bar_pending.size
+    while i < pending_size
+      entry = $bar_pending[i]
+      if entry[0] == url
+        $bar_pending.delete_at(i)
+        entry[1].call(response)
+        return true
+      end
+      i += 1
+    end
+    false
+  end
+
+  def ok(data)
+    Funicular::HTTP::Response.new(200, data)
+  end
+
+  def test_all_green_boots_then_runs_the_block_once
+    $bar_done = 0
+    Funicular.load_schemas({ BarUser => "bar_user",
+                             BarPost => "bar_post" }) do
+      $bar_done += 1
+    end
+    # The block waits for the WHOLE barrier and the boot.
+    assert_equal(0, $bar_done)
+    assert_equal(true, respond("/api/schema/bar_user", ok(USER_SCHEMA)))
+    assert_equal(0, $bar_done)
+    assert_equal(true, respond("/api/schema/bar_post", ok(USER_SCHEMA)))
+    assert_equal(1, $bar_done)
+    assert_equal(:ready, Funicular::DB.boot_state)
+    # The page metadata reached the boot: epoch and namespace.
+    assert_equal("epoch-7", Funicular::DB.session_epoch)
+    # The declared set came from the model registry: the local table
+    # exists too.
+    assert_equal(0, BarDraft.count)
+    assert_equal([[0]],
+                 Funicular::DB.replica.execute(
+                   "SELECT COUNT(*) FROM bar_users"))
+  end
+
+  def test_partial_failure_settles_aggregates_and_never_completes
+    $bar_done = 0
+    $bar_errors = nil
+    Funicular::DB.configure do
+      config.on_boot_error = ->(errors) { $bar_errors = errors }
+    end
+    Funicular.load_schemas({ BarUser => "bar_user",
+                             BarPost => "bar_post" }) do
+      $bar_done += 1
+    end
+    respond("/api/schema/bar_user", ok(USER_SCHEMA))
+    # The HTTP failure SETTLES its slot -- the barrier completes
+    # instead of hanging -- but the round is a failure.
+    respond("/api/schema/bar_post",
+            Funicular::HTTP::Response.new(500, nil))
+    assert_equal(0, $bar_done)
+    assert_equal(:failed, Funicular::DB.boot_state)
+    assert_equal(1, $bar_errors.size)
+    assert_equal(Funicular::DB::Error, $bar_errors[0].class)
+    # Even with an empty error body the report stays precise: the
+    # schema, the model, and the HTTP status are always named.
+    message = $bar_errors[0].message
+    assert_equal(true, message.include?("bar_post"))
+    assert_equal(true, message.include?("BarPost"))
+    assert_equal(true, message.include?("HTTP 500"))
+    # start refuses to mount on top of the failure.
+    assert_equal(false, Funicular.__boot_for_start)
+  end
+
+  def test_unappliable_schema_settles_as_a_failure
+    $bar_done = 0
+    $bar_errors = nil
+    Funicular::DB.configure do
+      config.on_boot_error = ->(errors) { $bar_errors = errors }
+    end
+    Funicular.load_schemas({ BarUser => "bar_user",
+                             BarPost => "bar_post" }) do
+      $bar_done += 1
+    end
+    # The payload arrives but cannot be applied: it settles as a
+    # failure instead of hanging the barrier.
+    respond("/api/schema/bar_user", ok({}))
+    respond("/api/schema/bar_post", ok(USER_SCHEMA))
+    assert_equal(0, $bar_done)
+    assert_equal(:failed, Funicular::DB.boot_state)
+    assert_equal(1, $bar_errors.size)
+    # The wrapper names the culprit among several models.
+    assert_equal(Funicular::DB::Error, $bar_errors[0].class)
+    assert_equal(true, $bar_errors[0].message.include?("bar_user"))
+    assert_equal(true, $bar_errors[0].message.include?("BarUser"))
+  end
+
+  def test_empty_barrier_with_a_schema_less_replica_model_fails
+    # Decision 6: an empty schema set is valid ONLY when no replica
+    # model is declared. BarUser is declared (registry) but its schema
+    # never arrives -- the boot must fail loud, not run on a missing
+    # table.
+    $bar_done = 0
+    $bar_errors = nil
+    Funicular::DB.configure do
+      config.on_boot_error = ->(errors) { $bar_errors = errors }
+    end
+    BarUser.schema = nil
+    BarUser.instance_variable_set(:@local_columns, nil)
+    Funicular.load_schemas({}) do
+      $bar_done += 1
+    end
+    assert_equal(0, $bar_done)
+    assert_equal(:failed, Funicular::DB.boot_state)
+    assert_equal(1, $bar_errors.size)
+  end
+
+  def test_boot_for_start_boots_local_only_apps
+    # No load_schemas round: start's gate boots directly from the
+    # registry and the page metadata.
+    BarUser.load_schema(USER_SCHEMA)
+    BarPost.load_schema(USER_SCHEMA)
+    assert_equal(true, Funicular.__boot_for_start)
+    assert_equal(:ready, Funicular::DB.boot_state)
+    # Already booted: the gate is a cheap true, not a second boot.
+    assert_equal(true, Funicular.__boot_for_start)
+  end
+
+  def test_read_page_metadata_contract
+    JS.global.eval(
+      "globalThis.document = { querySelector: (s) => ({ dataset: {" \
+      "  funicularApplicationId: 'meta_app'," \
+      "  funicularUserKey: 'k1'," \
+      "  funicularUserKeyConfigured: 'true'," \
+      "  funicularEpoch: 'e9' } }) }")
+    meta = Funicular::DB.read_page_metadata
+    assert_equal("meta_app", meta[:application_id])
+    assert_equal("k1", meta[:user_key])
+    assert_equal(true, meta[:user_key_configured])
+    assert_equal(false, meta[:anonymous_only])
+    assert_equal("e9", meta[:epoch])
+    # No include tag on the page: the replica-only anonymous default.
+    JS.global.eval(
+      "globalThis.document = { querySelector: (s) => null }")
+    assert_equal({}, Funicular::DB.read_page_metadata)
+  end
+
+  def test_every_model_subclass_registers_itself
+    klass = Class.new(Funicular::Model)
+    # Ephemeral so the leftover registration never disturbs the boots
+    # of the other tests in this VM.
+    klass.class_eval do
+      storage :ephemeral
+    end
+    assert_equal(true,
+                 Funicular::Model.__registered_models.include?(klass))
+  end
+end

--- a/test/boot_barrier_test.rb
+++ b/test/boot_barrier_test.rb
@@ -32,6 +32,7 @@ class BootBarrierTest < Picotest::Test
       querySelector(sel) {
         return {
           dataset: {
+            funicularLocalDatabase: "true",
             funicularApplicationId: "bar_app",
             funicularAnonymousOnly: "true",
             funicularEpoch: "epoch-7",
@@ -228,6 +229,101 @@ class BootBarrierTest < Picotest::Test
     assert_equal(true, Funicular.__boot_for_start)
   end
 
+  def test_disabled_start_bypasses_the_database_for_rest_only_models
+    registered = Funicular::Model.instance_variable_get(:@registered_models)
+    JS.global.eval(
+      "globalThis.__disabledLockCalls = 0; " \
+      "globalThis.__funicularLocksApi = { request: () => { " \
+      "globalThis.__disabledLockCalls += 1; throw new Error('lock used') } }; " \
+      "globalThis.document = { querySelector: (s) => null }")
+    Funicular::Model.instance_variable_set(:@registered_models,
+                                           [BarUser, BarPost])
+    begin
+      assert_equal(true, Funicular.__boot_for_start)
+      assert_equal(:unbooted, Funicular::DB.boot_state)
+      assert_equal(:unbooted, Funicular::DB.durability)
+      assert_equal(0, JS.global[:__disabledLockCalls].to_i)
+    ensure
+      Funicular::Model.instance_variable_set(:@registered_models, registered)
+    end
+  end
+
+  def test_disabled_start_rejects_an_explicit_local_model
+    JS.global.eval(
+      "globalThis.document = { querySelector: (s) => null }")
+    assert_raise(Funicular::DB::ConfigError) do
+      Funicular.start(container: "must_not_be_looked_up") { }
+    end
+    assert_equal(:unbooted, Funicular::DB.boot_state)
+  end
+
+  def test_disabled_runtime_local_apis_fail_as_unavailable
+    JS.global.eval(
+      "globalThis.document = { querySelector: (s) => null }")
+    operations = [
+      -> { BarDraft.count },
+      -> { BarDraft.on_change { } },
+      -> { BarDraft.reset_local },
+      -> { Funicular::DB.local },
+      -> { Funicular::DB.replica },
+      -> { Funicular::DB.flush },
+      -> { Funicular::DB.wipe },
+    ]
+    i = 0
+    operations_size = operations.size
+    while i < operations_size
+      assert_raise(Funicular::DB::UnavailableError) do
+        operations[i].call
+      end
+      i += 1
+    end
+    error = nil
+    begin
+      Funicular::DB.local
+    rescue => e
+      error = e
+    end
+    assert_equal(true, error.message.include?("local database is disabled"))
+    assert_equal(true, error.message.include?("config.local_database = true"))
+    # Hook configuration and state inspection remain available.
+    Funicular::DB.configure do
+      config.on_boot_error = ->(_errors) { }
+    end
+    assert_equal(:unbooted, Funicular::DB.boot_state)
+    assert_equal(:unbooted, Funicular::DB.durability)
+  end
+
+  def test_disabled_schema_barrier_loads_rest_schema_without_booting
+    JS.global.eval(
+      "globalThis.document = { querySelector: (s) => null }")
+    $bar_done = 0
+    Funicular.load_schemas({ BarUser => "bar_user" }) do
+      $bar_done += 1
+    end
+    respond("/api/schema/bar_user", ok(USER_SCHEMA))
+    assert_equal(1, $bar_done)
+    assert_equal(:unbooted, Funicular::DB.boot_state)
+    assert_equal(:unbooted, Funicular::DB.durability)
+  end
+
+  def test_disabled_schema_failure_reports_without_failing_db_state
+    JS.global.eval(
+      "globalThis.document = { querySelector: (s) => null }")
+    $bar_done = 0
+    $bar_errors = nil
+    Funicular::DB.configure do
+      config.on_boot_error = ->(errors) { $bar_errors = errors }
+    end
+    Funicular.load_schemas({ BarUser => "bar_user" }) do
+      $bar_done += 1
+    end
+    respond("/api/schema/bar_user", Funicular::HTTP::Response.new(500, nil))
+    assert_equal(0, $bar_done)
+    assert_equal(1, $bar_errors.size)
+    assert_equal(:unbooted, Funicular::DB.boot_state)
+    assert_equal(:unbooted, Funicular::DB.durability)
+  end
+
   def test_page_epoch_is_latched_before_schema_requests
     # A session rotated DURING schema loading must not slip past the
     # check just because DB.boot (the usual latch point) has not run
@@ -253,15 +349,28 @@ class BootBarrierTest < Picotest::Test
       "  funicularUserKeyConfigured: 'true'," \
       "  funicularEpoch: 'e9' } }) }")
     meta = Funicular::DB.read_page_metadata
+    assert_equal(true, meta[:local_database])
     assert_equal("meta_app", meta[:application_id])
     assert_equal("k1", meta[:user_key])
     assert_equal(true, meta[:user_key_configured])
     assert_equal(false, meta[:anonymous_only])
     assert_equal("e9", meta[:epoch])
-    # No include tag on the page: the replica-only anonymous default.
+    # No opt-in tag on the page means that the subsystem is disabled.
     JS.global.eval(
       "globalThis.document = { querySelector: (s) => null }")
     assert_equal({}, Funicular::DB.read_page_metadata)
+  end
+
+  def test_opt_in_flag_is_latched_from_the_page_once
+    JS.global.eval(
+      "globalThis.__metaReads = 0; globalThis.__metaEnabled = false; " \
+      "globalThis.document = { querySelector: (s) => { " \
+      "globalThis.__metaReads += 1; return globalThis.__metaEnabled ? " \
+      "{ dataset: { funicularLocalDatabase: 'true' } } : null } }")
+    assert_equal(false, Funicular::DB.local_database_enabled?)
+    JS.global.eval("globalThis.__metaEnabled = true")
+    assert_equal(false, Funicular::DB.local_database_enabled?)
+    assert_equal(1, JS.global[:__metaReads].to_i)
   end
 
   def test_every_model_subclass_registers_itself

--- a/test/boot_barrier_test.rb
+++ b/test/boot_barrier_test.rb
@@ -159,6 +159,21 @@ class BootBarrierTest < Picotest::Test
     assert_equal(false, Funicular.__boot_for_start)
   end
 
+  def test_start_mounts_nothing_on_a_failed_boot
+    # The whole point of the gate: after a failed boot, start returns
+    # nil BEFORE any DOM work -- no container lookup, no listener, no
+    # mount. The fake document here has no getElementById, so slipping
+    # past the gate would raise instead of quietly passing.
+    Funicular::DB.configure do
+      config.on_boot_error = ->(_errors) {}
+    end
+    Funicular.load_schemas({ BarUser => "bar_user" }) { }
+    respond("/api/schema/bar_user",
+            Funicular::HTTP::Response.new(500, nil))
+    assert_equal(:failed, Funicular::DB.boot_state)
+    assert_equal(nil, Funicular.start(container: "bar_missing"))
+  end
+
   def test_unappliable_schema_settles_as_a_failure
     $bar_done = 0
     $bar_errors = nil

--- a/test/boot_test.rb
+++ b/test/boot_test.rb
@@ -1,0 +1,446 @@
+# Tests for DB.boot (docs decision 19): the wiring of namespace,
+# election, snapshot store, restore, migrations, replica DDL, and the
+# guarded handles -- plus the SchemaTooNew whole-DB lockdown (docs
+# decision 7) and Model.reset_local. The Web Locks fake rides the
+# shim's injection seam; the snapshot store is injected before boot
+# (no store injected = the real IndexedDB open fails under Node =
+# the volatile path).
+
+class BootTest < Picotest::Test
+  FAKE_JS = <<~'FUNICULAR_BOOT_FAKE'
+    globalThis.__lockFake = { mode: "grant" };
+    globalThis.__funicularLocksApi = {
+      request(name, opts, cb) {
+        if (globalThis.__lockFake.mode === "busy") {
+          return Promise.resolve(cb(null));
+        }
+        const held = cb({ name: name });
+        return Promise.resolve(held);
+      }
+    };
+    globalThis.__funicularStorageApi = null;
+  FUNICULAR_BOOT_FAKE
+
+  class FakeStore
+    attr_reader :data, :put_count
+
+    def initialize
+      @data = {}
+      @put_count = 0
+    end
+
+    def [](key)
+      @data[key]
+    end
+
+    def []=(key, value)
+      @put_count += 1
+      @data[key] = value
+    end
+
+    def delete(key)
+      @data.delete(key)
+      nil
+    end
+  end
+
+  class SlowGetStore < FakeStore
+    def [](key)
+      # Suspend the booting Task inside the restore GET.
+      JS.global.eval("new Promise((r) => setTimeout(r, 30))").await
+      @data[key]
+    end
+  end
+
+  class GetBrokenStore < FakeStore
+    def [](key)
+      raise "corrupt snapshot"
+    end
+  end
+
+  NOTE_SCHEMA = {
+    "attributes" => {
+      "id" => { "readonly" => true, "type" => "integer" },
+      "body" => { "type" => "string" },
+    },
+    "endpoints" => {},
+  }
+
+  META = { application_id: "boot_app", anonymous_only: true }
+
+  def setup
+    JS.global.eval(FAKE_JS)
+    $boot_store = FakeStore.new
+    define_models
+  end
+
+  def teardown
+    Funicular::DB.__reset_boot
+    Funicular::DB.__set_boot_state(:unbooted)
+    Funicular::DB.__reset_config
+    JS.global.eval(FAKE_JS)
+  end
+
+  def define_models
+    return if Object.const_defined?(:BootDraft)
+
+    Object.const_set(:BootDraft, Class.new(Funicular::Model))
+    BootDraft.class_eval do
+      table_name "boot_drafts"
+      storage :local do
+        migrate 1 do |t|
+          t.string :title
+        end
+      end
+    end
+
+    Object.const_set(:BootNote, Class.new(Funicular::Model))
+    BootNote.class_eval do
+      table_name "boot_notes"
+    end
+    BootNote.load_schema(NOTE_SCHEMA)
+
+    # Never passed to boot: its rebuild fails on the raw execute, which
+    # is exactly what the failed-reset test needs.
+    Object.const_set(:BootBrokenDraft, Class.new(Funicular::Model))
+    BootBrokenDraft.class_eval do
+      table_name "boot_broken"
+      storage :local do
+        migrate 1 do |t|
+          t.string :x
+          t.execute "THIS IS NOT SQL"
+        end
+      end
+    end
+  end
+
+  def pump(ms)
+    JS.global.eval("new Promise((r) => setTimeout(r, #{ms}))").await
+  end
+
+  def boot(models = [BootDraft, BootNote], metadata = META)
+    Funicular::DB.__set_snapshot_store($boot_store)
+    Funicular::DB.boot(models: models, metadata: metadata)
+  end
+
+  def test_boot_wires_a_writer_tab
+    result = boot([BootDraft, BootNote],
+                  { application_id: "boot_app", anonymous_only: true,
+                    epoch: "e1" })
+    assert_equal(true, result)
+    assert_equal(:ready, Funicular::DB.boot_state)
+    assert_equal(:persistent_writer, Funicular::DB.durability)
+    assert_equal("e1", Funicular::DB.session_epoch)
+    # The local table exists and model-level CRUD runs through the
+    # guarded funnel.
+    draft = BootDraft.local_create(title: "hello")
+    assert_equal(false, draft.new_record?)
+    assert_equal(1, BootDraft.count)
+    # The replica table came from the schema-derived DDL.
+    assert_equal([[0]],
+                 Funicular::DB.replica.execute(
+                   "SELECT COUNT(*) FROM boot_notes"))
+    # The raw escape hatches hand out guarded proxies.
+    assert_equal(Funicular::DB::GuardedDatabase,
+                 Funicular::DB.local.class)
+    assert_equal(BootNote.replica_db.class,
+                 Funicular::DB.replica.class)
+  end
+
+  def test_boot_restores_previous_snapshots
+    boot
+    BootDraft.local_create(title: "persisted")
+    assert_equal(true, Funicular::DB.flush)
+    store = $boot_store
+    Funicular::DB.__reset_boot
+    Funicular::DB.__set_boot_state(:unbooted)
+    Funicular::DB.__set_snapshot_store(store)
+    assert_equal(true,
+                 Funicular::DB.boot(models: [BootDraft, BootNote],
+                                    metadata: META))
+    assert_equal(1, BootDraft.count)
+    assert_equal("persisted", BootDraft.first.title)
+  end
+
+  def test_boot_is_one_shot
+    boot
+    assert_raise(Funicular::DB::Error) do
+      Funicular::DB.boot(models: [BootDraft], metadata: META)
+    end
+  end
+
+  def test_boot_refuses_on_ssr
+    Funicular.server = true
+    begin
+      assert_raise(Funicular::DB::UnavailableError) do
+        Funicular::DB.boot(models: [], metadata: {})
+      end
+    ensure
+      Funicular.server = false
+    end
+    assert_equal(:unbooted, Funicular::DB.boot_state)
+  end
+
+  def test_reader_boot_locks_local_writes_only
+    JS.global.eval("globalThis.__lockFake.mode = 'busy'")
+    assert_equal(true, boot)
+    assert_equal(:persistent_reader, Funicular::DB.durability)
+    # Local writes refuse at the guarded layer...
+    assert_raise(Funicular::DB::ReadOnlyTabError) do
+      BootDraft.local_create(title: "nope")
+    end
+    # ...reads work, and the replica stays memory-writable for
+    # fetch-through revalidation.
+    assert_equal(0, BootDraft.count)
+    Funicular::DB.replica.execute(
+      "INSERT INTO boot_notes (id, body) VALUES (1, 'ok')")
+    assert_equal([[1]],
+                 Funicular::DB.replica.execute(
+                   "SELECT COUNT(*) FROM boot_notes"))
+    assert_raise(Funicular::DB::ReadOnlyTabError) do
+      Funicular::DB.flush
+    end
+  end
+
+  def test_volatile_boot_without_storage
+    # No injected store: the real IndexedDB.open (fallback: false)
+    # fails under Node -- by-design absence, the volatile state.
+    $boot_volatile_errors = []
+    Funicular::DB.configure do
+      config.on_persist_error = ->(e) { $boot_volatile_errors << e }
+    end
+    result = Funicular::DB.boot(models: [BootDraft, BootNote],
+                                metadata: META)
+    assert_equal(true, result)
+    assert_equal(:ready, Funicular::DB.boot_state)
+    assert_equal(:volatile, Funicular::DB.durability)
+    assert_equal(1, $boot_volatile_errors.size)
+    # Everything works, nothing persists.
+    BootDraft.local_create(title: "memory only")
+    assert_equal(1, BootDraft.count)
+    assert_equal(false, Funicular::DB.flush)
+    assert_equal(nil, Funicular::DB.snapshot_store)
+  end
+
+  def test_boot_fails_loud_on_config_errors
+    $boot_errors = nil
+    Funicular::DB.configure do
+      config.on_boot_error = ->(errors) { $boot_errors = errors }
+    end
+    # A local model is declared but neither user_key nor
+    # anonymous_only is configured (docs decision 12).
+    result = boot([BootDraft, BootNote], { application_id: "boot_app" })
+    assert_equal(false, result)
+    assert_equal(:failed, Funicular::DB.boot_state)
+    assert_equal(1, $boot_errors.size)
+    assert_equal(Funicular::DB::ConfigError, $boot_errors[0].class)
+  end
+
+  def test_corrupt_snapshot_recovery_wipes_from_the_boot_hook
+    # Decision 16's official recovery: a snapshot GET failure fails
+    # the boot, and on_boot_error may call DB.wipe to discard the
+    # corrupt snapshot before reloading -- so wipe must stay allowed
+    # from the :failed state.
+    broken = GetBrokenStore.new
+    key = Funicular::DB.snapshot_key(
+      Funicular::DB.namespace_identity("boot_app", nil, true), :local)
+    broken.data[key] = "corrupt"
+    $boot_wipe_ran = false
+    Funicular::DB.configure do
+      config.on_boot_error = ->(_errors) {
+        Funicular::DB.wipe
+        $boot_wipe_ran = true
+      }
+    end
+    Funicular::DB.__set_snapshot_store(broken)
+    result = Funicular::DB.boot(models: [BootDraft, BootNote],
+                                metadata: META)
+    assert_equal(false, result)
+    assert_equal(:failed, Funicular::DB.boot_state)
+    assert_equal(true, $boot_wipe_ran)
+    assert_equal(false, broken.data.has_key?(key))
+    # After the hook the writer slot is released (the shim holds
+    # nothing), so a NEW tab can win the next election.
+    held = JS.global.eval(
+      "Object.keys(globalThis.__funicularLocks.holds).length").to_s
+    assert_equal("0", held)
+    assert_equal(:persistent_reader, Funicular::DB.durability)
+    Funicular::DB.__set_durability(:unbooted)
+    assert_equal(:persistent_writer,
+                 Funicular::DB.elect_writer("funicular:lock:recovered"))
+  end
+
+  def test_schema_too_new_locks_down_and_reset_local_recovers
+    boot([BootDraft], META)
+    raw = Funicular::DB.__registered_database(:local)
+    # Simulate a deploy rollback: the stored version outruns the code.
+    Funicular::DB.store_table_version(raw, "boot_drafts", 99)
+    assert_equal(true, Funicular::DB.flush)
+    store = $boot_store
+    Funicular::DB.__reset_boot
+    Funicular::DB.__set_boot_state(:unbooted)
+    Funicular::DB.__set_snapshot_store(store)
+    # The boot COMPLETES -- locked down, not failed.
+    assert_equal(true,
+                 Funicular::DB.boot(models: [BootDraft], metadata: META))
+    assert_equal(:ready, Funicular::DB.boot_state)
+    # Model-level operations raise...
+    assert_raise(Funicular::DB::SchemaTooNewError) do
+      BootDraft.count
+    end
+    # ...while the raw SELECT export path survives...
+    assert_equal([[0]],
+                 Funicular::DB.local.execute(
+                   "SELECT COUNT(*) FROM boot_drafts"))
+    # ...and SQLite itself refuses raw writes (query_only).
+    write_refused = false
+    begin
+      Funicular::DB.local.execute(
+        "INSERT INTO boot_drafts (title) VALUES ('nope')")
+    rescue => e
+      write_refused = true
+    end
+    assert_equal(true, write_refused)
+    # reset_local rebuilds from the baseline and lifts the lockdown.
+    assert_equal(true, BootDraft.reset_local)
+    assert_equal(nil, Funicular::DB.schema_lockdown)
+    BootDraft.local_create(title: "recovered")
+    assert_equal(1, BootDraft.count)
+  end
+
+  def test_reset_local_guards
+    JS.global.eval("globalThis.__lockFake.mode = 'busy'")
+    boot
+    assert_raise(Funicular::DB::ReadOnlyTabError) do
+      BootDraft.reset_local
+    end
+    assert_raise(Funicular::DB::NoTableError) do
+      BootNote.reset_local
+    end
+  end
+
+  def test_handles_stay_hidden_off_the_ready_state
+    boot
+    assert_equal(0, BootDraft.count)
+    # Mid-boot (:booting) and after a failure (:failed) the handles
+    # exist internally but must be equally out of reach.
+    Funicular::DB.__set_boot_state(:booting)
+    assert_raise(Funicular::DB::UnavailableError) do
+      Funicular::DB.local
+    end
+    assert_equal(nil, BootNote.replica_db)
+    assert_raise(Funicular::DB::UnavailableError) do
+      BootDraft.count
+    end
+    Funicular::DB.__set_boot_state(:failed)
+    assert_raise(Funicular::DB::UnavailableError) do
+      Funicular::DB.replica
+    end
+    Funicular::DB.__set_boot_state(:ready)
+    assert_equal(0, BootDraft.count)
+  end
+
+  def test_boot_suspended_mid_await_exposes_nothing
+    # navigator.storage.persist() stays pending for a while: the boot
+    # Task suspends AFTER installing the handles, and another Task
+    # (this one) must still see an unbooted database.
+    JS.global.eval(
+      "globalThis.__funicularStorageApi = { persist: () => " \
+      "new Promise((r) => setTimeout(() => r(true), 30)) }")
+    Funicular::DB.__set_snapshot_store($boot_store)
+    $boot_async_result = nil
+    Task.new(name: "boot-test") do
+      $boot_async_result = Funicular::DB.boot(
+        models: [BootDraft, BootNote], metadata: META)
+    end
+    pump(10)
+    assert_equal(:booting, Funicular::DB.boot_state)
+    assert_raise(Funicular::DB::UnavailableError) do
+      Funicular::DB.local
+    end
+    assert_equal(nil, BootNote.replica_db)
+    # The raw-DB paths (they bypass the handles) refuse too.
+    assert_raise(Funicular::DB::UnavailableError) do
+      BootDraft.reset_local
+    end
+    assert_raise(Funicular::DB::Error) do
+      Funicular::DB.wipe
+    end
+    pump(60)
+    assert_equal(true, $boot_async_result)
+    assert_equal(:ready, Funicular::DB.boot_state)
+    assert_equal(0, BootDraft.count)
+  end
+
+  def test_flush_mid_boot_cannot_overwrite_snapshots
+    # While the boot Task hangs in the local restore GET, the election
+    # is already won and the raw databases are registered -- but they
+    # are UNRESTORED. Persisting now would overwrite the stored
+    # snapshots with empty images, so the final persistence entry
+    # refuses during :booting.
+    store = SlowGetStore.new
+    Funicular::DB.__set_snapshot_store(store)
+    $boot_flush_result = nil
+    Task.new(name: "boot-flush-test") do
+      $boot_flush_result = Funicular::DB.boot(
+        models: [BootDraft, BootNote], metadata: META)
+    end
+    pump(10)
+    assert_equal(:booting, Funicular::DB.boot_state)
+    assert_equal(:persistent_writer, Funicular::DB.durability)
+    assert_equal(false, Funicular::DB.flush)
+    assert_equal(false, Funicular::DB.persist_snapshot(:local))
+    assert_equal(0, store.put_count)
+    pump(100)
+    assert_equal(true, $boot_flush_result)
+    assert_equal(:ready, Funicular::DB.boot_state)
+  end
+
+  def test_failed_reset_restores_the_sqlite_write_refusal
+    # Reach the locked-down state first (a stored version outruns the
+    # code), exactly like the recovery test above.
+    boot([BootDraft], META)
+    raw = Funicular::DB.__registered_database(:local)
+    Funicular::DB.store_table_version(raw, "boot_drafts", 99)
+    assert_equal(true, Funicular::DB.flush)
+    store = $boot_store
+    Funicular::DB.__reset_boot
+    Funicular::DB.__set_snapshot_store(store)
+    Funicular::DB.boot(models: [BootDraft], metadata: META)
+    assert_equal(false, Funicular::DB.schema_lockdown.nil?)
+    # This reset lifts query_only, then fails mid-rebuild: the lift
+    # was provisional and SQLite's own refusal must stand back up.
+    reset_failed = false
+    begin
+      BootBrokenDraft.reset_local
+    rescue => e
+      reset_failed = true
+    end
+    assert_equal(true, reset_failed)
+    assert_equal(false, Funicular::DB.schema_lockdown.nil?)
+    write_refused = false
+    begin
+      Funicular::DB.local.execute(
+        "INSERT INTO boot_drafts (title) VALUES ('nope')")
+    rescue => e
+      write_refused = true
+    end
+    assert_equal(true, write_refused)
+  end
+
+  def test_metadata_defaults_to_the_anonymous_funicular_namespace
+    assert_equal(true, boot([BootNote], {}))
+    assert_equal(nil, Funicular::DB.session_epoch)
+    Funicular::DB.replica.execute(
+      "INSERT INTO boot_notes (id, body) VALUES (1, 'x')")
+    assert_equal(true, Funicular::DB.flush)
+    keys = $boot_store.data.keys
+    found = false
+    i = 0
+    while i < keys.size
+      found = true if keys[i].include?("\"funicular\",\"anonymous\"")
+      i += 1
+    end
+    assert_equal(true, found)
+  end
+end

--- a/test/boot_test.rb
+++ b/test/boot_test.rb
@@ -152,6 +152,22 @@ class BootTest < Picotest::Test
                  Funicular::DB.replica.class)
   end
 
+  def test_booted_replica_model_local_query_uses_the_replica_database
+    boot
+    Funicular::DB.replica.execute(
+      "INSERT INTO boot_notes (id, body) VALUES (7, 'replicated')")
+    note = BootNote.local.find(7)
+    assert_equal("replicated", note.body)
+  end
+
+  def test_replica_model_local_create_cannot_forge_a_replica_row
+    boot
+    assert_raise(Funicular::DB::ReplicaWriteError) do
+      BootNote.local_create(id: 9, body: "forged")
+    end
+    assert_equal(0, BootNote.local.count)
+  end
+
   def test_boot_restores_previous_snapshots
     boot
     BootDraft.local_create(title: "persisted")
@@ -363,10 +379,12 @@ class BootTest < Picotest::Test
   end
 
   def test_schema_too_new_locks_down_and_reset_local_recovers
-    boot([BootDraft], META)
+    boot([BootDraft, BootNote], META)
     raw = Funicular::DB.__registered_database(:local)
     # Simulate a deploy rollback: the stored version outruns the code.
     Funicular::DB.store_table_version(raw, "boot_drafts", 99)
+    Funicular::DB.replica.execute(
+      "INSERT INTO boot_notes (id, body) VALUES (8, 'still readable')")
     assert_equal(true, Funicular::DB.flush)
     store = $boot_store
     Funicular::DB.__reset_boot
@@ -374,12 +392,16 @@ class BootTest < Picotest::Test
     Funicular::DB.__set_snapshot_store(store)
     # The boot COMPLETES -- locked down, not failed.
     assert_equal(true,
-                 Funicular::DB.boot(models: [BootDraft], metadata: META))
+                 Funicular::DB.boot(models: [BootDraft, BootNote],
+                                    metadata: META))
     assert_equal(:ready, Funicular::DB.boot_state)
     # Model-level operations raise...
     assert_raise(Funicular::DB::SchemaTooNewError) do
       BootDraft.count
     end
+    # The lockdown belongs to the client-only database; replica reads use
+    # their own handle and remain available.
+    assert_equal("still readable", BootNote.local.find(8).body)
     # ...while the raw SELECT export path survives...
     assert_equal([[0]],
                  Funicular::DB.local.execute(

--- a/test/boot_test.rb
+++ b/test/boot_test.rb
@@ -66,7 +66,11 @@ class BootTest < Picotest::Test
     "endpoints" => {},
   }
 
-  META = { application_id: "boot_app", anonymous_only: true }
+  META = {
+    local_database: true,
+    application_id: "boot_app",
+    anonymous_only: true,
+  }
 
   def setup
     JS.global.eval(FAKE_JS)
@@ -125,7 +129,8 @@ class BootTest < Picotest::Test
 
   def test_boot_wires_a_writer_tab
     result = boot([BootDraft, BootNote],
-                  { application_id: "boot_app", anonymous_only: true,
+                  { local_database: true, application_id: "boot_app",
+                    anonymous_only: true,
                     epoch: "e1" })
     assert_equal(true, result)
     assert_equal(:ready, Funicular::DB.boot_state)
@@ -179,6 +184,46 @@ class BootTest < Picotest::Test
       Funicular.server = false
     end
     assert_equal(:unbooted, Funicular::DB.boot_state)
+  end
+
+  def test_direct_boot_requires_the_opt_in_flag
+    assert_raise(Funicular::DB::ConfigError) do
+      Funicular::DB.boot(models: [BootDraft],
+                         metadata: { application_id: "boot_app",
+                                     anonymous_only: true })
+    end
+    assert_equal(:unbooted, Funicular::DB.boot_state)
+    assert_equal(:unbooted, Funicular::DB.durability)
+  end
+
+  def test_enabled_boot_requires_application_identity_metadata
+    $boot_errors = nil
+    Funicular::DB.configure do
+      config.on_boot_error = ->(errors) { $boot_errors = errors }
+    end
+    result = boot([BootDraft],
+                  { local_database: true, anonymous_only: true })
+    assert_equal(false, result)
+    assert_equal(:failed, Funicular::DB.boot_state)
+    assert_equal(Funicular::DB::ConfigError, $boot_errors[0].class)
+  end
+
+  def test_ssr_runtime_guards_do_not_read_browser_metadata
+    JS.global.eval(
+      "Object.defineProperty(globalThis, 'document', { configurable: true, " \
+      "get: () => { throw new Error('document was read') } })")
+    Funicular.server = true
+    begin
+      assert_raise(Funicular::DB::UnavailableError) do
+        Funicular::DB.local
+      end
+      assert_raise(Funicular::DB::UnavailableError) do
+        BootDraft.count
+      end
+    ensure
+      Funicular.server = false
+      JS.global.eval("delete globalThis.document")
+    end
   end
 
   def test_reader_boot_locks_local_writes_only
@@ -273,9 +318,10 @@ class BootTest < Picotest::Test
     Funicular::DB.configure do
       config.on_boot_error = ->(errors) { $boot_errors = errors }
     end
-    # A local model is declared but neither user_key nor
-    # anonymous_only is configured (docs decision 12).
-    result = boot([BootDraft, BootNote], { application_id: "boot_app" })
+    # Durable storage is enabled but neither user_key nor anonymous_only
+    # is configured.
+    result = boot([BootDraft, BootNote],
+                  { local_database: true, application_id: "boot_app" })
     assert_equal(false, result)
     assert_equal(:failed, Funicular::DB.boot_state)
     assert_equal(1, $boot_errors.size)
@@ -474,19 +520,4 @@ class BootTest < Picotest::Test
     assert_equal(true, write_refused)
   end
 
-  def test_metadata_defaults_to_the_anonymous_funicular_namespace
-    assert_equal(true, boot([BootNote], {}))
-    assert_equal(nil, Funicular::DB.session_epoch)
-    Funicular::DB.replica.execute(
-      "INSERT INTO boot_notes (id, body) VALUES (1, 'x')")
-    assert_equal(true, Funicular::DB.flush)
-    keys = $boot_store.data.keys
-    found = false
-    i = 0
-    while i < keys.size
-      found = true if keys[i].include?("\"funicular\",\"anonymous\"")
-      i += 1
-    end
-    assert_equal(true, found)
-  end
 end

--- a/test/boot_test.rb
+++ b/test/boot_test.rb
@@ -222,6 +222,52 @@ class BootTest < Picotest::Test
     assert_equal(nil, Funicular::DB.snapshot_store)
   end
 
+  class BootOpenError < StandardError; end
+
+  # Swaps the real IndexedDB::KVS.open for a stub raising a
+  # NON-availability error: exactly what quota or an unknown
+  # DOMException at open looks like.
+  def self.break_kvs_open
+    kvs = IndexedDB::KVS
+    kvs.singleton_class.alias_method(:__funicular_test_open, :open)
+    kvs.define_singleton_method(:open) do |_name, fallback: true|
+      raise BootTest::BootOpenError, "quota exceeded during open"
+    end
+  end
+
+  def self.restore_kvs_open
+    IndexedDB::KVS.singleton_class.alias_method(:open,
+                                                :__funicular_test_open)
+  end
+
+  def test_a_non_availability_open_error_fails_the_boot
+    # Availability errors mean "no storage BY DESIGN" and go volatile
+    # (the test above); ANY other failure at the store open fails the
+    # boot per docs decision 16 -- and the writer lock, already won by
+    # then, is released so the next tab is not condemned to reader.
+    $boot_errors = nil
+    Funicular::DB.configure do
+      config.on_boot_error = ->(errors) { $boot_errors = errors }
+    end
+    BootTest.break_kvs_open
+    begin
+      # No injected store: the boot must reach the real open path.
+      result = Funicular::DB.boot(models: [BootDraft, BootNote],
+                                  metadata: META)
+    ensure
+      BootTest.restore_kvs_open
+    end
+    assert_equal(false, result)
+    assert_equal(:failed, Funicular::DB.boot_state)
+    assert_equal(1, $boot_errors.size)
+    assert_equal(BootOpenError, $boot_errors[0].class)
+    # Release is what steps the durability down from the won election.
+    assert_equal(:persistent_reader, Funicular::DB.durability)
+    assert_raise(Funicular::DB::UnavailableError) do
+      Funicular::DB.local
+    end
+  end
+
   def test_boot_fails_loud_on_config_errors
     $boot_errors = nil
     Funicular::DB.configure do

--- a/test/epoch_test.rb
+++ b/test/epoch_test.rb
@@ -19,6 +19,18 @@ class EpochTest < Picotest::Test
           if (globalThis.__epochSend) {
             headers["X-Funicular-Epoch"] = globalThis.__epochHeader;
           }
+          // Headers arrive intact, the body stream dies mid-flight:
+          // the epoch is knowable, reading the body is not. The
+          // destroy is delayed so the client's fetch RESOLVES on the
+          // headers first -- killing the socket right away rejects
+          // the fetch itself, which is a different failure.
+          if (globalThis.__epochAbortBody) {
+            headers["Content-Length"] = "100";
+            res.writeHead(200, headers);
+            res.write('{"id": 1,');
+            setTimeout(() => { res.socket.destroy(); }, 50);
+            return;
+          }
           res.writeHead(200, headers);
           res.end(JSON.stringify({ "id": 1, "title": "from server" }));
         });
@@ -127,7 +139,7 @@ class EpochTest < Picotest::Test
     $epoch_port = JS.global.eval(SERVER_JS).await.to_s.to_i
     JS.global.eval(
       "globalThis.__epochHeader = 'e1'; globalThis.__epochSend = true;" \
-      " globalThis.__epochHits = 0")
+      " globalThis.__epochAbortBody = false; globalThis.__epochHits = 0")
     define_models
   end
 
@@ -337,6 +349,25 @@ class EpochTest < Picotest::Test
     pump(100)
     assert_equal(hits,
                  JS.global.eval("globalThis.__epochHits").to_s.to_i)
+  end
+
+  def test_a_broken_body_still_processes_the_epoch_mismatch
+    # The headers (epoch included) arrived, the body stream did not.
+    # Checked after the body read, the failure would surface as a
+    # plain network error and the rotated session would go unnoticed:
+    # the page stays live and its next click talks to the server under
+    # someone else's session. The epoch verdict comes first.
+    $epoch_changed = 0
+    Funicular::DB.configure do
+      config.on_session_change = -> { $epoch_changed += 1 }
+    end
+    Funicular::DB.__set_session_epoch("e0")
+    JS.global.eval("globalThis.__epochAbortBody = true")
+    response = get_once(server_url)
+    assert_equal(0, response.status)
+    assert_equal(true, response.error_message.include?("session"))
+    assert_equal(true, Funicular::DB.session_terminated?)
+    assert_equal(1, $epoch_changed)
   end
 
   def test_missing_header_counts_as_a_mismatch

--- a/test/epoch_test.rb
+++ b/test/epoch_test.rb
@@ -119,6 +119,7 @@ class EpochTest < Picotest::Test
   end
 
   def setup
+    Funicular::DB.__set_local_database_enabled(true)
     JS.global.eval(LOCKS_JS)
     # The epoch check latches lazily off the page's DOM: no leftover
     # fake document (this suite's or another's) may leak an epoch in.
@@ -361,7 +362,8 @@ class EpochTest < Picotest::Test
     assert_equal(true,
                  Funicular::DB.boot(
                    models: [EpochDraft],
-                   metadata: { application_id: "epoch_app",
+                   metadata: { local_database: true,
+                               application_id: "epoch_app",
                                anonymous_only: true, epoch: "e0" }))
     assert_equal(:persistent_writer, Funicular::DB.durability)
     EpochDraft.local_create(title: "before")
@@ -411,7 +413,8 @@ class EpochTest < Picotest::Test
     assert_equal(true,
                  Funicular::DB.boot(
                    models: [EpochDraft],
-                   metadata: { application_id: "epoch_app",
+                   metadata: { local_database: true,
+                               application_id: "epoch_app",
                                anonymous_only: true, epoch: "e0" }))
     EpochDraft.local_create(title: "inflight")
     Task.new(name: "epoch_flusher") { Funicular::DB.flush }
@@ -456,7 +459,8 @@ class EpochTest < Picotest::Test
     Task.new(name: "epoch_booter") do
       $epoch_boot_result = Funicular::DB.boot(
         models: [EpochDraft],
-        metadata: { application_id: "epoch_app",
+        metadata: { local_database: true,
+                    application_id: "epoch_app",
                     anonymous_only: true, epoch: "e0" })
     end
     pump(50)
@@ -490,7 +494,8 @@ class EpochTest < Picotest::Test
     Task.new(name: "epoch_restore_booter") do
       $epoch_boot_result = Funicular::DB.boot(
         models: [EpochDraft],
-        metadata: { application_id: "epoch_app",
+        metadata: { local_database: true,
+                    application_id: "epoch_app",
                     anonymous_only: true, epoch: "e0" })
     end
     pump(50)
@@ -519,7 +524,8 @@ class EpochTest < Picotest::Test
     assert_equal(true,
                  Funicular::DB.boot(
                    models: [EpochDraft],
-                   metadata: { application_id: "epoch_app",
+                   metadata: { local_database: true,
+                               application_id: "epoch_app",
                                anonymous_only: true, epoch: "e0" }))
     assert_equal(:volatile, Funicular::DB.durability)
     response = get_once(server_url)

--- a/test/epoch_test.rb
+++ b/test/epoch_test.rb
@@ -1,0 +1,506 @@
+# Tests for the session-epoch terminal latch (docs decision 13, client
+# half) and http.rb's exactly-once settle -- against the REAL fetch,
+# talking to a local node:http server whose X-Funicular-Epoch header
+# the tests control. The latch's writer step-down is exercised through
+# a real boot.
+
+class EpochTest < Picotest::Test
+  SERVER_JS = <<~'FUNICULAR_EPOCH_SERVER'
+    (() => {
+      if (globalThis.__epochSrvPort) {
+        return Promise.resolve(globalThis.__epochSrvPort);
+      }
+      return import("node:http").then((http) => {
+        globalThis.__epochHeader = "e1";
+        globalThis.__epochSend = true;
+        const srv = http.createServer((req, res) => {
+          globalThis.__epochHits = (globalThis.__epochHits || 0) + 1;
+          const headers = { "Content-Type": "application/json" };
+          if (globalThis.__epochSend) {
+            headers["X-Funicular-Epoch"] = globalThis.__epochHeader;
+          }
+          res.writeHead(200, headers);
+          res.end(JSON.stringify({ "id": 1, "title": "from server" }));
+        });
+        srv.unref();
+        return new Promise((resolve) => {
+          srv.listen(0, "127.0.0.1", () => {
+            globalThis.__epochSrvPort = srv.address().port;
+            resolve(globalThis.__epochSrvPort);
+          });
+        });
+      });
+    })()
+  FUNICULAR_EPOCH_SERVER
+
+  LOCKS_JS = <<~'FUNICULAR_EPOCH_LOCKS'
+    globalThis.__funicularLocksApi = {
+      request(name, opts, cb) {
+        const held = cb({ name: name });
+        return Promise.resolve(held);
+      }
+    };
+    globalThis.__funicularStorageApi = null;
+  FUNICULAR_EPOCH_LOCKS
+
+  class FakeStore
+    attr_reader :data, :put_count
+
+    def initialize
+      @data = {}
+      @put_count = 0
+    end
+
+    def [](key)
+      @data[key]
+    end
+
+    def []=(key, value)
+      @put_count += 1
+      @data[key] = value
+    end
+
+    def delete(key)
+      @data.delete(key)
+      nil
+    end
+  end
+
+  # A store whose put suspends long enough for the epoch mismatch to
+  # land mid-write; it records when the put completed and whether the
+  # writer lock was still held at that moment.
+  class SlowPutStore
+    attr_reader :data, :put_count
+
+    def initialize
+      @data = {}
+      @put_count = 0
+    end
+
+    def [](key)
+      @data[key]
+    end
+
+    def []=(key, value)
+      $epoch_order << :put_start
+      EpochTest.pump(200)
+      @put_count += 1
+      @data[key] = value
+      $epoch_lock_at_put = Funicular::DB.durability
+      $epoch_order << :put_done
+    end
+
+    def delete(key)
+      @data.delete(key)
+      nil
+    end
+  end
+
+  # A store whose GET suspends: the boot parks inside the local
+  # restore long enough for a mismatch to land mid-boot.
+  class SlowGetStore
+    def initialize
+      @data = {}
+    end
+
+    def [](key)
+      EpochTest.pump(200)
+      @data[key]
+    end
+
+    def []=(key, value)
+      @data[key] = value
+    end
+
+    def delete(key)
+      @data.delete(key)
+      nil
+    end
+  end
+
+  def setup
+    JS.global.eval(LOCKS_JS)
+    # The epoch check latches lazily off the page's DOM: no leftover
+    # fake document (this suite's or another's) may leak an epoch in.
+    JS.global.eval("delete globalThis.document;")
+    $epoch_port = JS.global.eval(SERVER_JS).await.to_s.to_i
+    JS.global.eval(
+      "globalThis.__epochHeader = 'e1'; globalThis.__epochSend = true;" \
+      " globalThis.__epochHits = 0")
+    define_models
+  end
+
+  def teardown
+    Funicular::DB.__reset_boot
+    Funicular::DB.__reset_config
+    JS.global.eval(LOCKS_JS)
+    JS.global.eval("delete globalThis.document;")
+  end
+
+  def define_models
+    return if Object.const_defined?(:EpochDraft)
+
+    Object.const_set(:EpochDraft, Class.new(Funicular::Model))
+    EpochDraft.class_eval do
+      table_name "epoch_drafts"
+      storage :local do
+        migrate 1 do |t|
+          t.string :title
+        end
+      end
+    end
+  end
+
+  # Sliced awaits: the Node runner exits after ~100 fully idle
+  # cycles (~100 ms), so no single timer await may sleep longer.
+  # A class method so the store fakes can wait through it too.
+  def self.pump(ms)
+    elapsed = 0
+    while elapsed < ms
+      slice = ms - elapsed
+      slice = 50 if 50 < slice
+      JS.global.eval("new Promise((r) => setTimeout(r, #{slice}))").await
+      elapsed += slice
+    end
+    nil
+  end
+
+  def pump(ms)
+    EpochTest.pump(ms)
+  end
+
+  def server_url
+    "http://127.0.0.1:#{$epoch_port}/thing"
+  end
+
+  def get_once(url)
+    $epoch_calls = 0
+    $epoch_response = nil
+    Funicular::HTTP.get(url) do |response|
+      $epoch_calls += 1
+      $epoch_response = response
+    end
+    assert_equal(1, $epoch_calls)
+    $epoch_response
+  end
+
+  def test_rejected_fetch_settles_exactly_once_with_an_error
+    response = get_once("http://127.0.0.1:1/unreachable")
+    assert_equal(0, response.status)
+    assert_equal(true, !response.error_message.nil?)
+  end
+
+  def test_an_exception_in_the_callers_block_never_settles_twice
+    $epoch_calls = 0
+    raised = false
+    begin
+      Funicular::HTTP.get(server_url) do |_response|
+        $epoch_calls += 1
+        raise "boom"
+      end
+    rescue => e
+      raised = e.message == "boom"
+    end
+    assert_equal(true, raised)
+    assert_equal(1, $epoch_calls)
+  end
+
+  def test_no_page_epoch_means_checks_off
+    # The server DOES send e1, but this page never received an epoch:
+    # the response passes untouched.
+    response = get_once(server_url)
+    assert_equal(200, response.status)
+    assert_equal("from server", response.data["title"])
+    assert_equal(false, Funicular::DB.session_terminated?)
+  end
+
+  def test_matching_epoch_delivers
+    Funicular::DB.__set_session_epoch("e1")
+    response = get_once(server_url)
+    assert_equal(200, response.status)
+    assert_equal(false, Funicular::DB.session_terminated?)
+  end
+
+  def test_the_first_ever_response_is_checked_via_the_lazy_latch
+    # Pre-boot, pre-barrier HTTP (an ephemeral model's REST call, a
+    # direct HTTP.get at app init) is epoch-checked too: nothing has
+    # latched the page's epoch yet, so the check itself must read it
+    # off the page. The server belongs to a NEWER session (e1) -- the
+    # very first response this page ever sees is discarded and the
+    # page goes terminal.
+    Funicular::DB.configure do
+      config.on_session_change = -> {}
+    end
+    JS.global.eval(
+      "globalThis.document = { querySelector: (s) => ({ dataset: {" \
+      "  funicularApplicationId: 'epoch_app'," \
+      "  funicularAnonymousOnly: 'true'," \
+      "  funicularEpoch: 'e-page' } }) }")
+    response = get_once(server_url)
+    assert_equal(0, response.status)
+    assert_equal(true, Funicular::DB.session_terminated?)
+    assert_equal("e-page", Funicular::DB.session_epoch)
+  end
+
+  def test_the_lazy_latch_delivers_when_the_page_epoch_matches
+    JS.global.eval(
+      "globalThis.document = { querySelector: (s) => ({ dataset: {" \
+      "  funicularApplicationId: 'epoch_app'," \
+      "  funicularAnonymousOnly: 'true'," \
+      "  funicularEpoch: 'e1' } }) }")
+    response = get_once(server_url)
+    assert_equal(200, response.status)
+    assert_equal(false, Funicular::DB.session_terminated?)
+    # The latch held on to what it read: later responses compare
+    # against the same value without re-reading the DOM.
+    assert_equal("e1", Funicular::DB.session_epoch)
+  end
+
+  def test_rotated_epoch_discards_and_terminates
+    $epoch_changed = 0
+    Funicular::DB.configure do
+      config.on_session_change = -> { $epoch_changed += 1 }
+    end
+    Funicular::DB.__set_session_epoch("e0")
+    response = get_once(server_url)
+    # Discarded: the caller settles with an error, never the payload.
+    assert_equal(0, response.status)
+    assert_equal(true, response.error_message.include?("session"))
+    assert_equal(true, Funicular::DB.session_terminated?)
+    assert_equal(1, $epoch_changed)
+    # A later request -- even one whose response would carry a
+    # matching epoch -- is refused at issue time, and the hook does
+    # not fire again.
+    JS.global.eval("globalThis.__epochHeader = 'e0'")
+    response = get_once(server_url)
+    assert_equal(0, response.status)
+    assert_equal(1, $epoch_changed)
+  end
+
+  def test_terminal_page_never_issues_new_requests
+    # Discarding responses is not enough: a request issued AFTER the
+    # terminal verdict would already have executed under the NEW
+    # session's cookies server-side -- an old screen's click could
+    # mutate another user's data. It must never leave the page.
+    Funicular::DB.configure do
+      config.on_session_change = -> {}
+    end
+    Funicular::DB.__set_session_epoch("e0")
+    response = get_once(server_url)
+    assert_equal(0, response.status)
+    assert_equal(true, Funicular::DB.session_terminated?)
+    hits = JS.global.eval("globalThis.__epochHits").to_s.to_i
+    $epoch_calls = 0
+    $epoch_response = nil
+    Funicular::HTTP.post(server_url, { "title" => "late" }) do |r|
+      $epoch_calls += 1
+      $epoch_response = r
+    end
+    # Settled exactly once, synchronously, with the session error.
+    assert_equal(1, $epoch_calls)
+    assert_equal(0, $epoch_response.status)
+    assert_equal(true,
+                 $epoch_response.error_message.include?("session"))
+    # And the server never saw it.
+    pump(100)
+    assert_equal(hits,
+                 JS.global.eval("globalThis.__epochHits").to_s.to_i)
+  end
+
+  def test_missing_header_counts_as_a_mismatch
+    Funicular::DB.configure do
+      config.on_session_change = -> {}
+    end
+    Funicular::DB.__set_session_epoch("e1")
+    JS.global.eval("globalThis.__epochSend = false")
+    response = get_once(server_url)
+    assert_equal(0, response.status)
+    assert_equal(true, Funicular::DB.session_terminated?)
+  end
+
+  def test_terminal_writer_steps_down_completely
+    Funicular::DB.configure do
+      config.on_session_change = -> {}
+      # Wide enough that the timer cannot fire during the fetch
+      # below; the terminal cancel is what must stop it.
+      config.local_debounce_ms = 500
+    end
+    store = FakeStore.new
+    Funicular::DB.__set_snapshot_store(store)
+    assert_equal(true,
+                 Funicular::DB.boot(
+                   models: [EpochDraft],
+                   metadata: { application_id: "epoch_app",
+                               anonymous_only: true, epoch: "e0" }))
+    assert_equal(:persistent_writer, Funicular::DB.durability)
+    EpochDraft.local_create(title: "before")
+    # The rotated response terminates the session.
+    response = get_once(server_url)
+    assert_equal(0, response.status)
+    assert_equal(true, Funicular::DB.session_terminated?)
+    # Lock released (a new tab could win), one-way reader status.
+    assert_equal(:persistent_reader, Funicular::DB.durability)
+    # Both handles became a non-persistent read view.
+    assert_raise(Funicular::DB::ReadOnlyTabError) do
+      Funicular::DB.local.execute(
+        "INSERT INTO epoch_drafts (title) VALUES ('after')")
+    end
+    assert_raise(Funicular::DB::ReadOnlyTabError) do
+      Funicular::DB.replica.execute("CREATE TABLE nope (id INTEGER)")
+    end
+    assert_equal(1, Funicular::DB.local.execute(
+                      "SELECT COUNT(*) FROM epoch_drafts")[0][0])
+    # Model-level writes refuse, persistence is dead, flush raises.
+    assert_raise(Funicular::DB::ReadOnlyTabError) do
+      EpochDraft.local_create(title: "nope")
+    end
+    assert_equal(false, Funicular::DB.persist_snapshot(:local))
+    assert_raise(Funicular::DB::ReadOnlyTabError) do
+      Funicular::DB.flush
+    end
+    # The armed debounce from the pre-terminal write cannot fire a
+    # snapshot either (its 500 ms deadline passes inside this wait).
+    pump(600)
+    assert_equal(0, store.put_count)
+  end
+
+  def test_terminal_waits_out_an_inflight_snapshot_before_releasing
+    # A put already past persist_snapshot's checks when the epoch
+    # mismatch lands keeps running inside the store. The step-down
+    # must wait it out BEFORE releasing the writer lock: released
+    # earlier, a fresh tab could boot as the writer while the old
+    # session's image is still landing over its store.
+    $epoch_order = []
+    $epoch_lock_at_put = nil
+    Funicular::DB.configure do
+      config.on_session_change = -> { $epoch_order << :released }
+    end
+    store = SlowPutStore.new
+    Funicular::DB.__set_snapshot_store(store)
+    assert_equal(true,
+                 Funicular::DB.boot(
+                   models: [EpochDraft],
+                   metadata: { application_id: "epoch_app",
+                               anonymous_only: true, epoch: "e0" }))
+    EpochDraft.local_create(title: "inflight")
+    Task.new(name: "epoch_flusher") { Funicular::DB.flush }
+    # Let the flush enter the store put and suspend inside it.
+    pump(50)
+    assert_equal([:put_start], $epoch_order)
+    response = get_once(server_url)
+    assert_equal(0, response.status)
+    assert_equal(true, Funicular::DB.session_terminated?)
+    # The put completed while the lock was STILL held; the hook (and
+    # the release before it) came strictly after.
+    assert_equal([:put_start, :put_done, :released], $epoch_order)
+    assert_equal(:persistent_writer, $epoch_lock_at_put)
+    assert_equal(:persistent_reader, Funicular::DB.durability)
+    # flush's second role never started: the terminal check refused it
+    # at the persist entry.
+    assert_equal(1, store.put_count)
+  end
+
+  def test_epoch_mismatch_during_the_election_aborts_the_boot
+    # A mismatch landing while the boot awaits the writer election
+    # finds no lock and no handles to tear down; the boot itself must
+    # notice on resume and abort -- and the lock the election acquired
+    # AFTER the termination must be released again, or a terminal page
+    # would hold the writer slot with writable handles.
+    $epoch_boot_errors = nil
+    Funicular::DB.configure do
+      config.on_session_change = -> {}
+      config.on_boot_error = ->(errors) { $epoch_boot_errors = errors }
+    end
+    JS.global.eval(<<~'FUNICULAR_EPOCH_SLOW_LOCKS')
+      globalThis.__funicularLocksApi = {
+        request(name, opts, cb) {
+          return new Promise((resolve) => {
+            setTimeout(() => { resolve(cb({ name: name })); }, 200);
+          });
+        }
+      };
+    FUNICULAR_EPOCH_SLOW_LOCKS
+    Funicular::DB.__set_snapshot_store(FakeStore.new)
+    $epoch_boot_result = :pending
+    Task.new(name: "epoch_booter") do
+      $epoch_boot_result = Funicular::DB.boot(
+        models: [EpochDraft],
+        metadata: { application_id: "epoch_app",
+                    anonymous_only: true, epoch: "e0" })
+    end
+    pump(50)
+    assert_equal(:booting, Funicular::DB.boot_state)
+    response = get_once(server_url)
+    assert_equal(0, response.status)
+    assert_equal(true, Funicular::DB.session_terminated?)
+    # Let the election grant and the boot notice the termination.
+    pump(300)
+    assert_equal(false, $epoch_boot_result)
+    assert_equal(:failed, Funicular::DB.boot_state)
+    # Releasing the late lock is what steps the durability down.
+    assert_equal(:persistent_reader, Funicular::DB.durability)
+    assert_equal(1, $epoch_boot_errors.size)
+    assert_raise(Funicular::DB::UnavailableError) do
+      Funicular::DB.local
+    end
+  end
+
+  def test_epoch_mismatch_during_the_restore_aborts_the_boot
+    # Here the boot already HOLDS the lock and suspends inside the
+    # local-snapshot read: the mismatch releases the lock right away,
+    # and the resuming boot must abort instead of installing writable
+    # handles over the terminal page.
+    Funicular::DB.configure do
+      config.on_session_change = -> {}
+      config.on_boot_error = ->(_errors) {}
+    end
+    Funicular::DB.__set_snapshot_store(SlowGetStore.new)
+    $epoch_boot_result = :pending
+    Task.new(name: "epoch_restore_booter") do
+      $epoch_boot_result = Funicular::DB.boot(
+        models: [EpochDraft],
+        metadata: { application_id: "epoch_app",
+                    anonymous_only: true, epoch: "e0" })
+    end
+    pump(50)
+    assert_equal(:persistent_writer, Funicular::DB.durability)
+    response = get_once(server_url)
+    assert_equal(0, response.status)
+    assert_equal(:persistent_reader, Funicular::DB.durability)
+    pump(400)
+    assert_equal(false, $epoch_boot_result)
+    assert_equal(:failed, Funicular::DB.boot_state)
+    assert_raise(Funicular::DB::UnavailableError) do
+      Funicular::DB.replica
+    end
+  end
+
+  def test_terminal_volatile_page_refuses_the_raw_rebuild_paths
+    # A terminated VOLATILE page never steps down to
+    # :persistent_reader (there is no lock to release), so wipe's and
+    # reset_local's durability checks alone would still let these raw
+    # paths through -- the latch itself must refuse them.
+    Funicular::DB.configure do
+      config.on_session_change = -> {}
+    end
+    JS.global.eval("globalThis.__funicularLocksApi = null")
+    Funicular::DB.__set_snapshot_store(FakeStore.new)
+    assert_equal(true,
+                 Funicular::DB.boot(
+                   models: [EpochDraft],
+                   metadata: { application_id: "epoch_app",
+                               anonymous_only: true, epoch: "e0" }))
+    assert_equal(:volatile, Funicular::DB.durability)
+    response = get_once(server_url)
+    assert_equal(0, response.status)
+    assert_equal(true, Funicular::DB.session_terminated?)
+    # Exactly the gap under test: the durability did NOT change.
+    assert_equal(:volatile, Funicular::DB.durability)
+    assert_raise(Funicular::DB::ReadOnlyTabError) do
+      Funicular::DB.wipe
+    end
+    assert_raise(Funicular::DB::ReadOnlyTabError) do
+      EpochDraft.reset_local
+    end
+  end
+end

--- a/test/epoch_test.rb
+++ b/test/epoch_test.rb
@@ -149,6 +149,12 @@ class EpochTest < Picotest::Test
         end
       end
     end
+
+    # A replica model for the real-fetch barrier test below.
+    Object.const_set(:EpochNote, Class.new(Funicular::Model))
+    EpochNote.class_eval do
+      table_name "epoch_notes"
+    end
   end
 
   # Sliced awaits: the Node runner exits after ~100 fully idle
@@ -188,6 +194,31 @@ class EpochTest < Picotest::Test
     response = get_once("http://127.0.0.1:1/unreachable")
     assert_equal(0, response.status)
     assert_equal(true, !response.error_message.nil?)
+  end
+
+  def test_a_rejected_schema_fetch_settles_the_barrier_and_fails_the_boot
+    # The schema barrier over the REAL fetch: under Node the relative
+    # schema URL rejects outright, and before the exactly-once settle
+    # a rejection would hang the barrier forever. Instead the slot
+    # settles, the boot fails loud, the completion block never runs,
+    # and the aggregated error names the schema, the model, and the
+    # network failure.
+    $epoch_barrier_errors = nil
+    $epoch_barrier_done = 0
+    Funicular::DB.configure do
+      config.on_boot_error = ->(errors) { $epoch_barrier_errors = errors }
+    end
+    Funicular.load_schemas({ EpochNote => "epoch_note" }) do
+      $epoch_barrier_done += 1
+    end
+    assert_equal(0, $epoch_barrier_done)
+    assert_equal(:failed, Funicular::DB.boot_state)
+    assert_equal(1, $epoch_barrier_errors.size)
+    message = $epoch_barrier_errors[0].message
+    assert_equal(true, message.include?("epoch_note"))
+    assert_equal(true, message.include?("EpochNote"))
+    assert_equal(true, message.include?("HTTP 0"))
+    assert_equal(true, message.include?("network error"))
   end
 
   def test_an_exception_in_the_callers_block_never_settles_twice

--- a/test/event_bus_test.rb
+++ b/test/event_bus_test.rb
@@ -8,6 +8,7 @@
 
 class EventBusTest < Picotest::Test
   def setup
+    Funicular::DB.__set_local_database_enabled(true)
     $bus_db = SQLite3::Database.new(":memory:")
     $bus_db.execute("CREATE TABLE ev (id INTEGER PRIMARY KEY, n TEXT)")
     @guard = Funicular::DB::GuardedDatabase.new($bus_db)
@@ -27,6 +28,7 @@ class EventBusTest < Picotest::Test
     # Flush anything left in the tick buffer, then restore the default.
     Funicular::DB.__drain_events
     Funicular::DB.__set_tick_scheduler(nil)
+    Funicular::DB.__set_local_database_enabled(false)
     $bus_db.close
   end
 

--- a/test/event_bus_test.rb
+++ b/test/event_bus_test.rb
@@ -1,0 +1,295 @@
+# Tests for the change-event bus (docs decision 10): subscribe/
+# unsubscribe, notify_changed's two forms, post-commit coalescing and
+# rollback discard inside guarded transactions, and next-tick delivery
+# (nothing is delivered synchronously; one drain per tick; events
+# raised by subscribers belong to the next tick; a raising subscriber
+# is isolated). A manual tick scheduler makes the ticks deterministic;
+# one test exercises the default JS setTimeout(0) scheduler for real.
+
+class EventBusTest < Picotest::Test
+  def setup
+    $bus_db = SQLite3::Database.new(":memory:")
+    $bus_db.execute("CREATE TABLE ev (id INTEGER PRIMARY KEY, n TEXT)")
+    @guard = Funicular::DB::GuardedDatabase.new($bus_db)
+    @events = []
+    @subs = []
+    $bus_ticks = 0
+    Funicular::DB.__set_tick_scheduler(proc { $bus_ticks += 1 })
+  end
+
+  def teardown
+    subs_size = @subs.size
+    i = 0
+    while i < subs_size
+      Funicular::DB.unsubscribe(@subs[i])
+      i += 1
+    end
+    # Flush anything left in the tick buffer, then restore the default.
+    Funicular::DB.__drain_events
+    Funicular::DB.__set_tick_scheduler(nil)
+    $bus_db.close
+  end
+
+  def define_models
+    return if Object.const_defined?(:BusDraft)
+
+    Object.const_set(:BusDraft, Class.new(Funicular::Model))
+    BusDraft.class_eval do
+      storage :local do
+        migrate 1 do |t|
+          t.string :name
+        end
+      end
+    end
+
+    Object.const_set(:BusPost, Class.new(Funicular::Model))
+    BusPost.class_eval do
+      table_name "bus_posts"
+    end
+
+    Object.const_set(:BusSession, Class.new(Funicular::Model))
+    BusSession.class_eval do
+      storage :ephemeral
+    end
+  end
+
+  def listen(role, table)
+    events = @events
+    id = Funicular::DB.subscribe(role, table) do |r, t|
+      events << [r, t]
+    end
+    @subs << id
+    id
+  end
+
+  def tick
+    Funicular::DB.__drain_events
+  end
+
+  # ---- next-tick delivery ----
+
+  def test_nothing_is_delivered_synchronously
+    listen(:local, "ev")
+    Funicular::DB.notify_changed(:local, "ev")
+    assert_equal([], @events)
+    assert_equal(1, $bus_ticks)
+    tick
+    assert_equal([[:local, "ev"]], @events)
+  end
+
+  def test_events_coalesce_within_one_tick_and_one_drain_is_scheduled
+    listen(:local, "ev")
+    listen(:local, "other")
+    Funicular::DB.notify_changed(:local, "ev")
+    Funicular::DB.notify_changed(:local, "ev")
+    Funicular::DB.notify_changed(:local, "other")
+    Funicular::DB.notify_changed(:local, "ev")
+    assert_equal(1, $bus_ticks)
+    tick
+    assert_equal([[:local, "ev"], [:local, "other"]], @events)
+  end
+
+  def test_subscriber_raised_events_belong_to_the_next_tick
+    events = @events
+    @subs << Funicular::DB.subscribe(:local, "one") do |r, t|
+      events << :one_start
+      Funicular::DB.notify_changed(:local, "two")
+      events << :one_end
+    end
+    @subs << Funicular::DB.subscribe(:local, "two") do |r, t|
+      events << :two
+    end
+    Funicular::DB.notify_changed(:local, "one")
+    tick
+    # Never nested into the running delivery...
+    assert_equal([:one_start, :one_end], @events)
+    # ...but not dropped either: it scheduled its own drain.
+    assert_equal(2, $bus_ticks)
+    tick
+    assert_equal([:one_start, :one_end, :two], @events)
+  end
+
+  def test_the_default_scheduler_delivers_on_a_real_js_tick
+    Funicular::DB.__set_tick_scheduler(nil)
+    listen(:local, "ev")
+    Funicular::DB.notify_changed(:local, "ev")
+    assert_equal([], @events)
+    waited = 0
+    while @events.empty? && waited < 50
+      JS.global.eval("new Promise((r) => setTimeout(r, 10))").await
+      waited += 1
+    end
+    assert_equal([[:local, "ev"]], @events)
+  end
+
+  # ---- the two notify forms ----
+
+  def test_model_form_resolves_role_and_table
+    define_models
+    listen(:local, "bus_drafts")
+    listen(:replica, "bus_posts")
+    Funicular::DB.notify_changed(BusDraft)
+    Funicular::DB.notify_changed(BusPost)
+    tick
+    assert_equal([[:local, "bus_drafts"], [:replica, "bus_posts"]], @events)
+  end
+
+  def test_ephemeral_model_has_no_table_to_notify_about
+    define_models
+    assert_raise(Funicular::DB::NoTableError) do
+      Funicular::DB.notify_changed(BusSession)
+    end
+  end
+
+  def test_role_is_validated
+    assert_raise(ArgumentError) do
+      Funicular::DB.notify_changed(:bogus, "ev")
+    end
+    assert_raise(ArgumentError) do
+      Funicular::DB.subscribe(:bogus, "ev") { }
+    end
+  end
+
+  def test_unsubscribe_stops_delivery
+    id = listen(:local, "ev")
+    Funicular::DB.notify_changed(:local, "ev")
+    tick
+    Funicular::DB.unsubscribe(id)
+    Funicular::DB.notify_changed(:local, "ev")
+    tick
+    assert_equal(1, @events.size)
+  end
+
+  # ---- post-commit semantics ----
+
+  def test_transaction_coalesces_and_fires_after_commit
+    listen(:local, "ev")
+    listen(:local, "other")
+    inside_ticks = nil
+    @guard.transaction do
+      Funicular::DB.notify_changed(:local, "ev")
+      Funicular::DB.notify_changed(:local, "ev")
+      Funicular::DB.notify_changed(:local, "other")
+      inside_ticks = $bus_ticks
+    end
+    # Nothing even reached the tick buffer before COMMIT.
+    assert_equal(0, inside_ticks)
+    tick
+    assert_equal([[:local, "ev"], [:local, "other"]], @events)
+  end
+
+  def test_blockless_transaction_defers_until_manual_commit
+    listen(:local, "ev")
+    @guard.transaction
+    Funicular::DB.notify_changed(:local, "ev")
+    assert_equal(0, $bus_ticks)
+    @guard.commit
+    assert_equal(1, $bus_ticks)
+    tick
+    assert_equal([[:local, "ev"]], @events)
+  end
+
+  def test_blockless_transaction_rollback_discards
+    listen(:local, "ev")
+    @guard.transaction
+    @guard.execute("INSERT INTO ev (n) VALUES ('x')")
+    Funicular::DB.notify_changed(:local, "ev")
+    @guard.rollback
+    tick
+    assert_equal([], @events)
+    assert_equal(0, $bus_db.execute("SELECT COUNT(*) FROM ev")[0][0])
+  end
+
+  def test_deferral_is_tracked_per_database_role
+    replica_raw = SQLite3::Database.new(":memory:")
+    replica_guard = Funicular::DB::GuardedDatabase.new(replica_raw, :replica)
+    listen(:local, "ev")
+    listen(:replica, "rev")
+    @guard.transaction
+    Funicular::DB.notify_changed(:local, "ev")
+    replica_guard.transaction
+    Funicular::DB.notify_changed(:replica, "rev")
+    replica_guard.rollback
+    @guard.commit
+    tick
+    # The rolled-back replica event is gone; the committed local one
+    # fired -- one shared depth counter would deliver both or neither.
+    assert_equal([[:local, "ev"]], @events)
+    replica_raw.close
+  end
+
+  def test_only_the_matching_role_defers
+    listen(:replica, "rev")
+    ticks_inside = nil
+    @guard.transaction do
+      # A replica event during a LOCAL transaction is not part of it:
+      # the replica database has no transaction open.
+      Funicular::DB.notify_changed(:replica, "rev")
+      ticks_inside = $bus_ticks
+    end
+    assert_equal(1, ticks_inside)
+    tick
+    assert_equal([[:replica, "rev"]], @events)
+  end
+
+  def test_rollback_discards_pending_events
+    listen(:local, "ev")
+    begin
+      @guard.transaction do
+        Funicular::DB.notify_changed(:local, "ev")
+        raise ArgumentError, "boom"
+      end
+    rescue ArgumentError
+    end
+    tick
+    assert_equal([], @events)
+    Funicular::DB.notify_changed(:local, "ev")
+    tick
+    assert_equal([[:local, "ev"]], @events)
+  end
+
+  # ---- subscriber isolation ----
+
+  def test_a_raising_subscriber_is_isolated
+    events = @events
+    @subs << Funicular::DB.subscribe(:local, "ev") do |r, t|
+      raise "broken watcher"
+    end
+    listen(:local, "ev")
+    Funicular::DB.notify_changed(:local, "ev")
+    tick
+    assert_equal([[:local, "ev"]], @events)
+    Funicular::DB.notify_changed(:local, "ev")
+    tick
+    assert_equal(2, @events.size)
+  end
+
+  def test_model_on_change_and_off_change
+    define_models
+    events = @events
+    sub = BusDraft.on_change { |r, t| events << :changed }
+    Funicular::DB.notify_changed(BusDraft)
+    tick
+    assert_equal([:changed], @events)
+    BusDraft.off_change(sub)
+    Funicular::DB.notify_changed(BusDraft)
+    tick
+    assert_equal(1, @events.size)
+  end
+
+  def test_on_change_contract
+    define_models
+    assert_raise(Funicular::DB::NoTableError) do
+      BusSession.on_change { }
+    end
+    assert_raise(ArgumentError) { BusPost.on_change }
+  end
+
+  def test_local_table_changed_feeds_the_bus
+    define_models
+    listen(:local, "bus_drafts")
+    BusDraft.local_table_changed
+    tick
+    assert_equal([[:local, "bus_drafts"]], @events)
+  end
+end

--- a/test/funicular_test.rb
+++ b/test/funicular_test.rb
@@ -3,6 +3,6 @@ class FunicularTest < Picotest::Test
   end
 
   def test_funicular_version
-    assert_equal('0.4.0', Funicular::VERSION)
+    assert_equal('0.5.0', Funicular::VERSION)
   end
 end

--- a/test/guarded_db_test.rb
+++ b/test/guarded_db_test.rb
@@ -1,0 +1,182 @@
+# Tests for the guarded database handles (docs decision 15): the closed
+# allowlist, the execution-time read-only enforcement backed by
+# Statement#readonly?, and the statements rejected in every state.
+
+class GuardedDbTest < Picotest::Test
+  def setup
+    @raw = SQLite3::Database.new(":memory:")
+    @raw.execute("CREATE TABLE gk (id INTEGER PRIMARY KEY, name TEXT)")
+    @raw.execute("INSERT INTO gk (name) VALUES ('seed')")
+    @writer = Funicular::DB::GuardedDatabase.new(@raw)
+    @reader = Funicular::DB::GuardedDatabase.new(@raw, true)
+  end
+
+  def teardown
+    @raw.close
+  end
+
+  # ---- the closed allowlist ----
+
+  def test_escape_hatches_do_not_exist_in_any_state
+    forbidden = [:persist, :close, :serialize, :deserialize, :backup,
+                 :results_as_hash=]
+    forbidden_size = forbidden.size
+    i = 0
+    while i < forbidden_size
+      assert_equal(false, @writer.respond_to?(forbidden[i]))
+      assert_equal(false, @reader.respond_to?(forbidden[i]))
+      i += 1
+    end
+  end
+
+  # ---- writable handle ----
+
+  def test_writer_writes_and_reads
+    @writer.execute("INSERT INTO gk (name) VALUES (?)", ["two"])
+    assert_equal(2, @writer.get_first_value("SELECT COUNT(*) FROM gk"))
+    assert_equal([1, "seed"], @writer.get_first_row(
+      "SELECT id, name FROM gk WHERE id = ?", [1]))
+    seen = []
+    @writer.execute("SELECT name FROM gk ORDER BY id") do |row|
+      seen << row[0]
+    end
+    assert_equal(["seed", "two"], seen)
+  end
+
+  def test_transaction_yields_the_proxy_and_preserves_exceptions
+    caught = nil
+    begin
+      @writer.transaction do |t|
+        assert_equal(true, t == @writer)
+        t.execute("INSERT INTO gk (name) VALUES ('doomed')")
+        raise ArgumentError, "boom"
+      end
+    rescue ArgumentError => e
+      caught = e.message
+    end
+    assert_equal("boom", caught)
+    assert_equal(1, @writer.get_first_value("SELECT COUNT(*) FROM gk"))
+  end
+
+  def test_transaction_mode_is_validated
+    assert_raise(ArgumentError) { @writer.transaction(:evil) }
+  end
+
+  # ---- read-only enforcement ----
+
+  def test_reader_reads_but_cannot_write
+    assert_equal("seed",
+      @reader.get_first_value("SELECT name FROM gk WHERE id = 1"))
+    assert_raise(Funicular::DB::ReadOnlyTabError) do
+      @reader.execute("INSERT INTO gk (name) VALUES ('nope')")
+    end
+    assert_raise(Funicular::DB::ReadOnlyTabError) do
+      @reader.execute("UPDATE gk SET name = 'nope'")
+    end
+    assert_equal(1, @raw.execute("SELECT COUNT(*) FROM gk")[0][0])
+  end
+
+  def test_prepared_write_is_refused_at_execution_time
+    stmt = @reader.prepare("INSERT INTO gk (name) VALUES (?)")
+    assert_raise(Funicular::DB::ReadOnlyTabError) { stmt.execute("x") }
+    assert_raise(Funicular::DB::ReadOnlyTabError) { stmt.step }
+    stmt.close
+    assert_equal(1, @raw.execute("SELECT COUNT(*) FROM gk")[0][0])
+  end
+
+  def test_lockdown_catches_statements_prepared_while_writable
+    stmt = @writer.prepare("INSERT INTO gk (name) VALUES (?)")
+    @writer.__become_read_only
+    assert_equal(true, @writer.read_only?)
+    assert_raise(Funicular::DB::ReadOnlyTabError) { stmt.execute("x") }
+    stmt.close
+    # Reads keep working after the lockdown.
+    assert_equal("seed",
+      @writer.get_first_value("SELECT name FROM gk WHERE id = 1"))
+  end
+
+  # ---- statements rejected in every state ----
+
+  def test_attach_detach_and_pragma_query_only_are_rejected
+    assert_raise(ArgumentError) do
+      @writer.execute("ATTACH DATABASE ':memory:' AS x")
+    end
+    assert_raise(ArgumentError) { @writer.execute("DETACH DATABASE x") }
+    assert_raise(ArgumentError) { @writer.execute("PRAGMA query_only = ON") }
+    assert_raise(ArgumentError) { @reader.execute("PRAGMA query_only = OFF") }
+    assert_raise(ArgumentError) { @reader.execute("pragma QUERY_ONLY") }
+  end
+
+  def test_comment_prefixes_do_not_smuggle_forbidden_statements
+    assert_raise(ArgumentError) do
+      @writer.execute("  /* sneak */ attach database 'f' as y")
+    end
+    assert_raise(ArgumentError) do
+      @writer.execute("-- c\nATTACH DATABASE 'f' AS z")
+    end
+  end
+
+  def test_read_pragmas_stay_available
+    rows = @reader.execute("PRAGMA table_info(gk)")
+    assert_equal(2, rows.size)
+  end
+
+  def test_pragma_rejection_matches_the_pragma_name_only
+    # Even a TABLE named query_only stays inspectable...
+    @raw.execute("CREATE TABLE query_only (id INTEGER PRIMARY KEY)")
+    assert_equal(1, @reader.execute("PRAGMA table_info(query_only)").size)
+    assert_equal(1, @reader.execute("PRAGMA table_info('query_only')").size)
+    assert_equal(2,
+      @reader.execute("PRAGMA table_info(gk) /* query_only */").size)
+    # ...while every spelling of the query_only PRAGMA itself is caught.
+    assert_raise(ArgumentError) do
+      @writer.execute("PRAGMA main.query_only = ON")
+    end
+    assert_raise(ArgumentError) do
+      @writer.execute("PRAGMA \"query_only\" = ON")
+    end
+    assert_raise(ArgumentError) { @writer.execute("PRAGMA [query_only]") }
+  end
+
+  # ---- guarded result sets ----
+
+  def test_query_yields_a_guarded_resultset_and_closes_it
+    got = nil
+    inside = nil
+    @writer.query("SELECT name FROM gk ORDER BY id") do |rs|
+      inside = rs.is_a?(Funicular::DB::GuardedResultSet)
+      got = rs.next
+    end
+    assert_equal(true, inside)
+    assert_equal(["seed"], got)
+    rows = @reader.query("SELECT COUNT(*) FROM gk").to_a
+    assert_equal([[1]], rows)
+  end
+
+  def test_resultset_next_rechecks_the_read_only_state
+    # A write+RETURNING result set created while writable must refuse to
+    # step once the handle went read-only -- stepping IS the write.
+    rs = @writer.query("INSERT INTO gk (name) VALUES ('r') RETURNING \"id\"")
+    @writer.__become_read_only
+    assert_raise(Funicular::DB::ReadOnlyTabError) { rs.next }
+    assert_raise(Funicular::DB::ReadOnlyTabError) { rs.reset }
+    rs.close
+    assert_equal(1, @raw.execute("SELECT COUNT(*) FROM gk")[0][0])
+  end
+
+  # ---- guarded statements ----
+
+  def test_statement_surface_and_block_form
+    stmt = @writer.prepare("SELECT name FROM gk ORDER BY id")
+    assert_equal(true, stmt.readonly?)
+    assert_equal([["seed"]], stmt.execute)
+    assert_equal(false, stmt.closed?)
+    stmt.close
+    assert_equal(true, stmt.closed?)
+    closed_inside = nil
+    @writer.prepare("SELECT COUNT(*) FROM gk") do |s|
+      closed_inside = s.closed?
+    end
+    assert_equal(false, closed_inside)
+  end
+end

--- a/test/guarded_db_test.rb
+++ b/test/guarded_db_test.rb
@@ -8,7 +8,7 @@ class GuardedDbTest < Picotest::Test
     @raw.execute("CREATE TABLE gk (id INTEGER PRIMARY KEY, name TEXT)")
     @raw.execute("INSERT INTO gk (name) VALUES ('seed')")
     @writer = Funicular::DB::GuardedDatabase.new(@raw)
-    @reader = Funicular::DB::GuardedDatabase.new(@raw, true)
+    @reader = Funicular::DB::GuardedDatabase.new(@raw, :local, true)
   end
 
   def teardown

--- a/test/guarded_db_test.rb
+++ b/test/guarded_db_test.rb
@@ -107,6 +107,48 @@ class GuardedDbTest < Picotest::Test
     assert_raise(ArgumentError) { @reader.execute("pragma QUERY_ONLY") }
   end
 
+  def test_transaction_control_is_rejected_on_the_public_sql_path
+    # Raw boundaries skip the deferral: a BEGIN here would let change
+    # events reach watchers before the commit, and a ROLLBACK would
+    # leave an open deferral's events parked and its postponed
+    # snapshot asleep. Savepoints move the same boundary, and END is
+    # SQLite's synonym for COMMIT.
+    assert_raise(ArgumentError) { @writer.execute("BEGIN") }
+    assert_raise(ArgumentError) { @writer.execute("begin immediate") }
+    assert_raise(ArgumentError) { @writer.execute("COMMIT") }
+    assert_raise(ArgumentError) { @writer.execute("END TRANSACTION") }
+    assert_raise(ArgumentError) { @writer.execute("ROLLBACK") }
+    assert_raise(ArgumentError) { @writer.execute("SAVEPOINT sp1") }
+    assert_raise(ArgumentError) { @writer.execute("RELEASE sp1") }
+    assert_raise(ArgumentError) { @writer.execute("ROLLBACK TO sp1") }
+    # Every entry point, in every state.
+    assert_raise(ArgumentError) { @writer.query("BEGIN") }
+    assert_raise(ArgumentError) { @writer.prepare("BEGIN") }
+    assert_raise(ArgumentError) { @reader.execute("BEGIN") }
+    assert_raise(ArgumentError) do
+      @writer.execute("  /* sneak */ begin deferred")
+    end
+  end
+
+  def test_the_frameworks_own_boundaries_still_run
+    # The refusal above must not reach transaction/commit/rollback,
+    # which pair each boundary with the deferral.
+    @writer.transaction do |db|
+      db.execute("INSERT INTO gk (name) VALUES ('inside')")
+    end
+    assert_equal(2, @writer.execute("SELECT COUNT(*) FROM gk")[0][0])
+    @writer.transaction
+    @writer.execute("INSERT INTO gk (name) VALUES ('rolled back')")
+    @writer.rollback
+    assert_equal(2, @writer.execute("SELECT COUNT(*) FROM gk")[0][0])
+  end
+
+  def test_only_the_leading_keyword_decides
+    # A table named after a transaction verb stays queryable.
+    @raw.execute("CREATE TABLE release (id INTEGER PRIMARY KEY)")
+    assert_equal([], @writer.execute("SELECT * FROM release"))
+  end
+
   def test_comment_prefixes_do_not_smuggle_forbidden_statements
     assert_raise(ArgumentError) do
       @writer.execute("  /* sneak */ attach database 'f' as y")

--- a/test/local_crud_test.rb
+++ b/test/local_crud_test.rb
@@ -1,0 +1,451 @@
+# Tests for storage :local CRUD and the bare-class alias, on a real
+# ":memory:" database. The boot machinery does not exist yet, so the
+# test model overrides local_db (the same override point DB.boot will
+# wire) and counts local_table_changed notifications.
+
+class LocalCrudTest < Picotest::Test
+  def setup
+    $crud_db = SQLite3::Database.new(":memory:")
+    $crud_notified = 0
+    define_model
+    Funicular::DB.apply_local_migrations($crud_db, CrudDraft)
+  end
+
+  def teardown
+    $crud_db.close
+  end
+
+  def define_model
+    return if Object.const_defined?(:CrudDraft)
+
+    Object.const_set(:CrudDraft, Class.new(Funicular::Model))
+    CrudDraft.class_eval do
+      storage :local do
+        migrate 1 do |t|
+          t.string :title
+          t.text :body
+          t.boolean :done, default: false, null: false
+          t.string :note, default: "N/A"
+          t.string :model_class
+          t.datetime :due_at
+          t.timestamps
+        end
+      end
+      validates :title, presence: true
+
+      def self.local_db
+        $crud_db
+      end
+
+      def self.local_table_changed
+        $crud_notified += 1
+      end
+    end
+  end
+
+  # ---- create ----
+
+  def test_create_returns_a_persisted_instance
+    draft = CrudDraft.create(title: "hello")
+    assert_equal(true, draft.id.is_a?(Integer))
+    assert_equal(false, draft.new_record?)
+    assert_equal(1, CrudDraft.count)
+    assert_equal(1, $crud_notified)
+  end
+
+  def test_create_syncs_sql_defaults_back_into_the_instance
+    draft = CrudDraft.create(title: "hello")
+    assert_equal(false, draft.done)
+  end
+
+  def test_create_sets_timestamps
+    draft = CrudDraft.create(title: "stamped")
+    assert_equal(true, draft.created_at.is_a?(Time))
+    assert_equal(true, draft.updated_at.is_a?(Time))
+  end
+
+  def test_create_encodes_and_decodes_types
+    due = Funicular::DB::Codec.iso_to_time("2023-11-14T22:13:20Z")
+    draft = CrudDraft.create(title: "typed", done: true, due_at: due)
+    raw = $crud_db.execute(
+      "SELECT done, due_at FROM crud_drafts WHERE id = ?", [draft.id])[0]
+    assert_equal(1, raw[0])
+    assert_equal("2023-11-14T22:13:20Z", raw[1])
+    found = CrudDraft.find(draft.id)
+    assert_equal(true, found.done)
+    assert_equal(due.to_i, found.due_at.to_i)
+  end
+
+  def test_create_returns_the_unsaved_instance_when_invalid
+    draft = CrudDraft.create({})
+    assert_equal(true, draft.new_record?)
+    assert_equal(false, draft.valid?)
+    assert_equal(0, CrudDraft.count)
+    assert_equal(0, $crud_notified)
+  end
+
+  def test_create_distinguishes_omitted_from_explicit_nil
+    # Omitted: the SQL DEFAULT applies.
+    omitted = CrudDraft.create(title: "a")
+    assert_equal("N/A", omitted.note)
+    # Explicit nil on a nullable column with a default: NULL, not "N/A".
+    explicit = CrudDraft.create(title: "b", note: nil)
+    assert_nil(explicit.note)
+    raw = $crud_db.execute(
+      "SELECT note FROM crud_drafts WHERE id = ?", [explicit.id])[0]
+    assert_nil(raw[0])
+    # Explicit nil on a NOT NULL column: the constraint fires, exactly
+    # like the same nil on update.
+    assert_raise(SQLite3::ConstraintException) do
+      CrudDraft.create(title: "c", done: nil)
+    end
+  end
+
+  def test_create_merges_positional_hash_and_keywords
+    draft = CrudDraft.create({ title: "positional" }, done: true)
+    assert_equal("positional", draft.title)
+    assert_equal(true, draft.done)
+  end
+
+  def test_create_keywords_win_on_the_same_key
+    draft = CrudDraft.create({ title: "hash" }, title: "keyword")
+    assert_equal("keyword", draft.title)
+    # Per attribute, not per literal key: a string-keyed positional hash
+    # loses to the symbol keyword as well.
+    stringy = CrudDraft.create({ "title" => "hash" }, title: "keyword")
+    assert_equal("keyword", stringy.title)
+  end
+
+  def test_create_model_class_is_an_ordinary_column_on_local_models
+    draft = CrudDraft.create(title: "x", model_class: "example")
+    assert_equal("example", draft.model_class)
+    assert_equal("example", CrudDraft.find(draft.id).model_class)
+  end
+
+  def test_create_ids_come_from_the_insert_itself
+    a = CrudDraft.create(title: "a")
+    b = CrudDraft.create(title: "b")
+    assert_equal(false, a.id == b.id)
+    assert_equal("a", CrudDraft.find(a.id).title)
+    assert_equal("b", CrudDraft.find(b.id).title)
+  end
+
+  def test_create_takes_no_block
+    assert_raise(ArgumentError) do
+      CrudDraft.create(title: "x") { |r, e| }
+    end
+  end
+
+  def test_writers_are_column_specific
+    # Regression: writers generated in a while loop once all captured the
+    # SAME loop variable and wrote to the last column (updated_at).
+    draft = CrudDraft.create(title: "t")
+    draft.title = "t2"
+    draft.body = "b2"
+    assert_equal("t2", draft.title)
+    assert_equal("b2", draft.body)
+  end
+
+  def test_user_defined_accessors_are_preserved
+    unless Object.const_defined?(:CrudShouty)
+      Object.const_set(:CrudShouty, Class.new(Funicular::Model))
+      CrudShouty.class_eval do
+        table_name "crud_shouties"
+        storage :local do
+          migrate 1 do |t|
+            t.string :title
+            t.string :plain
+          end
+        end
+
+        def self.local_db
+          $crud_db
+        end
+
+        # A hand-written reader must survive the lazy accessor
+        # generation; only the missing writer is generated.
+        def title
+          "#{@title}!"
+        end
+      end
+    end
+    Funicular::DB.apply_local_migrations($crud_db, CrudShouty)
+    record = CrudShouty.create(title: "loud", plain: "quiet")
+    assert_equal("loud!", record.title)
+    assert_equal("quiet", record.plain)
+    found = CrudShouty.find(record.id)
+    assert_equal(true, found.update(title: "still"))
+    assert_equal("still!", CrudShouty.find(record.id).title)
+  end
+
+  def test_user_defined_writer_is_wrapped_for_dirty_tracking
+    unless Object.const_defined?(:CrudTrimmy)
+      Object.const_set(:CrudTrimmy, Class.new(Funicular::Model))
+      CrudTrimmy.class_eval do
+        table_name "crud_trimmies"
+        storage :local do
+          migrate 1 do |t|
+            t.string :title
+          end
+        end
+
+        def self.local_db
+          $crud_db
+        end
+
+        def self.local_table_changed
+          $crud_notified += 1
+        end
+
+        # A normalizing writer: it must keep running AND stay tracked.
+        def title=(value)
+          @title = value.to_s.strip
+        end
+      end
+    end
+    Funicular::DB.apply_local_migrations($crud_db, CrudTrimmy)
+    # The writer applies on create too, not only on update.
+    record = CrudTrimmy.create(title: "  start  ")
+    assert_equal("start", record.title)
+    assert_equal("start", $crud_db.execute(
+      "SELECT title FROM crud_trimmies WHERE id = ?", [record.id])[0][0])
+    found = CrudTrimmy.find(record.id)
+    assert_equal(true, found.update(title: "  new  "))
+    assert_equal("new", found.title)
+    raw = $crud_db.execute(
+      "SELECT title FROM crud_trimmies WHERE id = ?", [record.id])[0]
+    assert_equal("new", raw[0])
+    # A value that normalizes back to the persisted one stays clean.
+    notified_before = $crud_notified
+    assert_equal(true, found.update(title: " new "))
+    assert_equal(notified_before, $crud_notified)
+  end
+
+  # ---- bare-class alias ----
+
+  def test_all_is_the_whole_table_relation
+    CrudDraft.create(title: "a")
+    CrudDraft.create(title: "b")
+    relation = CrudDraft.all
+    assert_equal(true, relation.is_a?(Funicular::Relation))
+    assert_equal(2, relation.to_a.size)
+  end
+
+  def test_all_takes_no_block_and_no_params
+    assert_raise(ArgumentError) { CrudDraft.all { |r, e| } }
+    assert_raise(ArgumentError) { CrudDraft.all(page: 2) }
+  end
+
+  def test_class_level_query_methods
+    CrudDraft.create(title: "a", done: true)
+    CrudDraft.create(title: "b")
+    CrudDraft.create(title: "c")
+    assert_equal(3, CrudDraft.count)
+    assert_equal(true, CrudDraft.exists?)
+    assert_equal("a", CrudDraft.order(:id).first.title)
+    assert_equal(1, CrudDraft.where(done: true).count)
+    assert_equal("b", CrudDraft.find_by(title: "b").title)
+    assert_equal(2, CrudDraft.order(:id).limit(2).to_a.size)
+    assert_equal(1, CrudDraft.order(:id).offset(2).to_a.size)
+    assert_equal(2, CrudDraft.where(done: false).delete_all)
+    assert_equal(1, CrudDraft.count)
+  end
+
+  def test_alias_is_absent_on_non_local_models
+    replica = Class.new(Funicular::Model)
+    assert_raise(NoMethodError) { replica.where(done: true) }
+    assert_raise(NoMethodError) { replica.delete_all }
+  end
+
+  def test_class_find_returns_or_raises
+    draft = CrudDraft.create(title: "findable")
+    assert_equal("findable", CrudDraft.find(draft.id).title)
+    assert_raise(Funicular::RecordNotFound) { CrudDraft.find(999) }
+    assert_raise(ArgumentError) { CrudDraft.find(draft.id) { |r, e| } }
+  end
+
+  def test_class_destroy
+    draft = CrudDraft.create(title: "doomed")
+    assert_equal(true, CrudDraft.destroy(draft.id))
+    assert_equal(0, CrudDraft.count)
+    assert_raise(Funicular::RecordNotFound) { CrudDraft.destroy(999) }
+  end
+
+  # ---- update ----
+
+  def test_update_persists_and_bumps_updated_at
+    draft = CrudDraft.create(title: "old")
+    $crud_db.execute(
+      "UPDATE crud_drafts SET updated_at = '2000-01-01T00:00:00Z' WHERE id = ?",
+      [draft.id])
+    record = CrudDraft.find(draft.id)
+    notified_before = $crud_notified
+    assert_equal(true, record.update(title: "new"))
+    raw = $crud_db.execute(
+      "SELECT title, updated_at FROM crud_drafts WHERE id = ?", [draft.id])[0]
+    assert_equal("new", raw[0])
+    assert_equal(false, raw[1] == "2000-01-01T00:00:00Z")
+    assert_equal(notified_before + 1, $crud_notified)
+  end
+
+  def test_update_with_no_actual_change_is_a_noop
+    draft = CrudDraft.create(title: "same")
+    $crud_db.execute(
+      "UPDATE crud_drafts SET updated_at = '2000-01-01T00:00:00Z' WHERE id = ?",
+      [draft.id])
+    record = CrudDraft.find(draft.id)
+    notified_before = $crud_notified
+    assert_equal(true, record.update({}))
+    assert_equal(true, record.update(title: "same"))
+    raw = $crud_db.execute(
+      "SELECT updated_at FROM crud_drafts WHERE id = ?", [draft.id])[0]
+    assert_equal("2000-01-01T00:00:00Z", raw[0])
+    assert_equal(notified_before, $crud_notified)
+  end
+
+  def test_reverting_to_the_persisted_value_cancels_the_change
+    draft = CrudDraft.create(title: "original")
+    $crud_db.execute(
+      "UPDATE crud_drafts SET updated_at = '2000-01-01T00:00:00Z' WHERE id = ?",
+      [draft.id])
+    record = CrudDraft.find(draft.id)
+    record.title = "temporary"
+    record.title = "original"
+    notified_before = $crud_notified
+    assert_equal(true, record.update)
+    raw = $crud_db.execute(
+      "SELECT title, updated_at FROM crud_drafts WHERE id = ?", [draft.id])[0]
+    assert_equal("original", raw[0])
+    assert_equal("2000-01-01T00:00:00Z", raw[1])
+    assert_equal(notified_before, $crud_notified)
+  end
+
+  def test_revert_is_clean_on_the_created_instance_too
+    draft = CrudDraft.create(title: "orig")
+    draft.body = "tmp"
+    draft.body = nil
+    notified_before = $crud_notified
+    assert_equal(true, draft.update)
+    assert_equal(notified_before, $crud_notified)
+  end
+
+  def test_update_syncs_normalized_values_back_into_the_instance
+    draft = CrudDraft.create(title: "t")
+    assert_equal(true, draft.update(due_at: "2026-01-01T09:00:00+09:00"))
+    utc = Funicular::DB::Codec.iso_to_time("2026-01-01T00:00:00Z")
+    # The instance carries what the table stores: the decoded Time, not
+    # the offset string that was assigned.
+    assert_equal(true, draft.due_at.is_a?(Time))
+    assert_equal(utc.to_i, draft.due_at.to_i)
+    found = CrudDraft.find(draft.id)
+    assert_equal(utc.to_i, found.due_at.to_i)
+    # The baseline matches too: assigning the equivalent Time is clean.
+    notified_before = $crud_notified
+    assert_equal(true, draft.update(due_at: utc))
+    assert_equal(notified_before, $crud_notified)
+  end
+
+  def test_update_validation_failure_returns_false
+    draft = CrudDraft.create(title: "valid")
+    notified_before = $crud_notified
+    assert_equal(false, draft.update(title: nil))
+    raw = $crud_db.execute(
+      "SELECT title FROM crud_drafts WHERE id = ?", [draft.id])[0]
+    assert_equal("valid", raw[0])
+    assert_equal(notified_before, $crud_notified)
+  end
+
+  def test_update_on_a_new_record_raises
+    assert_raise(ArgumentError) do
+      CrudDraft.new(title: "floating").update(title: "x")
+    end
+  end
+
+  def test_update_takes_no_block
+    draft = CrudDraft.create(title: "x")
+    assert_raise(ArgumentError) do
+      draft.update(title: "y") { |r, e| }
+    end
+  end
+
+  # ---- destroy / reload ----
+
+  def test_destroy_removes_the_row
+    draft = CrudDraft.create(title: "bye")
+    notified_before = $crud_notified
+    assert_equal(true, draft.destroy)
+    assert_equal(0, CrudDraft.count)
+    assert_equal(notified_before + 1, $crud_notified)
+  end
+
+  def test_destroy_on_a_new_record_raises
+    assert_raise(ArgumentError) { CrudDraft.new(title: "x").destroy }
+    draft = CrudDraft.create(title: "x")
+    assert_raise(ArgumentError) { draft.destroy { |ok, e| } }
+  end
+
+  def test_reload_rereads_the_row
+    draft = CrudDraft.create(title: "before")
+    $crud_db.execute(
+      "UPDATE crud_drafts SET title = 'after' WHERE id = ?", [draft.id])
+    assert_equal(draft, draft.reload)
+    assert_equal("after", draft.title)
+    assert_raise(ArgumentError) { draft.reload { |r, e| } }
+  end
+
+  def test_destroy_of_an_already_deleted_row_does_not_notify
+    draft = CrudDraft.create(title: "gone")
+    $crud_db.execute("DELETE FROM crud_drafts WHERE id = ?", [draft.id])
+    notified_before = $crud_notified
+    assert_equal(true, draft.destroy)
+    assert_equal(notified_before, $crud_notified)
+  end
+
+  def test_reload_on_a_deleted_row_raises
+    draft = CrudDraft.create(title: "gone")
+    $crud_db.execute("DELETE FROM crud_drafts WHERE id = ?", [draft.id])
+    assert_raise(Funicular::RecordNotFound) { draft.reload }
+  end
+
+  def test_update_on_a_deleted_row_raises_keeps_changes_and_does_not_notify
+    draft = CrudDraft.create(title: "gone")
+    $crud_db.execute("DELETE FROM crud_drafts WHERE id = ?", [draft.id])
+    notified_before = $crud_notified
+    assert_raise(Funicular::RecordNotFound) { draft.update(title: "new") }
+    assert_equal(notified_before, $crud_notified)
+    assert_equal("new", draft.title)
+    pending = draft.instance_variable_get("@changed_attributes")
+    assert_equal("new", pending["title"])
+  end
+
+  def test_failed_update_reverts_the_internal_updated_at_stamp
+    draft = CrudDraft.create(title: "t")
+    record = CrudDraft.find(draft.id)
+    assert_raise(SQLite3::ConstraintException) { record.update(done: nil) }
+    # Back to the persisted value: the record is now genuinely clean --
+    # unless the failed update left its internal updated_at stamp dirty.
+    record.done = false
+    notified_before = $crud_notified
+    assert_equal(true, record.update)
+    assert_equal(notified_before, $crud_notified)
+  end
+
+  def test_failed_encode_also_reverts_the_stamp
+    draft = CrudDraft.create(title: "t")
+    record = CrudDraft.find(draft.id)
+    assert_raise(ArgumentError) { record.update(due_at: "invalid") }
+    record.due_at = nil
+    notified_before = $crud_notified
+    assert_equal(true, record.update)
+    assert_equal(notified_before, $crud_notified)
+  end
+
+  def test_constraint_violations_escape_as_sqlite_exception
+    draft = CrudDraft.create(title: "x")
+    # done is NOT NULL: a raw nil assignment slips past presence
+    # validation (only title is validated) and must fail loud in SQLite.
+    assert_raise(SQLite3::ConstraintException) do
+      draft.update(done: nil)
+    end
+  end
+end

--- a/test/migration_test.rb
+++ b/test/migration_test.rb
@@ -404,6 +404,21 @@ class MigrationTest < Picotest::Test
     assert_raise(ArgumentError) { Funicular::DB.fold_local_columns(renamer) }
   end
 
+  def test_local_table_cannot_be_named_funicular_meta
+    bad = Class.new(Funicular::Model)
+    bad.class_eval do
+      table_name "Funicular_Meta"
+      storage :local do
+        migrate 1 do |t|
+          t.string :name
+        end
+      end
+    end
+    assert_raise(ArgumentError) do
+      Funicular::DB.apply_local_migrations(@db, bad)
+    end
+  end
+
   def test_migrate_blocks_are_evaluated_once_per_run
     $mig_block_runs = 0
     counted = Class.new(Funicular::Model)

--- a/test/migration_test.rb
+++ b/test/migration_test.rb
@@ -247,6 +247,83 @@ class MigrationTest < Picotest::Test
     assert_equal(["index_mig_gadgets_on_name"], index_names("mig_gadgets"))
   end
 
+  # ---- reset: true kept mid-history ----
+  # The docs only say pre-reset blocks MAY be deleted: a reset block must
+  # act as the baseline even when the superseded history stays in code.
+
+  def reset_history_model(extra_version = nil)
+    klass = Class.new(Funicular::Model)
+    klass.class_eval do
+      table_name "mig_resets"
+      storage :local do
+        migrate 1 do |t|
+          t.string :old_name
+          t.string :title
+        end
+        migrate 2, reset: true do |t|
+          t.string :title
+          t.string :new_name
+        end
+        migrate 3 do |t|
+          t.integer :rank
+        end
+        if extra_version
+          migrate 4 do |t|
+            t.float :score
+          end
+        end
+      end
+    end
+    klass
+  end
+
+  def test_mid_history_reset_is_the_fold_baseline
+    expected = {
+      "id" => :integer,
+      "title" => :string,
+      "new_name" => :string,
+      "rank" => :integer,
+    }
+    # No duplicate-column error although the reset block redefines title.
+    assert_equal(expected, Funicular::DB.fold_local_columns(reset_history_model))
+  end
+
+  def test_fresh_apply_skips_pre_reset_history
+    model = reset_history_model
+    assert_equal(3, Funicular::DB.apply_local_migrations(@db, model))
+    assert_equal(["id", "title", "new_name", "rank"],
+                 table_columns("mig_resets"))
+    assert_equal(3, Funicular::DB.stored_table_version(@db, "mig_resets"))
+  end
+
+  def test_below_mid_history_reset_rebuilds
+    v1 = Class.new(Funicular::Model)
+    v1.class_eval do
+      table_name "mig_resets"
+      storage :local do
+        migrate 1 do |t|
+          t.string :old_name
+          t.string :title
+        end
+      end
+    end
+    Funicular::DB.apply_local_migrations(@db, v1)
+    @db.execute("INSERT INTO mig_resets (old_name) VALUES ('stale')")
+    assert_equal(3, Funicular::DB.apply_local_migrations(@db, reset_history_model))
+    assert_equal(["id", "title", "new_name", "rank"],
+                 table_columns("mig_resets"))
+    assert_equal(0, @db.execute("SELECT COUNT(*) FROM mig_resets")[0][0])
+  end
+
+  def test_incremental_upgrade_above_mid_history_reset_keeps_data
+    Funicular::DB.apply_local_migrations(@db, reset_history_model)
+    @db.execute("INSERT INTO mig_resets (title) VALUES ('kept')")
+    assert_equal(4, Funicular::DB.apply_local_migrations(@db, reset_history_model(4)))
+    assert_equal(["id", "title", "new_name", "rank", "score"],
+                 table_columns("mig_resets"))
+    assert_equal("kept", @db.execute("SELECT title FROM mig_resets")[0][0])
+  end
+
   # ---- failure handling ----
 
   def test_failed_upgrade_rolls_back_in_production

--- a/test/migration_test.rb
+++ b/test/migration_test.rb
@@ -367,6 +367,43 @@ class MigrationTest < Picotest::Test
     assert_equal("intact", @db.execute("SELECT title FROM mig_docs")[0][0])
   end
 
+  def test_reserved_column_names_are_rejected
+    # The generated reader would clobber the model API (or Object's);
+    # __-prefixed names would clobber framework internals (the
+    # __custom_* stash that wraps hand-written writers, notably).
+    bad_names = ["destroy", "class", "errors", "initialize", "__custom_title"]
+    bad_names_size = bad_names.size
+    i = 0
+    while i < bad_names_size
+      bad_name = bad_names[i]
+      suffix = i
+      bad = Class.new(Funicular::Model)
+      bad.class_eval do
+        table_name "mig_reserved#{suffix}"
+        storage :local do
+          migrate 1 do |t|
+            t.string bad_name
+          end
+        end
+      end
+      assert_raise(ArgumentError) { Funicular::DB.fold_local_columns(bad) }
+      i += 1
+    end
+    renamer = Class.new(Funicular::Model)
+    renamer.class_eval do
+      table_name "mig_reserved_rename"
+      storage :local do
+        migrate 1 do |t|
+          t.string :title
+        end
+        migrate 2 do |t|
+          t.rename :title, :reload
+        end
+      end
+    end
+    assert_raise(ArgumentError) { Funicular::DB.fold_local_columns(renamer) }
+  end
+
   def test_migrate_blocks_are_evaluated_once_per_run
     $mig_block_runs = 0
     counted = Class.new(Funicular::Model)

--- a/test/migration_test.rb
+++ b/test/migration_test.rb
@@ -324,6 +324,49 @@ class MigrationTest < Picotest::Test
     assert_equal("kept", @db.execute("SELECT title FROM mig_resets")[0][0])
   end
 
+  def test_incremental_id_rename_or_remove_is_rejected_before_any_sql
+    Funicular::DB.apply_local_migrations(@db, MigDocV1)
+    @db.execute("INSERT INTO mig_docs (title) VALUES ('intact')")
+    renamer = Class.new(Funicular::Model)
+    renamer.class_eval do
+      table_name "mig_docs"
+      storage :local do
+        migrate 1 do |t|
+          t.string :title, null: false
+          t.text :body
+        end
+        migrate 2 do |t|
+          t.rename :id, :legacy_id
+        end
+      end
+    end
+    remover = Class.new(Funicular::Model)
+    remover.class_eval do
+      table_name "mig_docs"
+      storage :local do
+        migrate 1 do |t|
+          t.string :title, null: false
+          t.text :body
+        end
+        migrate 2 do |t|
+          t.remove :id
+        end
+      end
+    end
+    # SQLite itself would happily rename the PRIMARY KEY column, so the
+    # fold must reject this before any DDL runs -- and it must do so even
+    # in development (fold errors never trigger the dev auto-reset).
+    assert_raise(ArgumentError) do
+      Funicular::DB.apply_local_migrations(@db, renamer)
+    end
+    assert_raise(ArgumentError) do
+      Funicular::DB.apply_local_migrations(@db, remover)
+    end
+    assert_equal(1, Funicular::DB.stored_table_version(@db, "mig_docs"))
+    assert_equal(["id", "title", "body"], table_columns("mig_docs"))
+    assert_equal("intact", @db.execute("SELECT title FROM mig_docs")[0][0])
+  end
+
   # ---- failure handling ----
 
   def test_failed_upgrade_rolls_back_in_production

--- a/test/migration_test.rb
+++ b/test/migration_test.rb
@@ -367,6 +367,26 @@ class MigrationTest < Picotest::Test
     assert_equal("intact", @db.execute("SELECT title FROM mig_docs")[0][0])
   end
 
+  def test_migrate_blocks_are_evaluated_once_per_run
+    $mig_block_runs = 0
+    counted = Class.new(Funicular::Model)
+    counted.class_eval do
+      table_name "mig_counts"
+      storage :local do
+        migrate 1 do |t|
+          $mig_block_runs += 1
+          t.string :name
+        end
+      end
+    end
+    # Fresh apply: validation and DDL share ONE evaluation of the block.
+    Funicular::DB.apply_local_migrations(@db, counted)
+    assert_equal(1, $mig_block_runs)
+    # A no-op re-application still validates, so exactly one more.
+    Funicular::DB.apply_local_migrations(@db, counted)
+    assert_equal(2, $mig_block_runs)
+  end
+
   # ---- failure handling ----
 
   def test_failed_upgrade_rolls_back_in_production

--- a/test/migration_test.rb
+++ b/test/migration_test.rb
@@ -1,0 +1,288 @@
+# Tests for the client-only-table migration machinery: TableBuilder, the
+# column fold, and the runner (baseline rebuild, incremental upgrade,
+# SchemaTooNew, rollback, dev auto-reset), against a real ":memory:"
+# database. Model classes are real Funicular::Model subclasses so the
+# recorded-by-the-DSL path is what runs.
+
+class MigrationTest < Picotest::Test
+  def setup
+    @db = SQLite3::Database.new(":memory:")
+    define_models
+  end
+
+  def teardown
+    @db.close
+    Funicular.env = nil
+  end
+
+  def define_models
+    return if Object.const_defined?(:MigDocV1)
+
+    # The same table ("mig_docs") declared at three points of its life:
+    # version 1 only, versions 1..2, and a squashed reset baseline at 3.
+    Object.const_set(:MigDocV1, Class.new(Funicular::Model))
+    MigDocV1.class_eval do
+      table_name "mig_docs"
+      storage :local do
+        migrate 1 do |t|
+          t.string :title, null: false
+          t.text :body
+        end
+      end
+    end
+
+    Object.const_set(:MigDocV2, Class.new(Funicular::Model))
+    MigDocV2.class_eval do
+      table_name "mig_docs"
+      storage :local do
+        migrate 1 do |t|
+          t.string :title, null: false
+          t.text :body
+        end
+        migrate 2 do |t|
+          t.boolean :pinned, default: false, null: false
+          t.rename :body, :content
+        end
+      end
+    end
+
+    Object.const_set(:MigDocV3, Class.new(Funicular::Model))
+    MigDocV3.class_eval do
+      table_name "mig_docs"
+      storage :local do
+        migrate 3, reset: true do |t|
+          t.string :slug
+        end
+      end
+    end
+
+    Object.const_set(:MigGadget, Class.new(Funicular::Model))
+    MigGadget.class_eval do
+      storage :local do
+        migrate 1 do |t|
+          t.string :name
+          t.integer :count, default: 0
+          t.timestamps
+          t.index :name
+        end
+        migrate 2 do |t|
+          t.remove_index :name
+          t.remove :count
+          t.execute "INSERT INTO \"mig_gadgets\" (\"name\") VALUES ('seeded')"
+        end
+      end
+    end
+  end
+
+  def table_columns(table)
+    # @type var names: Array[String]
+    names = []
+    rows = @db.execute("PRAGMA table_info(\"#{table}\")")
+    i = 0
+    while i < rows.size
+      names << rows[i][1]
+      i += 1
+    end
+    names
+  end
+
+  def index_names(table)
+    # @type var names: Array[String]
+    names = []
+    rows = @db.execute(
+      "SELECT name FROM sqlite_master WHERE type = 'index' AND tbl_name = ?",
+      [table])
+    i = 0
+    while i < rows.size
+      names << rows[i][0]
+      i += 1
+    end
+    names
+  end
+
+  # ---- fold ----
+
+  def test_fold_includes_implicit_id_and_follows_rename_and_remove
+    expected = {
+      "id" => :integer,
+      "title" => :string,
+      "pinned" => :boolean,
+      "content" => :text,
+    }
+    assert_equal(expected, Funicular::DB.fold_local_columns(MigDocV2))
+  end
+
+  def test_fold_rejects_duplicate_and_unknown_columns
+    dup = Class.new(Funicular::Model)
+    dup.class_eval do
+      table_name "mig_dups"
+      storage :local do
+        migrate 1 do |t|
+          t.string :a
+        end
+        migrate 2 do |t|
+          t.integer :a
+        end
+      end
+    end
+    assert_raise(ArgumentError) { Funicular::DB.fold_local_columns(dup) }
+
+    unknown = Class.new(Funicular::Model)
+    unknown.class_eval do
+      table_name "mig_unknowns"
+      storage :local do
+        migrate 1 do |t|
+          t.rename :ghost, :spirit
+        end
+      end
+    end
+    assert_raise(ArgumentError) { Funicular::DB.fold_local_columns(unknown) }
+  end
+
+  def test_builder_guards_identifiers_and_the_implicit_id
+    assert_raise(ArgumentError) do
+      Class.new(Funicular::Model) do
+        table_name "mig_bad_ids"
+        storage :local do
+          migrate 1 do |t|
+            t.string :id
+          end
+        end
+      end.local_columns
+    end
+    assert_raise(ArgumentError) do
+      Funicular::DB.validate_identifier("bad\"name")
+    end
+  end
+
+  # ---- fresh apply / no-op re-apply ----
+
+  def test_fresh_apply_creates_table_and_records_version
+    assert_equal(1, Funicular::DB.apply_local_migrations(@db, MigDocV1))
+    assert_equal(["id", "title", "body"], table_columns("mig_docs"))
+    assert_equal(1, Funicular::DB.stored_table_version(@db, "mig_docs"))
+  end
+
+  def test_reapply_is_a_noop_and_keeps_data
+    Funicular::DB.apply_local_migrations(@db, MigDocV1)
+    @db.execute("INSERT INTO mig_docs (title) VALUES ('kept')")
+    assert_equal(1, Funicular::DB.apply_local_migrations(@db, MigDocV1))
+    assert_equal("kept", @db.execute("SELECT title FROM mig_docs")[0][0])
+  end
+
+  # ---- incremental upgrade ----
+
+  def test_upgrade_applies_only_missing_blocks_and_keeps_data
+    Funicular::DB.apply_local_migrations(@db, MigDocV1)
+    @db.execute("INSERT INTO mig_docs (title, body) VALUES ('a', 'text')")
+    assert_equal(2, Funicular::DB.apply_local_migrations(@db, MigDocV2))
+    assert_equal(["id", "title", "content", "pinned"],
+                 table_columns("mig_docs"))
+    row = @db.execute("SELECT title, content, pinned FROM mig_docs")[0]
+    assert_equal(["a", "text", 0], row)
+    assert_equal(2, Funicular::DB.stored_table_version(@db, "mig_docs"))
+  end
+
+  def test_boolean_default_applies_to_existing_rows
+    Funicular::DB.apply_local_migrations(@db, MigDocV1)
+    @db.execute("INSERT INTO mig_docs (title) VALUES ('x')")
+    Funicular::DB.apply_local_migrations(@db, MigDocV2)
+    assert_equal(0, @db.execute("SELECT pinned FROM mig_docs")[0][0])
+  end
+
+  # ---- baseline rebuild ----
+
+  def test_below_baseline_rebuilds_and_discards_data
+    Funicular::DB.apply_local_migrations(@db, MigDocV2)
+    @db.execute("INSERT INTO mig_docs (title) VALUES ('doomed')")
+    assert_equal(3, Funicular::DB.apply_local_migrations(@db, MigDocV3))
+    assert_equal(["id", "slug"], table_columns("mig_docs"))
+    assert_equal(0, @db.execute("SELECT COUNT(*) FROM mig_docs")[0][0])
+    assert_equal(3, Funicular::DB.stored_table_version(@db, "mig_docs"))
+  end
+
+  # ---- SchemaTooNew ----
+
+  def test_stored_version_newer_than_declared_raises
+    Funicular::DB.apply_local_migrations(@db, MigDocV3)
+    assert_raise(Funicular::DB::SchemaTooNewError) do
+      Funicular::DB.apply_local_migrations(@db, MigDocV2)
+    end
+    # Untouched: still at version 3 with the version-3 shape.
+    assert_equal(3, Funicular::DB.stored_table_version(@db, "mig_docs"))
+    assert_equal(["id", "slug"], table_columns("mig_docs"))
+  end
+
+  # ---- index / remove / execute ops ----
+
+  def test_index_timestamps_remove_and_execute
+    Funicular::DB.apply_local_migrations(@db, MigGadget)
+    assert_equal(["id", "name", "created_at", "updated_at"],
+                 table_columns("mig_gadgets"))
+    assert_equal([], index_names("mig_gadgets"))
+    assert_equal("seeded", @db.execute("SELECT name FROM mig_gadgets")[0][0])
+    expected = {
+      "id" => :integer,
+      "name" => :string,
+      "created_at" => :datetime,
+      "updated_at" => :datetime,
+    }
+    assert_equal(expected, MigGadget.local_columns)
+  end
+
+  def test_index_exists_at_version_one
+    v1 = Class.new(Funicular::Model)
+    v1.class_eval do
+      table_name "mig_gadgets"
+      storage :local do
+        migrate 1 do |t|
+          t.string :name
+          t.integer :count, default: 0
+          t.timestamps
+          t.index :name
+        end
+      end
+    end
+    Funicular::DB.apply_local_migrations(@db, v1)
+    assert_equal(["index_mig_gadgets_on_name"], index_names("mig_gadgets"))
+  end
+
+  # ---- failure handling ----
+
+  def test_failed_upgrade_rolls_back_in_production
+    Funicular.env = "production"
+    Funicular::DB.apply_local_migrations(@db, MigDocV1)
+    @db.execute("INSERT INTO mig_docs (title) VALUES ('safe')")
+    broken = Class.new(Funicular::Model)
+    broken.class_eval do
+      table_name "mig_docs"
+      storage :local do
+        migrate 1 do |t|
+          t.string :title, null: false
+          t.text :body
+        end
+        migrate 2 do |t|
+          t.execute "THIS IS NOT SQL"
+        end
+      end
+    end
+    assert_raise(SQLite3::Exception) do
+      Funicular::DB.apply_local_migrations(@db, broken)
+    end
+    assert_equal(1, Funicular::DB.stored_table_version(@db, "mig_docs"))
+    assert_equal("safe", @db.execute("SELECT title FROM mig_docs")[0][0])
+  end
+
+  def test_failed_upgrade_auto_resets_in_development
+    Funicular.env = "development"
+    Funicular::DB.apply_local_migrations(@db, MigDocV1)
+    @db.execute("INSERT INTO mig_docs (title) VALUES ('dev')")
+    # Dirty dev table: the column version 2 wants to add already exists.
+    @db.execute("ALTER TABLE mig_docs ADD COLUMN pinned INTEGER")
+    assert_equal(2, Funicular::DB.apply_local_migrations(@db, MigDocV2))
+    assert_equal(["id", "title", "content", "pinned"],
+                 table_columns("mig_docs"))
+    assert_equal(0, @db.execute("SELECT COUNT(*) FROM mig_docs")[0][0])
+    assert_equal(2, Funicular::DB.stored_table_version(@db, "mig_docs"))
+  end
+end

--- a/test/model_dsl_test.rb
+++ b/test/model_dsl_test.rb
@@ -1,0 +1,275 @@
+# Tests for the model-side declaration DSL of the local database layer:
+# storage / migrate recording and version rules / refresh / table_name /
+# the `.local` entry point and the schema-derived replica columns.
+# Nothing here needs a database: migrate blocks are only recorded, and
+# Relation chains are lazy (materializing without DB.boot fails loud).
+
+class ModelDslTest < Picotest::Test
+  SCHEMA = {
+    "attributes" => {
+      "id" => { "readonly" => true, "type" => "integer" },
+      "title" => { "type" => "string" },
+      "done" => { "type" => "boolean" },
+      "avatar" => { "type" => "binary" },
+      "created_at" => { "type" => "datetime" },
+    },
+    "endpoints" => {},
+  }
+
+  def setup
+    return if Object.const_defined?(:DslPost)
+
+    Object.const_set(:DslPost, Class.new(Funicular::Model))
+    DslPost.load_schema(SCHEMA)
+
+    # No schema loaded on purpose (local_columns must fail loud).
+    Object.const_set(:DslCategory, Class.new(Funicular::Model))
+
+    Object.const_set(:DslSession, Class.new(Funicular::Model))
+    DslSession.class_eval do
+      storage :ephemeral
+    end
+
+    Object.const_set(:DslDraft, Class.new(Funicular::Model))
+    DslDraft.class_eval do
+      storage :local do
+        migrate 1 do |t|
+          t.string :title
+        end
+        migrate 2 do |t|
+          t.boolean :done
+        end
+      end
+    end
+  end
+
+  # ---- storage axis ----
+
+  def test_default_storage_is_replica
+    assert_equal(:replica, DslPost.storage_kind)
+    assert_equal(true, DslPost.replica?)
+    assert_equal(false, DslPost.ephemeral?)
+    assert_equal(false, DslPost.local?)
+  end
+
+  def test_storage_ephemeral
+    assert_equal(true, DslSession.ephemeral?)
+    assert_equal(false, DslSession.replica?)
+  end
+
+  def test_storage_local_records_migrations_without_running_them
+    assert_equal(true, DslDraft.local?)
+    migrations = DslDraft.local_migrations
+    assert_equal(2, migrations.size)
+    assert_equal(1, migrations[0][:version])
+    assert_equal(2, migrations[1][:version])
+    assert_equal(false, migrations[0][:reset])
+  end
+
+  def test_storage_rejects_unknown_kind
+    assert_raise(ArgumentError) do
+      Class.new(Funicular::Model) { storage :cloud }
+    end
+  end
+
+  def test_storage_non_local_rejects_block
+    assert_raise(ArgumentError) do
+      Class.new(Funicular::Model) do
+        storage :ephemeral do
+        end
+      end
+    end
+  end
+
+  def test_storage_local_requires_block
+    assert_raise(ArgumentError) do
+      Class.new(Funicular::Model) { storage :local }
+    end
+  end
+
+  def test_storage_local_requires_at_least_one_migration
+    assert_raise(ArgumentError) do
+      Class.new(Funicular::Model) do
+        storage :local do
+        end
+      end
+    end
+  end
+
+  # ---- migrate version rules ----
+
+  def test_migrate_outside_storage_block_raises
+    assert_raise(ArgumentError) do
+      Class.new(Funicular::Model) do
+        migrate 1 do |t|
+        end
+      end
+    end
+  end
+
+  def test_migrate_requires_block
+    assert_raise(ArgumentError) do
+      Class.new(Funicular::Model) do
+        storage :local do
+          migrate 1
+        end
+      end
+    end
+  end
+
+  def test_migrate_version_must_be_a_positive_integer
+    assert_raise(ArgumentError) do
+      Class.new(Funicular::Model) do
+        storage :local do
+          migrate 0 do |t|
+          end
+        end
+      end
+    end
+    assert_raise(ArgumentError) do
+      Class.new(Funicular::Model) do
+        storage :local do
+          migrate "1" do |t|
+          end
+        end
+      end
+    end
+  end
+
+  def test_first_migration_must_be_version_one
+    assert_raise(ArgumentError) do
+      Class.new(Funicular::Model) do
+        storage :local do
+          migrate 2 do |t|
+          end
+        end
+      end
+    end
+  end
+
+  def test_first_migration_may_be_a_reset_baseline_at_any_version
+    klass = Class.new(Funicular::Model) do
+      storage :local do
+        migrate 5, reset: true do |t|
+        end
+        migrate 6 do |t|
+        end
+      end
+    end
+    migrations = klass.local_migrations
+    assert_equal(5, migrations[0][:version])
+    assert_equal(true, migrations[0][:reset])
+  end
+
+  def test_migration_versions_must_be_contiguous
+    assert_raise(ArgumentError) do
+      Class.new(Funicular::Model) do
+        storage :local do
+          migrate 1 do |t|
+          end
+          migrate 3 do |t|
+          end
+        end
+      end
+    end
+  end
+
+  # ---- refresh axis ----
+
+  def test_refresh_manual_is_accepted
+    klass = Class.new(Funicular::Model) { refresh :manual }
+    assert_equal(:manual, klass.refresh_mode)
+  end
+
+  def test_refresh_defaults_to_manual
+    assert_equal(:manual, DslPost.refresh_mode)
+  end
+
+  def test_refresh_auto_and_live_are_not_yet_supported
+    assert_raise(NotImplementedError) do
+      Class.new(Funicular::Model) { refresh :auto }
+    end
+    assert_raise(NotImplementedError) do
+      Class.new(Funicular::Model) { refresh :live }
+    end
+  end
+
+  def test_refresh_rejects_unknown_mode
+    assert_raise(ArgumentError) do
+      Class.new(Funicular::Model) { refresh :sometimes }
+    end
+  end
+
+  # ---- table_name ----
+
+  def test_table_name_naive_pluralization
+    assert_equal("dsl_posts", DslPost.table_name)
+  end
+
+  def test_table_name_y_becomes_ies
+    assert_equal("dsl_categories", DslCategory.table_name)
+  end
+
+  def test_table_name_override
+    unless Object.const_defined?(:DslThing)
+      Object.const_set(:DslThing, Class.new(Funicular::Model))
+      DslThing.class_eval do
+        table_name "gadgets"
+      end
+    end
+    assert_equal("gadgets", DslThing.table_name)
+  end
+
+  # ---- .local entry point ----
+
+  def test_local_on_ephemeral_raises_no_table_error
+    assert_raise(Funicular::DB::NoTableError) { DslSession.local }
+  end
+
+  def test_local_returns_a_whole_table_relation
+    assert_equal(true, DslPost.local.is_a?(Funicular::Relation))
+    assert_equal(true, DslDraft.local.is_a?(Funicular::Relation))
+  end
+
+  def test_local_chain_builds_without_a_database
+    rel = DslPost.local.where(done: true).order(created_at: :desc).limit(3)
+    assert_equal(true, rel.is_a?(Funicular::Relation))
+  end
+
+  def test_materializing_without_boot_fails_loud
+    assert_raise(Funicular::DB::UnavailableError) { DslPost.local.count }
+    assert_raise(Funicular::DB::UnavailableError) do
+      DslPost.local.where(done: false).to_a
+    end
+  end
+
+  # ---- replica column derivation ----
+
+  def test_replica_columns_derive_from_schema_excluding_binary
+    expected = {
+      "id" => :integer,
+      "title" => :string,
+      "done" => :boolean,
+      "created_at" => :datetime,
+    }
+    assert_equal(expected, DslPost.local_columns)
+  end
+
+  def test_local_columns_without_schema_fails_loud
+    assert_raise(Funicular::DB::UnavailableError) { DslCategory.local_columns }
+  end
+
+  def test_local_columns_on_local_model_not_available_before_runner
+    assert_raise(Funicular::DB::UnavailableError) { DslDraft.local_columns }
+  end
+
+  def test_local_columns_on_ephemeral_raises_no_table_error
+    assert_raise(Funicular::DB::NoTableError) { DslSession.local_columns }
+  end
+
+  def test_build_from_local
+    record = DslPost.build_from_local({ "title" => "hello", "done" => false })
+    assert_equal("hello", record.title)
+    assert_equal(false, record.done)
+  end
+end

--- a/test/model_dsl_test.rb
+++ b/test/model_dsl_test.rb
@@ -200,6 +200,50 @@ class ModelDslTest < Picotest::Test
     end
   end
 
+  def test_refresh_is_a_replica_only_axis
+    # Nothing to refresh FROM on a local table, and no table at all on
+    # an ephemeral model: the declaration is meaningless, so it fails
+    # at class-definition time rather than quietly succeeding.
+    assert_raise(ArgumentError) do
+      Class.new(Funicular::Model) do
+        storage(:local) { migrate(1) { |t| t.string :title } }
+        refresh :manual
+      end
+    end
+    assert_raise(ArgumentError) do
+      Class.new(Funicular::Model) do
+        storage :ephemeral
+        refresh :manual
+      end
+    end
+  end
+
+  def test_refresh_before_storage_is_caught_too
+    # The reverse declaration order reaches the same verdict: whichever
+    # of the two comes second raises.
+    assert_raise(ArgumentError) do
+      Class.new(Funicular::Model) do
+        refresh :manual
+        storage(:local) { migrate(1) { |t| t.string :title } }
+      end
+    end
+    assert_raise(ArgumentError) do
+      Class.new(Funicular::Model) do
+        refresh :manual
+        storage :ephemeral
+      end
+    end
+  end
+
+  def test_refresh_and_storage_replica_coexist
+    klass = Class.new(Funicular::Model) do
+      refresh :manual
+      storage :replica
+    end
+    assert_equal(:manual, klass.refresh_mode)
+    assert_equal(:replica, klass.storage_kind)
+  end
+
   # ---- table_name ----
 
   def test_table_name_naive_pluralization

--- a/test/model_dsl_test.rb
+++ b/test/model_dsl_test.rb
@@ -259,8 +259,9 @@ class ModelDslTest < Picotest::Test
     assert_raise(Funicular::DB::UnavailableError) { DslCategory.local_columns }
   end
 
-  def test_local_columns_on_local_model_not_available_before_runner
-    assert_raise(Funicular::DB::UnavailableError) { DslDraft.local_columns }
+  def test_local_columns_on_local_model_fold_the_migrate_blocks
+    expected = { "id" => :integer, "title" => :string, "done" => :boolean }
+    assert_equal(expected, DslDraft.local_columns)
   end
 
   def test_local_columns_on_ephemeral_raises_no_table_error

--- a/test/model_test.rb
+++ b/test/model_test.rb
@@ -93,6 +93,18 @@ class ModelCallbackTest < Picotest::Test
     assert_nil(error)
   end
 
+  def test_all_forwards_params_as_query_string
+    $http_response = ok_response([])
+    CallbackPost.all(page: 2, q: "hello world") { |r, e| }
+    assert_equal([["GET", "/posts?page=2&q=hello+world", nil]], $http_calls)
+  end
+
+  def test_all_without_params_has_no_query_string
+    $http_response = ok_response([])
+    CallbackPost.all { |r, e| }
+    assert_equal([["GET", "/posts", nil]], $http_calls)
+  end
+
   def test_all_failure_yields_nil_result
     $http_response = error_response("boom")
     result = :untouched

--- a/test/model_test.rb
+++ b/test/model_test.rb
@@ -1,0 +1,228 @@
+# The unified REST callback contract (0.5.0, breaking vs <= 0.4):
+# every callback is (result, error). On success `result` is the payload
+# (all -> array, find/create -> instance, update -> the applied instance,
+# destroy -> true) and `error` is nil; on failure `result` is nil.
+#
+# Funicular::HTTP is stubbed at the module level below. Each Picotest file
+# runs in its own VM process, so the override cannot leak into other tests.
+module Funicular
+  module HTTP
+    class << self
+      def get(url, &block)
+        $http_calls << ["GET", url, nil]
+        block.call($http_response) if block
+      end
+
+      def post(url, body = nil, &block)
+        $http_calls << ["POST", url, body]
+        block.call($http_response) if block
+      end
+
+      def patch(url, body = nil, &block)
+        $http_calls << ["PATCH", url, body]
+        block.call($http_response) if block
+      end
+
+      def delete(url, &block)
+        $http_calls << ["DELETE", url, nil]
+        block.call($http_response) if block
+      end
+    end
+  end
+end
+
+class ModelCallbackTest < Picotest::Test
+  SCHEMA = {
+    "attributes" => {
+      "id" => { "readonly" => true, "type" => "integer" },
+      "title" => { "type" => "string", "validations" => { "presence" => true } },
+      "done" => { "type" => "boolean" },
+    },
+    "endpoints" => {
+      "all" => { "path" => "/posts" },
+      "find" => { "path" => "/posts/:id" },
+      "create" => { "path" => "/posts" },
+      "update" => { "path" => "/posts/:id" },
+      "destroy" => { "path" => "/posts/:id" },
+    },
+  }
+
+  def setup
+    unless Object.const_defined?(:CallbackPost)
+      Object.const_set(:CallbackPost, Class.new(Funicular::Model))
+      CallbackPost.load_schema(SCHEMA)
+    end
+    $http_calls = []
+    $http_response = nil
+  end
+
+  def ok_response(data)
+    Funicular::HTTP::Response.new(200, data)
+  end
+
+  def error_response(message)
+    Funicular::HTTP::Response.new(500, { "error" => message })
+  end
+
+  # ---- initialize ----
+
+  def test_initialize_keeps_string_keyed_false
+    post = CallbackPost.new({ "title" => "t", "done" => false })
+    assert_equal(false, post.done)
+  end
+
+  def test_initialize_symbol_keys_still_work
+    post = CallbackPost.new({ title: "sym", done: false })
+    assert_equal("sym", post.title)
+    assert_equal(false, post.done)
+  end
+
+  # ---- all ----
+
+  def test_all_success_yields_instances_and_nil_error
+    $http_response = ok_response([{ "id" => 1, "title" => "a", "done" => false }])
+    result = nil
+    error = :untouched
+    CallbackPost.all do |r, e|
+      result = r
+      error = e
+    end
+    assert_equal(1, result.size)
+    assert_equal("a", result[0].title)
+    assert_equal(false, result[0].done)
+    assert_nil(error)
+  end
+
+  def test_all_failure_yields_nil_result
+    $http_response = error_response("boom")
+    result = :untouched
+    error = nil
+    CallbackPost.all do |r, e|
+      result = r
+      error = e
+    end
+    assert_nil(result)
+    assert_equal("boom", error)
+  end
+
+  # ---- find ----
+
+  def test_find_success_yields_instance
+    $http_response = ok_response({ "id" => 7, "title" => "found" })
+    result = nil
+    CallbackPost.find(7) { |r, e| result = r }
+    assert_equal(7, result.id)
+    assert_equal([["GET", "/posts/7", nil]], $http_calls)
+  end
+
+  # ---- create ----
+
+  def test_create_success_yields_instance
+    $http_response = ok_response({ "id" => 2, "title" => "made" })
+    result = nil
+    error = :untouched
+    CallbackPost.create({ "title" => "made" }) do |r, e|
+      result = r
+      error = e
+    end
+    assert_equal(2, result.id)
+    assert_nil(error)
+  end
+
+  def test_create_validation_failure_yields_nil_result_and_no_request
+    result = :untouched
+    error = nil
+    CallbackPost.create({ "title" => "" }) do |r, e|
+      result = r
+      error = e
+    end
+    assert_nil(result)
+    assert_not_nil(error)
+    assert_equal([], $http_calls)
+  end
+
+  # ---- destroy ----
+
+  def test_class_destroy_success_yields_true_and_nil_error
+    $http_response = ok_response(nil)
+    result = nil
+    error = :untouched
+    CallbackPost.destroy(3) do |r, e|
+      result = r
+      error = e
+    end
+    assert_equal(true, result)
+    assert_nil(error)
+    assert_equal([["DELETE", "/posts/3", nil]], $http_calls)
+  end
+
+  def test_class_destroy_failure_yields_nil_result
+    $http_response = error_response("nope")
+    result = :untouched
+    error = nil
+    CallbackPost.destroy(3) do |r, e|
+      result = r
+      error = e
+    end
+    assert_nil(result)
+    assert_equal("nope", error)
+  end
+
+  # ---- update ----
+
+  def test_update_success_yields_applied_instance
+    post = CallbackPost.new({ "id" => 1, "title" => "before" })
+    $http_response = ok_response({ "id" => 1, "title" => "after (server)" })
+    result = nil
+    error = :untouched
+    post.update({ "title" => "after" }) do |r, e|
+      result = r
+      error = e
+    end
+    # The yielded result IS the receiver, with the server's authoritative
+    # row already applied.
+    assert_equal(post.__id__, result.__id__)
+    assert_equal("after (server)", post.title)
+    assert_nil(error)
+    assert_equal([["PATCH", "/posts/1", { "title" => "after" }]], $http_calls)
+  end
+
+  def test_update_with_no_changes_is_a_successful_no_op
+    post = CallbackPost.new({ "id" => 1, "title" => "same" })
+    result = nil
+    error = :untouched
+    post.update do |r, e|
+      result = r
+      error = e
+    end
+    assert_equal(post.__id__, result.__id__)
+    assert_nil(error)
+    assert_equal([], $http_calls)
+  end
+
+  def test_update_validation_failure_yields_nil_result
+    post = CallbackPost.new({ "id" => 1, "title" => "ok" })
+    result = :untouched
+    error = nil
+    post.update({ "title" => "" }) do |r, e|
+      result = r
+      error = e
+    end
+    assert_nil(result)
+    assert_not_nil(error)
+    assert_equal([], $http_calls)
+  end
+
+  def test_update_http_failure_yields_nil_result
+    post = CallbackPost.new({ "id" => 1, "title" => "ok" })
+    $http_response = error_response("denied")
+    result = :untouched
+    error = nil
+    post.update({ "title" => "changed" }) do |r, e|
+      result = r
+      error = e
+    end
+    assert_nil(result)
+    assert_equal("denied", error)
+  end
+end

--- a/test/namespace_test.rb
+++ b/test/namespace_test.rb
@@ -57,21 +57,21 @@ class NamespaceTest < Picotest::Test
     assert_raise(Funicular::DB::ConfigError) do
       db.resolve_namespace(application_id: "a", user_key: "u",
                            user_key_configured: true,
-                           anonymous_only: true, local_models: false)
+                           anonymous_only: true)
     end
     # Detected even while the configured lambda currently resolves nil.
     assert_raise(Funicular::DB::ConfigError) do
       db.resolve_namespace(application_id: "a", user_key: nil,
                            user_key_configured: true,
-                           anonymous_only: true, local_models: false)
+                           anonymous_only: true)
     end
   end
 
-  def test_local_models_require_a_configured_user_key
+  def test_every_enabled_database_requires_an_identity_declaration
     assert_raise(Funicular::DB::ConfigError) do
       db.resolve_namespace(application_id: "a", user_key: nil,
                            user_key_configured: false,
-                           anonymous_only: false, local_models: true)
+                           anonymous_only: false)
     end
   end
 
@@ -80,7 +80,7 @@ class NamespaceTest < Picotest::Test
     assert_equal("[\"v1\",\"a\",\"anonymous\"]",
       db.resolve_namespace(application_id: "a", user_key: nil,
                            user_key_configured: true,
-                           anonymous_only: false, local_models: true))
+                           anonymous_only: false))
   end
 
   def test_empty_resolved_user_key_is_a_config_error
@@ -89,7 +89,7 @@ class NamespaceTest < Picotest::Test
     assert_raise(Funicular::DB::ConfigError) do
       db.resolve_namespace(application_id: "a", user_key: "",
                            user_key_configured: true,
-                           anonymous_only: false, local_models: true)
+                           anonymous_only: false)
     end
   end
 
@@ -97,21 +97,22 @@ class NamespaceTest < Picotest::Test
     assert_equal("[\"v1\",\"a\",\"anonymous\"]",
       db.resolve_namespace(application_id: "a", user_key: nil,
                            user_key_configured: false,
-                           anonymous_only: true, local_models: true))
+                           anonymous_only: true))
   end
 
-  def test_replica_only_apps_default_to_anonymous
-    assert_equal("[\"v1\",\"a\",\"anonymous\"]",
+  def test_replica_only_apps_do_not_default_to_anonymous
+    assert_raise(Funicular::DB::ConfigError) do
       db.resolve_namespace(application_id: "a", user_key: nil,
                            user_key_configured: false,
-                           anonymous_only: false, local_models: false))
+                           anonymous_only: false)
+    end
   end
 
   def test_user_key_resolves_to_the_user_identity
     assert_equal("[\"v1\",\"a\",\"user\",\"u\"]",
       db.resolve_namespace(application_id: "a", user_key: "u",
                            user_key_configured: true,
-                           anonymous_only: false, local_models: true))
+                           anonymous_only: false))
   end
 
   # ---- derived names ----

--- a/test/namespace_test.rb
+++ b/test/namespace_test.rb
@@ -1,0 +1,138 @@
+# Tests for the namespace identity (docs decisions 12/13): the typed,
+# versioned tuple every durable name hangs off, and the declaration
+# rules resolved authoritatively on the client.
+
+class NamespaceTest < Picotest::Test
+  def db
+    Funicular::DB
+  end
+
+  # ---- identity structure ----
+
+  def test_anonymous_differs_from_a_user_literally_named_anonymous
+    anon = db.namespace_identity("app1", nil, true)
+    tricky = db.namespace_identity("app1", "anonymous", false)
+    assert_equal(false, anon == tricky)
+  end
+
+  def test_identity_is_canonical_and_stable
+    assert_equal("[\"v1\",\"app1\",\"user\",\"u1\"]",
+                 db.namespace_identity("app1", "u1", false))
+    assert_equal("[\"v1\",\"app1\",\"anonymous\"]",
+                 db.namespace_identity("app1", nil, true))
+    assert_equal(db.namespace_identity("app1", "u1", false),
+                 db.namespace_identity("app1", "u1", false))
+  end
+
+  def test_structure_beats_delimiter_tricks
+    # A naive "app:user" concatenation would collide these two.
+    assert_equal(false,
+      db.namespace_identity("a:b", "c", false) ==
+        db.namespace_identity("a", "b:c", false))
+  end
+
+  def test_identities_differ_between_users_and_apps
+    base = db.namespace_identity("a", "u1", false)
+    assert_equal(false, base == db.namespace_identity("a", "u2", false))
+    assert_equal(false, base == db.namespace_identity("b", "u1", false))
+  end
+
+  def test_empty_values_fail_loud
+    assert_raise(Funicular::DB::ConfigError) do
+      db.namespace_identity("", "u", false)
+    end
+    assert_raise(Funicular::DB::ConfigError) do
+      db.namespace_identity("app", "", false)
+    end
+    assert_raise(Funicular::DB::ConfigError) do
+      db.namespace_identity("app", nil, false)
+    end
+  end
+
+  # ---- declaration rules ----
+  # Configuration errors key off user_key_configured (is a SOURCE
+  # declared?); the anonymous/user choice keys off the resolved value.
+
+  def test_user_key_and_anonymous_only_are_mutually_exclusive
+    assert_raise(Funicular::DB::ConfigError) do
+      db.resolve_namespace(application_id: "a", user_key: "u",
+                           user_key_configured: true,
+                           anonymous_only: true, local_models: false)
+    end
+    # Detected even while the configured lambda currently resolves nil.
+    assert_raise(Funicular::DB::ConfigError) do
+      db.resolve_namespace(application_id: "a", user_key: nil,
+                           user_key_configured: true,
+                           anonymous_only: true, local_models: false)
+    end
+  end
+
+  def test_local_models_require_a_configured_user_key
+    assert_raise(Funicular::DB::ConfigError) do
+      db.resolve_namespace(application_id: "a", user_key: nil,
+                           user_key_configured: false,
+                           anonymous_only: false, local_models: true)
+    end
+  end
+
+  def test_signed_out_visit_boots_into_the_anonymous_namespace
+    # user_key IS configured; it just resolves to nil right now.
+    assert_equal("[\"v1\",\"a\",\"anonymous\"]",
+      db.resolve_namespace(application_id: "a", user_key: nil,
+                           user_key_configured: true,
+                           anonymous_only: false, local_models: true))
+  end
+
+  def test_empty_resolved_user_key_is_a_config_error
+    # Only nil means signed out: an empty string is a broken user_key
+    # source, and folding it into anonymous would mix users' data.
+    assert_raise(Funicular::DB::ConfigError) do
+      db.resolve_namespace(application_id: "a", user_key: "",
+                           user_key_configured: true,
+                           anonymous_only: false, local_models: true)
+    end
+  end
+
+  def test_anonymous_only_is_the_explicit_opt_out
+    assert_equal("[\"v1\",\"a\",\"anonymous\"]",
+      db.resolve_namespace(application_id: "a", user_key: nil,
+                           user_key_configured: false,
+                           anonymous_only: true, local_models: true))
+  end
+
+  def test_replica_only_apps_default_to_anonymous
+    assert_equal("[\"v1\",\"a\",\"anonymous\"]",
+      db.resolve_namespace(application_id: "a", user_key: nil,
+                           user_key_configured: false,
+                           anonymous_only: false, local_models: false))
+  end
+
+  def test_user_key_resolves_to_the_user_identity
+    assert_equal("[\"v1\",\"a\",\"user\",\"u\"]",
+      db.resolve_namespace(application_id: "a", user_key: "u",
+                           user_key_configured: true,
+                           anonymous_only: false, local_models: true))
+  end
+
+  # ---- derived names ----
+
+  def test_derived_names_are_distinct_and_carry_the_identity
+    identity = db.namespace_identity("a", "u", false)
+    replica_key = db.snapshot_key(identity, :replica)
+    local_key = db.snapshot_key(identity, :local)
+    lock = db.lock_name(identity)
+    assert_equal(false, replica_key == local_key)
+    assert_equal(false, lock == replica_key)
+    assert_equal(true, replica_key.include?(identity))
+    assert_equal(true, local_key.include?(identity))
+    assert_equal(true, lock.include?(identity))
+    assert_raise(ArgumentError) { db.snapshot_key(identity, :other) }
+  end
+
+  def test_derived_names_differ_between_identities
+    a = db.namespace_identity("a", "u1", false)
+    b = db.namespace_identity("a", "u2", false)
+    assert_equal(false, db.snapshot_key(a, :local) == db.snapshot_key(b, :local))
+    assert_equal(false, db.lock_name(a) == db.lock_name(b))
+  end
+end

--- a/test/persistence_test.rb
+++ b/test/persistence_test.rb
@@ -44,6 +44,7 @@ class PersistenceTest < Picotest::Test
   end
 
   def setup
+    Funicular::DB.__set_local_database_enabled(true)
     $per_db = SQLite3::Database.new(":memory:")
     $per_db.execute(
       "CREATE TABLE items (id INTEGER PRIMARY KEY, name TEXT)")
@@ -64,6 +65,7 @@ class PersistenceTest < Picotest::Test
     Funicular::DB.__register_database(:local, nil, [])
     Funicular::DB.__register_database(:replica, nil, [])
     Funicular::DB.__reset_config
+    Funicular::DB.__set_local_database_enabled(false)
     JS.global.eval(
       "delete globalThis.__funicularStorageApi; " \
       "delete globalThis.document")

--- a/test/persistence_test.rb
+++ b/test/persistence_test.rb
@@ -1,0 +1,369 @@
+# Tests for the persistence core (docs decisions 11/16): the snapshot
+# round trip through a fake store, the debounced auto-persist riding the
+# post-commit event funnel, flush per durability state, failure
+# reporting, the availability -> volatile classification (real
+# IndexedDB.open under Node has no indexedDB global), and the
+# navigator.storage.persist shim. Boot wiring (which decides WHEN these
+# run) is a later change; here handles and identity are passed in.
+
+class PersistenceTest < Picotest::Test
+  class FakeStore
+    attr_reader :data, :put_count
+
+    def initialize
+      @data = {}
+      @put_count = 0
+    end
+
+    def [](key)
+      @data[key]
+    end
+
+    def []=(key, value)
+      @put_count += 1
+      @data[key] = value
+    end
+
+    def delete(key)
+      @data.delete(key)
+      nil
+    end
+  end
+
+  class PutBrokenError < StandardError; end
+  class GetBrokenError < StandardError; end
+
+  class BrokenStore
+    def [](key)
+      raise GetBrokenError, "get failed"
+    end
+
+    def []=(key, value)
+      raise PutBrokenError, "put failed"
+    end
+  end
+
+  def setup
+    $per_db = SQLite3::Database.new(":memory:")
+    $per_db.execute(
+      "CREATE TABLE items (id INTEGER PRIMARY KEY, name TEXT)")
+    $per_store = FakeStore.new
+    $per_identity = Funicular::DB.namespace_identity("app", nil, true)
+    Funicular::DB.__set_durability(:persistent_writer)
+    Funicular::DB.__set_snapshot_store($per_store)
+    Funicular::DB.__set_snapshot_identity($per_identity)
+    Funicular::DB.__register_database(:local, $per_db, [])
+    Funicular::DB.__register_database(:replica, nil, [])
+  end
+
+  def teardown
+    Funicular::DB.cancel_persist_timers
+    Funicular::DB.__set_durability(:unbooted)
+    Funicular::DB.__set_snapshot_store(nil)
+    Funicular::DB.__set_snapshot_identity(nil)
+    Funicular::DB.__register_database(:local, nil, [])
+    Funicular::DB.__register_database(:replica, nil, [])
+    Funicular::DB.__reset_config
+    JS.global.eval(
+      "delete globalThis.__funicularStorageApi; " \
+      "delete globalThis.document")
+    $per_db.close
+  end
+
+  def local_key
+    Funicular::DB.snapshot_key($per_identity, :local)
+  end
+
+  def pump(ms)
+    JS.global.eval("new Promise((r) => setTimeout(r, #{ms}))").await
+  end
+
+  def test_configure_runs_with_bareword_config
+    Funicular::DB.configure do
+      config.local_debounce_ms = 123
+      config.replica_debounce_ms = 4567
+    end
+    assert_equal(123, Funicular::DB.config.local_debounce_ms)
+    assert_equal(4567, Funicular::DB.config.replica_debounce_ms)
+  end
+
+  def test_snapshot_round_trip
+    $per_db.execute("INSERT INTO items (name) VALUES ('alpha')")
+    $per_db.execute("INSERT INTO items (name) VALUES ('beta')")
+    assert_equal(true, Funicular::DB.persist_snapshot(:local))
+    assert_equal(true, $per_store.data.has_key?(local_key))
+
+    fresh = SQLite3::Database.new(":memory:")
+    Funicular::DB.__register_database(:local, fresh, [])
+    assert_equal(true, Funicular::DB.restore_snapshot(:local))
+    rows = fresh.execute("SELECT name FROM items ORDER BY id")
+    assert_equal([["alpha"], ["beta"]], rows)
+    fresh.close
+  end
+
+  def test_persist_refuses_off_writer_states
+    Funicular::DB.__set_durability(:persistent_reader)
+    assert_equal(false, Funicular::DB.persist_snapshot(:local))
+    Funicular::DB.__set_durability(:volatile)
+    assert_equal(false, Funicular::DB.persist_snapshot(:local))
+    assert_equal(0, $per_store.put_count)
+  end
+
+  def test_restore_returns_false_without_snapshot
+    assert_equal(false, Funicular::DB.restore_snapshot(:local))
+  end
+
+  def test_restore_read_errors_propagate
+    # Docs decision 16: storage exists but could not be read -- the
+    # boot must fail loud on top of it, never continue empty.
+    Funicular::DB.__set_snapshot_store(BrokenStore.new)
+    assert_raise(GetBrokenError) do
+      Funicular::DB.restore_snapshot(:local)
+    end
+  end
+
+  def test_persist_failure_reports_and_returns_false
+    $per_hook_errors = []
+    Funicular::DB.configure do
+      config.on_persist_error = ->(e) { $per_hook_errors << e }
+    end
+    Funicular::DB.__set_snapshot_store(BrokenStore.new)
+    assert_equal(false, Funicular::DB.persist_snapshot(:local))
+    assert_equal(1, $per_hook_errors.size)
+    assert_equal(PutBrokenError, $per_hook_errors[0].class)
+  end
+
+  def test_flush_persists_now_and_cancels_the_debounce
+    Funicular::DB.configure do
+      config.local_debounce_ms = 30
+    end
+    Funicular::DB.notify_changed(:local, "items")
+    assert_equal(true, Funicular::DB.flush)
+    assert_equal(1, $per_store.put_count)
+    # The armed timer was cancelled: the quiet window passing must not
+    # snapshot a second time.
+    pump(60)
+    assert_equal(1, $per_store.put_count)
+  end
+
+  def test_flush_raises_on_a_reader
+    Funicular::DB.__set_durability(:persistent_reader)
+    assert_raise(Funicular::DB::ReadOnlyTabError) do
+      Funicular::DB.flush
+    end
+  end
+
+  def test_flush_is_a_noop_on_volatile
+    Funicular::DB.__set_durability(:volatile)
+    assert_equal(false, Funicular::DB.flush)
+    assert_equal(0, $per_store.put_count)
+  end
+
+  def test_debounce_persists_after_the_quiet_window
+    Funicular::DB.configure do
+      config.local_debounce_ms = 20
+    end
+    Funicular::DB.notify_changed(:local, "items")
+    assert_equal(0, $per_store.put_count)
+    pump(60)
+    assert_equal(1, $per_store.put_count)
+    assert_equal(true, $per_store.data.has_key?(local_key))
+  end
+
+  def test_debounce_rearms_per_write
+    Funicular::DB.configure do
+      config.local_debounce_ms = 60
+    end
+    Funicular::DB.notify_changed(:local, "items")
+    pump(40)
+    # Still inside the first window: this write pushes the timer back.
+    Funicular::DB.notify_changed(:local, "items")
+    pump(40)
+    # 80ms since the FIRST write, but only 40 since the second.
+    assert_equal(0, $per_store.put_count)
+    pump(60)
+    assert_equal(1, $per_store.put_count)
+  end
+
+  def test_persist_refuses_mid_transaction_and_rearms_at_commit
+    # serialize would copy UNCOMMITTED pages; a persist landing inside
+    # an open transaction (stale timer, visibilitychange, in-block
+    # flush) must defer to the settle instead.
+    Funicular::DB.configure do
+      config.local_debounce_ms = 20
+    end
+    guarded = Funicular::DB::GuardedDatabase.new($per_db, :local)
+    guarded.transaction do
+      $per_db.execute("INSERT INTO items (name) VALUES ('mid')")
+      assert_equal(false, Funicular::DB.persist_snapshot(:local))
+      assert_equal(0, $per_store.put_count)
+    end
+    pump(60)
+    assert_equal(1, $per_store.put_count)
+  end
+
+  def test_flush_inside_a_transaction_defers_the_local_snapshot
+    Funicular::DB.configure do
+      config.local_debounce_ms = 20
+    end
+    guarded = Funicular::DB::GuardedDatabase.new($per_db, :local)
+    guarded.transaction do
+      $per_db.execute("INSERT INTO items (name) VALUES ('committed')")
+      assert_equal(false, Funicular::DB.flush)
+      assert_equal(0, $per_store.put_count)
+    end
+    pump(60)
+    assert_equal(1, $per_store.put_count)
+  end
+
+  def test_rolled_back_rows_never_reach_a_snapshot
+    Funicular::DB.configure do
+      config.local_debounce_ms = 20
+    end
+    guarded = Funicular::DB::GuardedDatabase.new($per_db, :local)
+    begin
+      guarded.transaction do
+        $per_db.execute("INSERT INTO items (name) VALUES ('ghost')")
+        # The mid-transaction refusal parks the persist; the ROLLBACK
+        # settle re-arms it, and the snapshot must hold the committed
+        # (= empty) state.
+        assert_equal(false, Funicular::DB.persist_snapshot(:local))
+        raise "boom"
+      end
+    rescue => e
+      raise e unless e.message == "boom"
+    end
+    pump(60)
+    assert_equal(1, $per_store.put_count)
+    fresh = SQLite3::Database.new(":memory:")
+    Funicular::DB.__register_database(:local, fresh, [])
+    assert_equal(true, Funicular::DB.restore_snapshot(:local))
+    assert_equal([[0]], fresh.execute("SELECT COUNT(*) FROM items"))
+    fresh.close
+  end
+
+  def test_stale_timer_callback_leaves_the_replacement_alone
+    # A timer whose JS deadline passed before its clearTimeout has its
+    # callback QUEUED already; when it finally runs it must not touch
+    # the replacement timer's bookkeeping (or snapshot).
+    Funicular::DB.configure do
+      config.local_debounce_ms = 30
+    end
+    Funicular::DB.notify_changed(:local, "items")
+    stale = Funicular::DB.__persist_timer_token(:local)
+    # The re-arm bumps the token; `stale` now names the dead timer.
+    Funicular::DB.notify_changed(:local, "items")
+    Funicular::DB.__persist_timer_fired(:local, stale)
+    assert_equal(0, $per_store.put_count)
+    # The replacement stayed under management: flush cancels it, and
+    # nothing double-fires afterwards.
+    assert_equal(true, Funicular::DB.flush)
+    pump(70)
+    assert_equal(1, $per_store.put_count)
+  end
+
+  def test_cancel_invalidates_queued_timer_callbacks
+    Funicular::DB.configure do
+      config.local_debounce_ms = 30
+    end
+    Funicular::DB.notify_changed(:local, "items")
+    queued = Funicular::DB.__persist_timer_token(:local)
+    Funicular::DB.cancel_persist_timers
+    # The callback was (hypothetically) already queued when the cancel
+    # ran: replaying it must be a no-op.
+    Funicular::DB.__persist_timer_fired(:local, queued)
+    assert_equal(0, $per_store.put_count)
+  end
+
+  def test_transaction_schedules_at_commit_only
+    Funicular::DB.configure do
+      config.local_debounce_ms = 20
+    end
+    guarded = Funicular::DB::GuardedDatabase.new($per_db, :local)
+    guarded.transaction do
+      Funicular::DB.notify_changed(:local, "items")
+      pump(60)
+      # Deferred: the write is not committed, nothing may be armed.
+      assert_equal(0, $per_store.put_count)
+    end
+    pump(60)
+    assert_equal(1, $per_store.put_count)
+  end
+
+  def test_rollback_schedules_nothing
+    Funicular::DB.configure do
+      config.local_debounce_ms = 20
+    end
+    guarded = Funicular::DB::GuardedDatabase.new($per_db, :local)
+    begin
+      guarded.transaction do
+        Funicular::DB.notify_changed(:local, "items")
+        raise "boom"
+      end
+    rescue => e
+      raise e unless e.message == "boom"
+    end
+    pump(60)
+    assert_equal(0, $per_store.put_count)
+  end
+
+  def test_open_snapshot_store_unavailable_becomes_volatile
+    # Under Node there is no globalThis.indexedDB, and the store opens
+    # with fallback: false -- by-design absence classifies as volatile
+    # (docs decision 16), announced once through on_persist_error.
+    $per_hook_errors = []
+    Funicular::DB.configure do
+      config.on_persist_error = ->(e) { $per_hook_errors << e }
+    end
+    Funicular::DB.__set_snapshot_store(nil)
+    assert_equal(nil, Funicular::DB.open_snapshot_store)
+    assert_equal(:volatile, Funicular::DB.durability)
+    assert_equal(1, $per_hook_errors.size)
+    assert_equal(IndexedDB::NotSupportedError, $per_hook_errors[0].class)
+    # The failure is sticky: a second open neither retries nor
+    # announces again.
+    assert_equal(nil, Funicular::DB.open_snapshot_store)
+    assert_equal(1, $per_hook_errors.size)
+  end
+
+  def test_visibility_flush_persists_when_hidden
+    Funicular::DB.configure do
+      config.local_debounce_ms = 20
+    end
+    JS.global.eval(
+      "globalThis.document = { visibilityState: 'hidden' }")
+    Funicular::DB.notify_changed(:local, "items")
+    Funicular::DB.__visibility_flush
+    assert_equal(1, $per_store.put_count)
+    # The debounce timer was cancelled along the way.
+    pump(60)
+    assert_equal(1, $per_store.put_count)
+  end
+
+  def test_visibility_flush_ignores_a_visible_page
+    JS.global.eval(
+      "globalThis.document = { visibilityState: 'visible' }")
+    Funicular::DB.__visibility_flush
+    assert_equal(0, $per_store.put_count)
+  end
+
+  def test_request_persistent_storage_results
+    JS.global.eval(
+      "globalThis.__funicularStorageApi = " \
+      "{ persist: () => Promise.resolve(true) }")
+    assert_equal(:granted, Funicular::DB.request_persistent_storage)
+    JS.global.eval(
+      "globalThis.__funicularStorageApi = " \
+      "{ persist: () => Promise.resolve(false) }")
+    assert_equal(:denied, Funicular::DB.request_persistent_storage)
+    JS.global.eval("globalThis.__funicularStorageApi = null")
+    assert_equal(:unsupported, Funicular::DB.request_persistent_storage)
+  end
+
+  def test_request_persistent_storage_respects_the_opt_out
+    Funicular::DB.configure do
+      config.request_persistent_storage = false
+    end
+    assert_equal(:disabled, Funicular::DB.request_persistent_storage)
+  end
+end

--- a/test/persistence_test.rb
+++ b/test/persistence_test.rb
@@ -76,6 +76,10 @@ class PersistenceTest < Picotest::Test
     Funicular::DB.snapshot_key($per_identity, :local)
   end
 
+  def replica_key
+    Funicular::DB.snapshot_key($per_identity, :replica)
+  end
+
   def pump(ms)
     JS.global.eval("new Promise((r) => setTimeout(r, #{ms}))").await
   end
@@ -216,6 +220,34 @@ class PersistenceTest < Picotest::Test
     end
     pump(60)
     assert_equal(1, $per_store.put_count)
+  end
+
+  def test_flush_reports_false_when_one_role_did_not_persist
+    # Both databases registered, one of them deferred by an open
+    # transaction: the replica image still goes out, but flush must
+    # NOT report success -- a caller about to navigate away would
+    # otherwise believe the unpersisted local data was safe.
+    Funicular::DB.configure do
+      config.local_debounce_ms = 20
+    end
+    replica = SQLite3::Database.new(":memory:")
+    replica.execute("CREATE TABLE notes (id INTEGER PRIMARY KEY)")
+    Funicular::DB.__register_database(:replica, replica, [])
+    guarded = Funicular::DB::GuardedDatabase.new($per_db, :local)
+    guarded.transaction do
+      $per_db.execute("INSERT INTO items (name) VALUES ('deferred')")
+      assert_equal(false, Funicular::DB.flush)
+      # The replica went out all the same: flush never short-circuits.
+      assert_equal(1, $per_store.put_count)
+      assert_equal(true, $per_store.data.has_key?(replica_key))
+      assert_equal(false, $per_store.data.has_key?(local_key))
+    end
+    # The commit settle re-arms the deferred local snapshot.
+    pump(60)
+    assert_equal(true, $per_store.data.has_key?(local_key))
+    Funicular::DB.cancel_persist_timers
+    Funicular::DB.__register_database(:replica, nil, [])
+    replica.close
   end
 
   def test_rolled_back_rows_never_reach_a_snapshot

--- a/test/relation_test.rb
+++ b/test/relation_test.rb
@@ -101,8 +101,17 @@ class CodecTest < Picotest::Test
   def test_datetime_decode_malformed_raises
     assert_raise(ArgumentError) { codec.iso_to_time("garbage") }
     assert_raise(ArgumentError) { codec.iso_to_time("2020-13-01T00:00:00Z") }
+    assert_raise(ArgumentError) { codec.iso_to_time("2023-02-29T00:00:00Z") }
+    assert_raise(ArgumentError) { codec.iso_to_time("2024-04-31T00:00:00Z") }
+    assert_raise(ArgumentError) { codec.iso_to_time("2020-01-01T00:00:00+24:00") }
+    assert_raise(ArgumentError) { codec.iso_to_time("2020-01-01T00:00:00+09:60") }
     assert_raise(ArgumentError) { codec.iso_to_time("2020-01-01T00:00:00X") }
     assert_raise(ArgumentError) { codec.iso_to_time("2020-01-01T00:00:00Ztrailing") }
+  end
+
+  def test_datetime_decode_accepts_leap_day_and_offset_boundaries
+    assert_equal(codec.iso_to_time("2024-02-29T00:00:00Z").to_i,
+                 codec.iso_to_time("2024-02-29T23:59:00+23:59").to_i)
   end
 
   def test_other_types_pass_through

--- a/test/relation_test.rb
+++ b/test/relation_test.rb
@@ -13,11 +13,14 @@ class RelationStubRecord
 end
 
 class RelationStubModel
+  attr_reader :notified
+
   def initialize(db, table, columns, replica)
     @db = db
     @table = table
     @columns = columns
     @replica = replica
+    @notified = 0
   end
 
   def table_name
@@ -38,6 +41,10 @@ class RelationStubModel
 
   def build_from_local(attrs)
     RelationStubRecord.new(attrs)
+  end
+
+  def local_table_changed
+    @notified += 1
   end
 end
 
@@ -68,8 +75,14 @@ class CodecTest < Picotest::Test
     assert_equal("2023-11-14T22:13:20Z", codec.encode(:datetime, Time.at(1700000000)))
   end
 
-  def test_datetime_encode_passes_strings_through
+  def test_datetime_encode_normalizes_strings_to_utc
     assert_equal("2020-01-01T00:00:00Z", codec.encode(:datetime, "2020-01-01T00:00:00Z"))
+    assert_equal("2020-01-01T00:00:00Z", codec.encode(:datetime, "2020-01-01T09:00:00+09:00"))
+    assert_equal("2020-01-01T00:00:00Z", codec.encode(:datetime, "2020-01-01T00:00:00.500Z"))
+  end
+
+  def test_datetime_encode_rejects_malformed_strings
+    assert_raise(ArgumentError) { codec.encode(:datetime, "yesterday") }
   end
 
   def test_datetime_roundtrip
@@ -334,5 +347,34 @@ class RelationTest < Picotest::Test
     replica = Funicular::Relation.new(RelationStubModel.new(@db, "posts", COLUMNS, true))
     assert_raise(Funicular::DB::ReplicaWriteError) { replica.delete_all }
     assert_equal(5, rel.count)
+  end
+
+  # ---- change notification (local_table_changed) ----
+
+  def test_delete_all_notifies_the_model
+    rel.where(done: true).delete_all
+    assert_equal(1, @model.notified)
+  end
+
+  def test_delete_all_removing_nothing_does_not_notify
+    rel.where(id: 99).delete_all
+    assert_equal(0, @model.notified)
+  end
+
+  def test_failed_delete_all_does_not_notify
+    replica = RelationStubModel.new(@db, "posts", COLUMNS, true)
+    assert_raise(Funicular::DB::ReplicaWriteError) do
+      Funicular::Relation.new(replica).delete_all
+    end
+    assert_raise(ArgumentError) { rel.limit(1).delete_all }
+    assert_equal(0, replica.notified)
+    assert_equal(0, @model.notified)
+  end
+
+  def test_reads_do_not_notify
+    rel.to_a
+    rel.count
+    rel.exists?
+    assert_equal(0, @model.notified)
   end
 end

--- a/test/relation_test.rb
+++ b/test/relation_test.rb
@@ -1,0 +1,329 @@
+# Tests for the local-query foundation: the shared value codec and the
+# lazy Relation SQL builder, run against a real SQLite ":memory:" database.
+# The model protocol Relation consumes (table_name / local_columns /
+# local_db / replica? / build_from_local) is provided by a stub here; the
+# real Funicular::Model wiring has its own tests.
+
+class RelationStubRecord
+  attr_reader :attrs
+
+  def initialize(attrs)
+    @attrs = attrs
+  end
+end
+
+class RelationStubModel
+  def initialize(db, table, columns, replica)
+    @db = db
+    @table = table
+    @columns = columns
+    @replica = replica
+  end
+
+  def table_name
+    @table
+  end
+
+  def local_columns
+    @columns
+  end
+
+  def local_db
+    @db
+  end
+
+  def replica?
+    @replica
+  end
+
+  def build_from_local(attrs)
+    RelationStubRecord.new(attrs)
+  end
+end
+
+class CodecTest < Picotest::Test
+  def codec
+    Funicular::DB::Codec
+  end
+
+  def test_boolean_encode
+    assert_equal(1, codec.encode(:boolean, true))
+    assert_equal(0, codec.encode(:boolean, false))
+    assert_nil(codec.encode(:boolean, nil))
+    assert_equal(1, codec.encode(:boolean, 1))
+  end
+
+  def test_boolean_decode
+    assert_equal(true, codec.decode(:boolean, 1))
+    assert_equal(false, codec.decode(:boolean, 0))
+    assert_nil(codec.decode(:boolean, nil))
+    assert_equal(true, codec.decode(:boolean, true))
+  end
+
+  def test_datetime_encode_epoch_zero
+    assert_equal("1970-01-01T00:00:00Z", codec.encode(:datetime, Time.at(0)))
+  end
+
+  def test_datetime_encode_known_epoch
+    assert_equal("2023-11-14T22:13:20Z", codec.encode(:datetime, Time.at(1700000000)))
+  end
+
+  def test_datetime_encode_passes_strings_through
+    assert_equal("2020-01-01T00:00:00Z", codec.encode(:datetime, "2020-01-01T00:00:00Z"))
+  end
+
+  def test_datetime_roundtrip
+    t = Time.at(1700000000)
+    assert_equal(t.to_i, codec.decode(:datetime, codec.encode(:datetime, t)).to_i)
+  end
+
+  def test_datetime_decode_utc
+    assert_equal(1700000000, codec.decode(:datetime, "2023-11-14T22:13:20Z").to_i)
+  end
+
+  def test_datetime_decode_offset
+    with_offset = codec.decode(:datetime, "2020-01-01T09:00:00+09:00")
+    utc = codec.decode(:datetime, "2020-01-01T00:00:00Z")
+    assert_equal(utc.to_i, with_offset.to_i)
+  end
+
+  def test_datetime_decode_fraction_truncated
+    plain = codec.decode(:datetime, "2020-01-01T00:00:00Z")
+    frac = codec.decode(:datetime, "2020-01-01T00:00:00.123Z")
+    assert_equal(plain.to_i, frac.to_i)
+  end
+
+  def test_datetime_decode_space_separator_and_no_zone_is_utc
+    assert_equal(codec.decode(:datetime, "2020-01-01T00:00:00Z").to_i,
+                 codec.decode(:datetime, "2020-01-01 00:00:00").to_i)
+  end
+
+  def test_datetime_decode_malformed_raises
+    assert_raise(ArgumentError) { codec.iso_to_time("garbage") }
+    assert_raise(ArgumentError) { codec.iso_to_time("2020-13-01T00:00:00Z") }
+    assert_raise(ArgumentError) { codec.iso_to_time("2020-01-01T00:00:00X") }
+    assert_raise(ArgumentError) { codec.iso_to_time("2020-01-01T00:00:00Ztrailing") }
+  end
+
+  def test_other_types_pass_through
+    assert_equal(42, codec.encode(:integer, 42))
+    assert_equal("x", codec.decode(:string, "x"))
+  end
+
+  def test_encode_bind_is_value_based
+    assert_equal(1, codec.encode_bind(true))
+    assert_equal(0, codec.encode_bind(false))
+    assert_equal("1970-01-01T00:00:00Z", codec.encode_bind(Time.at(0)))
+    assert_equal(5, codec.encode_bind(5))
+    assert_equal("x", codec.encode_bind("x"))
+  end
+end
+
+class RelationTest < Picotest::Test
+  COLUMNS = {
+    "id" => :integer,
+    "title" => :string,
+    "done" => :boolean,
+    "score" => :float,
+    "created_at" => :datetime,
+  }
+
+  def setup
+    @db = SQLite3::Database.new(":memory:")
+    @db.execute("CREATE TABLE posts (id INTEGER PRIMARY KEY, title TEXT, " \
+                "done INTEGER, score REAL, created_at TEXT)")
+    @model = RelationStubModel.new(@db, "posts", COLUMNS, false)
+    seed = [
+      [1, "alpha", 0, 1.5, "2024-01-01T00:00:00Z"],
+      [2, "bravo", 1, 2.5, "2024-01-02T00:00:00Z"],
+      [3, "charlie", 0, 3.5, "2024-01-03T00:00:00Z"],
+      [4, "delta", 1, 4.5, "2024-01-04T00:00:00Z"],
+      [5, "echo", 0, nil, "2024-01-05T00:00:00Z"],
+    ]
+    i = 0
+    while i < seed.size
+      @db.execute("INSERT INTO posts VALUES (?, ?, ?, ?, ?)", seed[i])
+      i += 1
+    end
+  end
+
+  def teardown
+    @db.close
+  end
+
+  def rel
+    Funicular::Relation.new(@model)
+  end
+
+  def ids(records)
+    out = []
+    i = 0
+    while i < records.size
+      out << records[i].attrs["id"]
+      i += 1
+    end
+    out
+  end
+
+  # ---- laziness and chaining ----
+
+  def test_chain_builders_return_new_relations
+    base = rel
+    filtered = base.where(done: false)
+    assert_equal(5, base.count)
+    assert_equal(3, filtered.count)
+  end
+
+  def test_multiple_where_calls_and_together
+    assert_equal([3], ids(rel.where(done: false).where("score > ?", 2.0).to_a))
+  end
+
+  # ---- condition forms ----
+
+  def test_where_equality_with_boolean_encoding
+    assert_equal([2, 4], ids(rel.where(done: true).order(:id).to_a))
+  end
+
+  def test_where_array_becomes_in
+    assert_equal([1, 3], ids(rel.where(id: [1, 3]).order(:id).to_a))
+  end
+
+  def test_where_empty_array_is_always_empty
+    assert_equal(0, rel.where(id: []).count)
+    assert_equal([], rel.where(id: []).to_a)
+  end
+
+  def test_where_nil_becomes_is_null
+    assert_equal([5], ids(rel.where(score: nil).to_a))
+  end
+
+  def test_where_inclusive_range_is_between
+    assert_equal([2, 3, 4], ids(rel.where(id: 2..4).order(:id).to_a))
+  end
+
+  def test_where_exclusive_range_excludes_end
+    assert_equal([2, 3], ids(rel.where(id: 2...4).order(:id).to_a))
+  end
+
+  def test_where_range_of_times_uses_codec
+    from = Funicular::DB::Codec.iso_to_time("2024-01-02T00:00:00Z")
+    to = Funicular::DB::Codec.iso_to_time("2024-01-04T00:00:00Z")
+    assert_equal([2, 3], ids(rel.where(created_at: from...to).order(:id).to_a))
+  end
+
+  def test_where_raw_fragment_with_placeholders
+    assert_equal([4], ids(rel.where("score > ? AND done = ?", 3.0, true).to_a))
+  end
+
+  def test_where_unknown_column_raises
+    assert_raise(ArgumentError) { rel.where(nope: 1) }
+  end
+
+  def test_where_unsupported_argument_raises
+    assert_raise(ArgumentError) { rel.where(42) }
+  end
+
+  # ---- order / limit / offset ----
+
+  def test_order_symbol_is_ascending
+    assert_equal([1, 2, 3, 4, 5], ids(rel.order(:id).to_a))
+  end
+
+  def test_order_hash_desc
+    assert_equal([5, 4, 3, 2, 1], ids(rel.order(id: :desc).to_a))
+  end
+
+  def test_order_multiple_keys
+    assert_equal([2, 4, 1, 3, 5], ids(rel.order(done: :desc, id: :asc).to_a))
+    assert_equal([1, 3, 5, 2, 4], ids(rel.order(:done).order(:id).to_a))
+  end
+
+  def test_order_unknown_column_raises
+    assert_raise(ArgumentError) { rel.order(:nope) }
+  end
+
+  def test_order_bad_direction_raises
+    assert_raise(ArgumentError) { rel.order(id: :sideways) }
+  end
+
+  def test_limit_and_offset
+    assert_equal([3, 4], ids(rel.order(:id).limit(2).offset(2).to_a))
+  end
+
+  def test_offset_without_limit
+    assert_equal([3, 4, 5], ids(rel.order(:id).offset(2).to_a))
+  end
+
+  def test_limit_rejects_bad_arguments
+    assert_raise(ArgumentError) { rel.limit(-1) }
+    assert_raise(ArgumentError) { rel.offset("2") }
+  end
+
+  # ---- materializers ----
+
+  def test_to_a_decodes_types
+    record = rel.where(id: [2]).to_a[0]
+    assert_equal(true, record.attrs["done"])
+    created = record.attrs["created_at"]
+    assert_equal(true, created.is_a?(Time))
+    assert_equal(Funicular::DB::Codec.iso_to_time("2024-01-02T00:00:00Z").to_i, created.to_i)
+  end
+
+  def test_each_yields_and_returns_records
+    seen = []
+    returned = rel.order(:id).limit(2).each { |r| seen << r.attrs["id"] }
+    assert_equal([1, 2], seen)
+    assert_equal(2, returned.size)
+  end
+
+  def test_first_respects_order_and_returns_nil_when_empty
+    assert_equal(5, rel.order(id: :desc).first.attrs["id"])
+    assert_nil(rel.where(id: []).first)
+  end
+
+  def test_count_plain_and_windowed
+    assert_equal(5, rel.count)
+    assert_equal(2, rel.limit(2).count)
+    assert_equal(1, rel.order(:id).offset(4).count)
+  end
+
+  def test_exists
+    assert_equal(true, rel.where(done: true).exists?)
+    assert_equal(false, rel.where(id: []).exists?)
+    assert_equal(false, rel.offset(5).exists?)
+  end
+
+  def test_find_returns_record_or_raises
+    assert_equal("bravo", rel.find(2).attrs["title"])
+    assert_raise(Funicular::RecordNotFound) { rel.find(99) }
+  end
+
+  def test_find_by_returns_nil_when_missing
+    assert_equal("bravo", rel.find_by(title: "bravo").attrs["title"])
+    assert_nil(rel.find_by(id: 99))
+  end
+
+  # ---- delete_all ----
+
+  def test_delete_all_with_condition
+    assert_equal(2, rel.where(done: true).delete_all)
+    assert_equal([1, 3, 5], ids(rel.order(:id).to_a))
+  end
+
+  def test_delete_all_whole_table
+    assert_equal(5, rel.delete_all)
+    assert_equal(0, rel.count)
+  end
+
+  def test_delete_all_rejects_order_limit_offset
+    assert_raise(ArgumentError) { rel.order(:id).delete_all }
+    assert_raise(ArgumentError) { rel.limit(1).delete_all }
+    assert_raise(ArgumentError) { rel.offset(1).delete_all }
+  end
+
+  def test_delete_all_on_replica_raises
+    replica = Funicular::Relation.new(RelationStubModel.new(@db, "posts", COLUMNS, true))
+    assert_raise(Funicular::DB::ReplicaWriteError) { replica.delete_all }
+    assert_equal(5, rel.count)
+  end
+end

--- a/test/replica_schema_test.rb
+++ b/test/replica_schema_test.rb
@@ -1,0 +1,235 @@
+# Tests for the replica-table plumbing: schema-derived DDL, the
+# canonical-JSON fingerprint, and the upsert/delete write-through entry
+# points, against a real ":memory:" database. Boot wiring (which decides
+# WHEN these run) is a later change; here the handle is passed in.
+
+class ReplicaSchemaTest < Picotest::Test
+  POST_SCHEMA = {
+    "attributes" => {
+      "id" => { "readonly" => true, "type" => "integer" },
+      "title" => { "type" => "string" },
+      "done" => { "type" => "boolean" },
+      "created_at" => { "type" => "datetime" },
+      "avatar" => { "type" => "binary" },
+    },
+    "endpoints" => {},
+  }
+
+  NOTE_SCHEMA = {
+    "attributes" => {
+      "id" => { "type" => "string" },
+      "body" => { "type" => "text" },
+    },
+    "endpoints" => {},
+  }
+
+  NO_ID_SCHEMA = {
+    "attributes" => {
+      "label" => { "type" => "string" },
+    },
+    "endpoints" => {},
+  }
+
+  def setup
+    $rep_db = SQLite3::Database.new(":memory:")
+    $rep_notified = 0
+    define_models
+  end
+
+  def teardown
+    $rep_db.close
+  end
+
+  def define_models
+    return if Object.const_defined?(:RepPost)
+
+    Object.const_set(:RepPost, Class.new(Funicular::Model))
+    RepPost.class_eval do
+      table_name "rep_posts"
+
+      def self.local_table_changed
+        $rep_notified += 1
+      end
+    end
+    RepPost.load_schema(POST_SCHEMA)
+
+    Object.const_set(:RepNote, Class.new(Funicular::Model))
+    RepNote.class_eval do
+      table_name "rep_notes"
+    end
+    RepNote.load_schema(NOTE_SCHEMA)
+
+    Object.const_set(:RepNoId, Class.new(Funicular::Model))
+    RepNoId.class_eval do
+      table_name "rep_no_ids"
+    end
+    RepNoId.load_schema(NO_ID_SCHEMA)
+  end
+
+  def table_columns(table)
+    # @type var names: Array[String]
+    names = []
+    rows = $rep_db.execute("PRAGMA table_info(\"#{table}\")")
+    i = 0
+    rows_size = rows.size
+    while i < rows_size
+      names << rows[i][1]
+      i += 1
+    end
+    names
+  end
+
+  # ---- DDL derivation ----
+
+  def test_ddl_follows_the_server_id_type_and_excludes_binary
+    ddl = Funicular::DB.replica_table_ddl(RepPost)
+    assert_equal(true, ddl.include?("\"id\" INTEGER PRIMARY KEY"))
+    assert_equal(false, ddl.include?("avatar"))
+    assert_equal(true,
+      Funicular::DB.replica_table_ddl(RepNote).include?("\"id\" TEXT PRIMARY KEY"))
+  end
+
+  def test_schema_without_id_raises_pointing_at_ephemeral
+    raised = false
+    begin
+      Funicular::DB.replica_table_ddl(RepNoId)
+    rescue ArgumentError => e
+      raised = true
+      assert_equal(true, e.message.include?("ephemeral"))
+    end
+    assert_equal(true, raised)
+  end
+
+  # ---- fingerprint ----
+
+  def test_first_build_creates_tables_and_stores_the_fingerprint
+    assert_equal(true, Funicular::DB.build_replica_tables($rep_db, [RepPost, RepNote]))
+    assert_equal(["id", "title", "done", "created_at"], table_columns("rep_posts"))
+    assert_equal(["id", "body"], table_columns("rep_notes"))
+  end
+
+  def test_matching_fingerprint_keeps_data
+    Funicular::DB.build_replica_tables($rep_db, [RepPost, RepNote])
+    $rep_db.execute("INSERT INTO rep_posts (id, title) VALUES (1, 'kept')")
+    assert_equal(false, Funicular::DB.build_replica_tables($rep_db, [RepPost, RepNote]))
+    assert_equal("kept", $rep_db.execute("SELECT title FROM rep_posts")[0][0])
+  end
+
+  def test_changed_schema_rebuilds_empty
+    Funicular::DB.build_replica_tables($rep_db, [RepPost, RepNote])
+    $rep_db.execute("INSERT INTO rep_posts (id, title) VALUES (1, 'doomed')")
+    grown = Class.new(Funicular::Model)
+    grown.class_eval do
+      table_name "rep_posts"
+    end
+    grown.load_schema({
+      "attributes" => {
+        "id" => { "type" => "integer" },
+        "title" => { "type" => "string" },
+        "done" => { "type" => "boolean" },
+        "created_at" => { "type" => "datetime" },
+        "rank" => { "type" => "integer" },
+      },
+      "endpoints" => {},
+    })
+    assert_equal(true, Funicular::DB.build_replica_tables($rep_db, [grown, RepNote]))
+    assert_equal(["id", "title", "done", "created_at", "rank"],
+                 table_columns("rep_posts"))
+    assert_equal(0, $rep_db.execute("SELECT COUNT(*) FROM rep_posts")[0][0])
+  end
+
+  def test_removed_models_lose_their_tables_on_rebuild
+    Funicular::DB.build_replica_tables($rep_db, [RepPost, RepNote])
+    $rep_db.execute("INSERT INTO rep_notes (id, body) VALUES ('u1', 'stale')")
+    assert_equal(true, Funicular::DB.build_replica_tables($rep_db, [RepPost]))
+    remaining = $rep_db.execute(
+      "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'rep_notes'")
+    assert_equal([], remaining)
+    assert_equal(0, $rep_db.execute("SELECT COUNT(*) FROM rep_posts")[0][0])
+  end
+
+  def test_duplicate_replica_table_names_fail_loud
+    twin = Class.new(Funicular::Model)
+    twin.class_eval do
+      table_name "rep_posts"
+    end
+    twin.load_schema(NOTE_SCHEMA)
+    assert_raise(ArgumentError) do
+      Funicular::DB.build_replica_tables($rep_db, [RepPost, twin])
+    end
+    # Case-insensitively too: "Rep_Posts" IS "rep_posts" to SQLite.
+    cased = Class.new(Funicular::Model)
+    cased.class_eval do
+      table_name "Rep_Posts"
+    end
+    cased.load_schema(NOTE_SCHEMA)
+    assert_raise(ArgumentError) do
+      Funicular::DB.build_replica_tables($rep_db, [RepPost, cased])
+    end
+  end
+
+  def test_funicular_meta_is_protected
+    meta_model = Class.new(Funicular::Model)
+    meta_model.class_eval do
+      table_name "Funicular_Meta"
+    end
+    meta_model.load_schema(NOTE_SCHEMA)
+    assert_raise(ArgumentError) do
+      Funicular::DB.build_replica_tables($rep_db, [meta_model])
+    end
+    # A stale fingerprint claiming funicular_meta must not drop it: the
+    # per-table migration versions live there.
+    Funicular::DB.store_meta($rep_db, "replica_fingerprint",
+      JSON.generate(["v1", [["funicular_meta", [["id", "string"]]]]]))
+    Funicular::DB.store_meta($rep_db, "table_version:mig_x", "3")
+    assert_equal(true, Funicular::DB.build_replica_tables($rep_db, [RepPost]))
+    assert_equal("3", Funicular::DB.read_meta($rep_db, "table_version:mig_x"))
+  end
+
+  def test_fingerprint_ignores_model_order
+    assert_equal(Funicular::DB.canonical_replica_schema([RepPost, RepNote]),
+                 Funicular::DB.canonical_replica_schema([RepNote, RepPost]))
+  end
+
+  # ---- upsert / delete ----
+
+  def test_upsert_inserts_then_replaces_through_the_codec
+    Funicular::DB.build_replica_tables($rep_db, [RepPost, RepNote])
+    Funicular::DB.replica_upsert($rep_db, RepPost,
+      { "id" => 1, "title" => "a", "done" => true,
+        "created_at" => "2024-01-02T09:00:00+09:00" })
+    row = $rep_db.execute(
+      "SELECT title, done, created_at FROM rep_posts WHERE id = 1")[0]
+    assert_equal(["a", 1, "2024-01-02T00:00:00Z"], row)
+    Funicular::DB.replica_upsert($rep_db, RepPost,
+      { "id" => 1, "title" => "b", "done" => false })
+    assert_equal(1, $rep_db.execute("SELECT COUNT(*) FROM rep_posts")[0][0])
+    assert_equal("b", $rep_db.execute("SELECT title FROM rep_posts")[0][0])
+    assert_equal(2, $rep_notified)
+  end
+
+  def test_upsert_stores_null_for_absent_keys
+    Funicular::DB.build_replica_tables($rep_db, [RepPost, RepNote])
+    Funicular::DB.replica_upsert($rep_db, RepPost, { "id" => 5, "title" => "t" })
+    assert_nil($rep_db.execute("SELECT done FROM rep_posts WHERE id = 5")[0][0])
+  end
+
+  def test_upsert_without_id_raises_and_does_not_notify
+    Funicular::DB.build_replica_tables($rep_db, [RepPost, RepNote])
+    notified_before = $rep_notified
+    assert_raise(ArgumentError) do
+      Funicular::DB.replica_upsert($rep_db, RepPost, { "title" => "lost" })
+    end
+    assert_equal(notified_before, $rep_notified)
+  end
+
+  def test_delete_notifies_only_when_the_row_existed
+    Funicular::DB.build_replica_tables($rep_db, [RepPost, RepNote])
+    Funicular::DB.replica_upsert($rep_db, RepPost, { "id" => 1, "title" => "x" })
+    notified_before = $rep_notified
+    assert_equal(true, Funicular::DB.replica_delete($rep_db, RepPost, 1))
+    assert_equal(notified_before + 1, $rep_notified)
+    assert_equal(false, Funicular::DB.replica_delete($rep_db, RepPost, 1))
+    assert_equal(notified_before + 1, $rep_notified)
+  end
+end

--- a/test/rest_write_through_test.rb
+++ b/test/rest_write_through_test.rb
@@ -207,7 +207,8 @@ class RestWriteThroughTest < Picotest::Test
     assert_equal(0, $wt_db.execute("SELECT COUNT(*) FROM wt_posts")[0][0])
   end
 
-  def test_without_a_replica_db_rest_still_works
+  def test_disabled_local_database_keeps_rest_working_without_write_through
+    assert_equal(false, Funicular::DB.local_database_enabled?)
     $wt_response = ok({ "id" => 1, "title" => "a" })
     got = nil
     WtBare.find(1) { |post, e| got = post }

--- a/test/rest_write_through_test.rb
+++ b/test/rest_write_through_test.rb
@@ -1,0 +1,223 @@
+# Tests for the REST wiring of decisions 5/6: responses decode through
+# the shared codec, and successful REST calls mirror rows into the
+# replica through the single apply entry point BEFORE user callbacks
+# run. HTTP is stubbed at the module level (each Picotest file runs in
+# its own VM); the replica handle is injected by overriding
+# Model.replica_db, the same seam DB.boot will use.
+
+module Funicular
+  module HTTP
+    class << self
+      def get(url, &block)
+        $wt_calls << ["GET", url]
+        block.call($wt_response) if block
+      end
+
+      def post(url, body = nil, &block)
+        $wt_calls << ["POST", url]
+        block.call($wt_response) if block
+      end
+
+      def patch(url, body = nil, &block)
+        $wt_calls << ["PATCH", url]
+        block.call($wt_response) if block
+      end
+
+      def delete(url, &block)
+        $wt_calls << ["DELETE", url]
+        block.call($wt_response) if block
+      end
+    end
+  end
+end
+
+class RestWriteThroughTest < Picotest::Test
+  SCHEMA = {
+    "attributes" => {
+      "id" => { "readonly" => true, "type" => "integer" },
+      "title" => { "type" => "string" },
+      "done" => { "type" => "boolean" },
+      "created_at" => { "type" => "datetime" },
+    },
+    "endpoints" => {
+      "all" => { "path" => "/wt_posts" },
+      "find" => { "path" => "/wt_posts/:id" },
+      "create" => { "path" => "/wt_posts" },
+      "update" => { "path" => "/wt_posts/:id" },
+      "destroy" => { "path" => "/wt_posts/:id" },
+    },
+  }
+
+  def setup
+    $wt_db = SQLite3::Database.new(":memory:")
+    $wt_calls = []
+    $wt_response = nil
+    $wt_notified = 0
+    define_models
+    Funicular::DB.build_replica_tables($wt_db, [WtPost])
+  end
+
+  def teardown
+    $wt_db.close
+  end
+
+  def define_models
+    return if Object.const_defined?(:WtPost)
+
+    Object.const_set(:WtPost, Class.new(Funicular::Model))
+    WtPost.class_eval do
+      table_name "wt_posts"
+
+      def self.replica_db
+        $wt_db
+      end
+
+      def self.local_table_changed
+        $wt_notified += 1
+      end
+    end
+    WtPost.load_schema(SCHEMA)
+
+    Object.const_set(:WtSession, Class.new(Funicular::Model))
+    WtSession.class_eval do
+      storage :ephemeral
+    end
+    WtSession.load_schema(SCHEMA)
+
+    # No replica_db override: the default nil keeps write-through inert.
+    Object.const_set(:WtBare, Class.new(Funicular::Model))
+    WtBare.class_eval do
+      table_name "wt_bare_posts"
+    end
+    WtBare.load_schema(SCHEMA)
+  end
+
+  def ok(data)
+    Funicular::HTTP::Response.new(200, data)
+  end
+
+  # ---- codec on REST init ----
+
+  def test_initialize_decodes_rest_types
+    post = WtPost.new({ "done" => 1, "created_at" => "2024-01-01T00:00:00Z" })
+    assert_equal(true, post.done)
+    assert_equal(true, post.created_at.is_a?(Time))
+    passthrough = WtPost.new({ "done" => false, "title" => "t" })
+    assert_equal(false, passthrough.done)
+    assert_equal("t", passthrough.title)
+  end
+
+  # ---- write-through ----
+
+  def test_all_upserts_rows_before_the_callback_and_decodes
+    $wt_response = ok([
+      { "id" => 1, "title" => "a", "done" => true,
+        "created_at" => "2024-01-02T09:00:00+09:00" },
+      { "id" => 2, "title" => "b", "done" => false,
+        "created_at" => "2024-01-03T00:00:00Z" },
+    ])
+    rows_inside = nil
+    got = nil
+    WtPost.all do |instances, error|
+      rows_inside = $wt_db.execute("SELECT COUNT(*) FROM wt_posts")[0][0]
+      got = instances
+    end
+    assert_equal(2, rows_inside)
+    assert_equal(true, got[0].done)
+    assert_equal(true, got[0].created_at.is_a?(Time))
+    row = $wt_db.execute(
+      "SELECT done, created_at FROM wt_posts WHERE id = 1")[0]
+    assert_equal([1, "2024-01-02T00:00:00Z"], row)
+  end
+
+  def test_all_applies_the_whole_collection_or_nothing
+    $wt_response = ok([
+      { "id" => 1, "title" => "good" },
+      { "id" => 2, "title" => "bad", "created_at" => "not-a-date" },
+    ])
+    called = false
+    raised = false
+    begin
+      WtPost.all { |instances, e| called = true }
+    rescue ArgumentError
+      raised = true
+    end
+    assert_equal(true, raised)
+    assert_equal(false, called)
+    # The first row rolled back with the second: no partial apply.
+    assert_equal(0, $wt_db.execute("SELECT COUNT(*) FROM wt_posts")[0][0])
+    assert_equal(0, $wt_notified)
+  end
+
+  def test_all_fires_one_change_event_per_batch
+    $wt_response = ok([
+      { "id" => 1, "title" => "a" },
+      { "id" => 2, "title" => "b" },
+      { "id" => 3, "title" => "c" },
+    ])
+    WtPost.all { |instances, e| }
+    assert_equal(1, $wt_notified)
+  end
+
+  def test_find_upserts_before_the_callback
+    $wt_response = ok({ "id" => 7, "title" => "found", "done" => false })
+    inside = nil
+    WtPost.find(7) do |post, error|
+      inside = $wt_db.execute("SELECT title FROM wt_posts WHERE id = 7")[0]
+    end
+    assert_equal(["found"], inside)
+  end
+
+  def test_create_upserts_the_server_row
+    $wt_response = ok({ "id" => 3, "title" => "server-normalized",
+                        "done" => false })
+    WtPost.create(title: "raw")
+    assert_equal("server-normalized",
+      $wt_db.execute("SELECT title FROM wt_posts WHERE id = 3")[0][0])
+  end
+
+  def test_update_upserts_and_applies_decoded_values
+    post = WtPost.new({ "id" => 9, "title" => "old" })
+    post.title = "sent"
+    $wt_response = ok({ "id" => 9, "title" => "SERVER", "done" => true,
+                        "created_at" => "2024-02-01T00:00:00Z" })
+    inside = nil
+    post.update do |updated, error|
+      inside = $wt_db.execute("SELECT title FROM wt_posts WHERE id = 9")[0][0]
+    end
+    assert_equal("SERVER", inside)
+    assert_equal("SERVER", post.title)
+    assert_equal(true, post.done)
+    assert_equal(true, post.created_at.is_a?(Time))
+  end
+
+  def test_destroy_deletes_the_replica_row
+    Funicular::DB.replica_upsert($wt_db, WtPost, { "id" => 4, "title" => "x" })
+    $wt_response = ok(nil)
+    inside = nil
+    WtPost.destroy(4) do |ok_flag, error|
+      inside = $wt_db.execute("SELECT COUNT(*) FROM wt_posts")[0][0]
+    end
+    assert_equal(0, inside)
+  end
+
+  def test_rest_error_writes_nothing
+    $wt_response = Funicular::HTTP::Response.new(422, { "errors" => ["nope"] })
+    WtPost.create(title: "x") { |r, e| }
+    assert_equal(0, $wt_db.execute("SELECT COUNT(*) FROM wt_posts")[0][0])
+  end
+
+  def test_without_a_replica_db_rest_still_works
+    $wt_response = ok({ "id" => 1, "title" => "a" })
+    got = nil
+    WtBare.find(1) { |post, e| got = post }
+    assert_equal("a", got.title)
+    assert_equal(0, $wt_notified)
+  end
+
+  def test_ephemeral_models_do_not_write_through
+    $wt_response = ok({ "id" => 1, "title" => "a" })
+    WtSession.find(1) { |s, e| }
+    assert_equal(0, $wt_db.execute("SELECT COUNT(*) FROM wt_posts")[0][0])
+  end
+end

--- a/test/watch_test.rb
+++ b/test/watch_test.rb
@@ -1,0 +1,275 @@
+# Tests for Component#watch (docs decision 10, "Reactivity"): initial
+# materialization into state, re-evaluation on change events,
+# re-subscription per evaluation (branchy blocks), the Relation-only
+# contract, and unsubscription on unmount -- lifecycle-hook exceptions
+# included. Components stay headless (never mounted), so set_state's
+# re_render is a no-op; a manual tick scheduler drives the bus.
+
+class WatchTest < Picotest::Test
+  def setup
+    $watch_db = SQLite3::Database.new(":memory:")
+    define_models
+    define_components
+    Funicular::DB.apply_local_migrations($watch_db, WatchTodo)
+    Funicular::DB.apply_local_migrations($watch_db, WatchNote)
+    $watch_ticks = 0
+    Funicular::DB.__set_tick_scheduler(proc { $watch_ticks += 1 })
+    @component = WatchComponent.new
+  end
+
+  def teardown
+    @component.cleanup_watches
+    Funicular::DB.__drain_events
+    Funicular::DB.__set_tick_scheduler(nil)
+    $watch_db.close
+  end
+
+  def define_models
+    return if Object.const_defined?(:WatchTodo)
+
+    Object.const_set(:WatchTodo, Class.new(Funicular::Model))
+    WatchTodo.class_eval do
+      storage :local do
+        migrate 1 do |t|
+          t.string :title
+          t.boolean :done, default: false, null: false
+        end
+      end
+
+      def self.local_db
+        $watch_db
+      end
+    end
+
+    Object.const_set(:WatchNote, Class.new(Funicular::Model))
+    WatchNote.class_eval do
+      storage :local do
+        migrate 1 do |t|
+          t.string :body
+        end
+      end
+
+      def self.local_db
+        $watch_db
+      end
+    end
+
+    # Declared but never migrated: materializing raises in SQLite.
+    Object.const_set(:WatchBroken, Class.new(Funicular::Model))
+    WatchBroken.class_eval do
+      table_name "watch_missing_table"
+      storage :local do
+        migrate 1 do |t|
+          t.string :x
+        end
+      end
+
+      def self.local_db
+        $watch_db
+      end
+    end
+  end
+
+  def define_components
+    return if Object.const_defined?(:WatchComponent)
+
+    Object.const_set(:WatchComponent, Class.new(Funicular::Component))
+    WatchComponent.class_eval do
+      def render
+        nil
+      end
+    end
+
+    Object.const_set(:WatchBoomComponent, Class.new(Funicular::Component))
+    WatchBoomComponent.class_eval do
+      def render
+        nil
+      end
+
+      def component_will_unmount
+        raise "boom in unmount hook"
+      end
+    end
+
+    Object.const_set(:WatchMountBoomComponent,
+                     Class.new(Funicular::Component))
+    WatchMountBoomComponent.class_eval do
+      def render
+        nil
+      end
+
+      def component_will_mount
+        raise "boom in mount hook"
+      end
+    end
+  end
+
+  def tick
+    Funicular::DB.__drain_events
+  end
+
+  def titles(records)
+    # @type var out: Array[untyped]
+    out = []
+    records_size = records.size
+    i = 0
+    while i < records_size
+      out << records[i].title
+      i += 1
+    end
+    out
+  end
+
+  # ---- the contract ----
+
+  def test_watch_materializes_the_relation_into_state
+    WatchTodo.create(title: "a")
+    WatchTodo.create(title: "b", done: true)
+    @component.watch(:todos) do
+      WatchTodo.local.where(done: false).order(:id)
+    end
+    assert_equal(["a"], titles(@component.state[:todos]))
+  end
+
+  def test_watch_requires_a_relation
+    raised = false
+    begin
+      @component.watch(:bad) { [1, 2, 3] }
+    rescue ArgumentError => e
+      raised = true
+      assert_equal(true, e.message.include?("on_change"))
+    end
+    assert_equal(true, raised)
+    assert_raise(ArgumentError) { @component.watch(:worse) }
+  end
+
+  # ---- re-evaluation on change events ----
+
+  def test_change_events_reevaluate_and_patch_state
+    @component.watch(:todos) { WatchTodo.local.order(:id) }
+    assert_equal([], @component.state[:todos])
+    WatchTodo.create(title: "later")
+    assert_equal([], @component.state[:todos])
+    tick
+    assert_equal(["later"], titles(@component.state[:todos]))
+    WatchTodo.create(title: "and again")
+    tick
+    assert_equal(["later", "and again"], titles(@component.state[:todos]))
+  end
+
+  def test_branchy_blocks_resubscribe_per_evaluation
+    use_notes = false
+    @component.watch(:items) do
+      use_notes ? WatchNote.local.order(:id) : WatchTodo.local.order(:id)
+    end
+    use_notes = true
+    # This todo event re-evaluates the block, which now returns the
+    # NOTES relation -- and must re-subscribe accordingly.
+    WatchTodo.create(title: "flip")
+    tick
+    assert_equal([], @component.state[:items])
+    # Todo changes no longer reach the watch...
+    WatchTodo.create(title: "ignored")
+    tick
+    assert_equal([], @component.state[:items])
+    # ...note changes do.
+    WatchNote.create(body: "seen")
+    tick
+    assert_equal(1, @component.state[:items].size)
+  end
+
+  # ---- materialization failures ----
+
+  def test_failed_initial_materialization_leaves_no_subscription
+    raised = false
+    begin
+      @component.watch(:broken) { WatchBroken.local }
+    rescue SQLite3::Exception
+      raised = true
+    end
+    assert_equal(true, raised)
+    watches = @component.instance_variable_get("@__watches")
+    assert_equal(true, watches.nil? || watches[:broken].nil?)
+  end
+
+  def test_failed_reevaluation_keeps_the_previous_subscription
+    fail_mode = false
+    @component.watch(:todos) do
+      fail_mode ? WatchBroken.local : WatchTodo.local.order(:id)
+    end
+    fail_mode = true
+    WatchTodo.create(title: "one")
+    tick
+    # The re-evaluation raised (isolated by the bus); state unchanged,
+    # but the previous healthy subscription survived...
+    assert_equal([], @component.state[:todos])
+    fail_mode = false
+    WatchTodo.create(title: "two")
+    tick
+    # ...so the next healthy evaluation catches up.
+    assert_equal(["one", "two"], titles(@component.state[:todos]))
+  end
+
+  # ---- unmount ----
+
+  def test_unmount_unsubscribes_watches
+    # watch first (unmounted, no DOM), then pretend to be mounted so
+    # unmount's full path runs headlessly.
+    @component.watch(:todos) { WatchTodo.local.order(:id) }
+    @component.instance_variable_set("@mounted", true)
+    @component.unmount
+    WatchTodo.create(title: "after unmount")
+    tick
+    assert_equal([], @component.state[:todos])
+  end
+
+  def test_failed_mount_releases_watch_subscriptions
+    component = WatchMountBoomComponent.new
+    component.watch(:todos) { WatchTodo.local.order(:id) }
+    raised = false
+    begin
+      component.mount(nil)
+    rescue RuntimeError
+      raised = true
+    end
+    assert_equal(true, raised)
+    # A failed mount never reaches unmount: the rescue path must have
+    # released the subscription, or this event would re-evaluate.
+    WatchTodo.create(title: "after failed mount")
+    tick
+    assert_equal([], component.state[:todos])
+  end
+
+  def test_failed_hydrate_releases_watch_subscriptions
+    component = WatchComponent.new
+    component.watch(:todos) { WatchTodo.local.order(:id) }
+    raised = false
+    begin
+      # A nil server element must take the same cleanup path as every
+      # other hydrate failure.
+      component.hydrate(nil)
+    rescue RuntimeError
+      raised = true
+    end
+    assert_equal(true, raised)
+    WatchTodo.create(title: "after failed hydrate")
+    tick
+    assert_equal([], component.state[:todos])
+  end
+
+  def test_unmount_unsubscribes_even_when_a_lifecycle_hook_raises
+    component = WatchBoomComponent.new
+    component.watch(:todos) { WatchTodo.local.order(:id) }
+    component.instance_variable_set("@mounted", true)
+    raised = false
+    begin
+      component.unmount
+    rescue RuntimeError
+      raised = true
+    end
+    assert_equal(true, raised)
+    WatchTodo.create(title: "zombie?")
+    tick
+    assert_equal([], component.state[:todos])
+  end
+end

--- a/test/watch_test.rb
+++ b/test/watch_test.rb
@@ -178,6 +178,51 @@ class WatchTest < Picotest::Test
     assert_equal(1, @component.state[:items].size)
   end
 
+  # ---- replica fetch-through drives a watch ----
+
+  # The chat-style flow: watch a REPLICA model's relation, then apply a
+  # REST collection through the write-through batch entry (what
+  # Model.all does after a fetch). The one post-commit event must
+  # re-evaluate the watch and land the rows in state.
+  def test_replica_fetch_through_reevaluates_a_watch
+    define_replica_model
+    @component.watch(:posts) { WatchPost.local.order(:id) }
+    assert_equal([], @component.state[:posts])
+    WatchPost.__write_through_upsert_all(
+      [{ "id" => 1, "title" => "first" },
+       { "id" => 2, "title" => "second" }])
+    assert_equal([], @component.state[:posts])
+    tick
+    assert_equal(["first", "second"], titles(@component.state[:posts]))
+  end
+
+  def define_replica_model
+    unless Object.const_defined?(:WatchPost)
+      Object.const_set(:WatchPost, Class.new(Funicular::Model))
+      WatchPost.class_eval do
+        table_name "watch_posts"
+
+        def self.local_db
+          $watch_replica_guard
+        end
+
+        def self.replica_db
+          $watch_replica_guard
+        end
+      end
+    end
+    WatchPost.load_schema(
+      "attributes" => {
+        "id" => { "type" => "integer", "readonly" => true },
+        "title" => { "type" => "string", "readonly" => false },
+      },
+      "endpoints" => {})
+    $watch_replica_db = SQLite3::Database.new(":memory:")
+    $watch_replica_guard =
+      Funicular::DB::GuardedDatabase.new($watch_replica_db, :replica)
+    $watch_replica_db.execute(Funicular::DB.replica_table_ddl(WatchPost))
+  end
+
   # ---- materialization failures ----
 
   def test_failed_initial_materialization_leaves_no_subscription

--- a/test/wipe_test.rb
+++ b/test/wipe_test.rb
@@ -100,12 +100,14 @@ class WipeTest < Picotest::Test
     Funicular::DB.__register_database(:replica, $wipe_replica_db,
                                       [WipeNote])
     Funicular::DB.__set_durability(:persistent_writer)
+    Funicular::DB.__set_boot_state(:ready)
     Funicular::DB.__set_snapshot_store($wipe_store)
     Funicular::DB.__set_snapshot_identity($wipe_identity)
   end
 
   def teardown
     Funicular::DB.cancel_persist_timers
+    Funicular::DB.__set_boot_state(:unbooted)
     Funicular::DB.__set_durability(:unbooted)
     Funicular::DB.__set_snapshot_store(nil)
     Funicular::DB.__set_snapshot_identity(nil)

--- a/test/wipe_test.rb
+++ b/test/wipe_test.rb
@@ -88,6 +88,7 @@ class WipeTest < Picotest::Test
   }
 
   def setup
+    Funicular::DB.__set_local_database_enabled(true)
     $wipe_pending = []
     $wipe_local_db = SQLite3::Database.new(":memory:")
     $wipe_replica_db = SQLite3::Database.new(":memory:")
@@ -114,6 +115,7 @@ class WipeTest < Picotest::Test
     Funicular::DB.__register_database(:local, nil, [])
     Funicular::DB.__register_database(:replica, nil, [])
     Funicular::DB.__reset_config
+    Funicular::DB.__set_local_database_enabled(false)
     $wipe_local_db.close
     $wipe_replica_db.close
   end

--- a/test/wipe_test.rb
+++ b/test/wipe_test.rb
@@ -1,0 +1,440 @@
+# Tests for wipe + the mutation generation (docs decision 17): both
+# databases dropped and rebuilt empty, both snapshot keys deleted, and
+# in-flight REST responses discarded instead of applied. The HTTP stub
+# here DEFERS responses (each Picotest file runs in its own VM), so a
+# wipe can land between issue and response exactly like in flight.
+
+module Funicular
+  module HTTP
+    class << self
+      def get(url, &block)
+        $wipe_pending << block
+      end
+
+      def post(url, body = nil, &block)
+        $wipe_pending << block
+      end
+
+      def patch(url, body = nil, &block)
+        $wipe_pending << block
+      end
+
+      def delete(url, &block)
+        $wipe_pending << block
+      end
+    end
+  end
+end
+
+class WipeTest < Picotest::Test
+  class FakeStore
+    attr_reader :data, :put_count
+
+    def initialize
+      @data = {}
+      @put_count = 0
+    end
+
+    def [](key)
+      @data[key]
+    end
+
+    def []=(key, value)
+      @put_count += 1
+      @data[key] = value
+    end
+
+    def delete(key)
+      @data.delete(key)
+      nil
+    end
+  end
+
+  class DeleteBrokenError < StandardError; end
+
+  class DeleteBrokenStore < FakeStore
+    def delete(key)
+      raise DeleteBrokenError, "delete failed"
+    end
+  end
+
+  class SlowStore < FakeStore
+    def delete(key)
+      # Suspend the wiping Task mid-delete, exactly where a scheduled
+      # drain would sneak in.
+      JS.global.eval("new Promise((r) => setTimeout(r, 15))").await
+      super
+    end
+  end
+
+  class OrderProbeStore < FakeStore
+    def delete(key)
+      # Recorded at delete time: when the rebuild really precedes the
+      # snapshot deletes, the table is already empty here.
+      $wipe_probe << $wipe_local_db.execute(
+        "SELECT COUNT(*) FROM wipe_drafts")[0][0]
+      super
+    end
+  end
+
+  NOTE_SCHEMA = {
+    "attributes" => {
+      "id" => { "readonly" => true, "type" => "integer" },
+      "body" => { "type" => "string" },
+    },
+    "endpoints" => {
+      "all" => { "path" => "/wipe_notes" },
+    },
+  }
+
+  def setup
+    $wipe_pending = []
+    $wipe_local_db = SQLite3::Database.new(":memory:")
+    $wipe_replica_db = SQLite3::Database.new(":memory:")
+    $wipe_store = FakeStore.new
+    $wipe_identity = Funicular::DB.namespace_identity("app", nil, true)
+    define_models
+    Funicular::DB.apply_local_migrations($wipe_local_db, WipeDraft)
+    Funicular::DB.build_replica_tables($wipe_replica_db, [WipeNote])
+    Funicular::DB.__register_database(:local, $wipe_local_db, [WipeDraft])
+    Funicular::DB.__register_database(:replica, $wipe_replica_db,
+                                      [WipeNote])
+    Funicular::DB.__set_durability(:persistent_writer)
+    Funicular::DB.__set_snapshot_store($wipe_store)
+    Funicular::DB.__set_snapshot_identity($wipe_identity)
+  end
+
+  def teardown
+    Funicular::DB.cancel_persist_timers
+    Funicular::DB.__set_durability(:unbooted)
+    Funicular::DB.__set_snapshot_store(nil)
+    Funicular::DB.__set_snapshot_identity(nil)
+    Funicular::DB.__register_database(:local, nil, [])
+    Funicular::DB.__register_database(:replica, nil, [])
+    Funicular::DB.__reset_config
+    $wipe_local_db.close
+    $wipe_replica_db.close
+  end
+
+  def define_models
+    return if Object.const_defined?(:WipeDraft)
+
+    Object.const_set(:WipeDraft, Class.new(Funicular::Model))
+    WipeDraft.class_eval do
+      table_name "wipe_drafts"
+      storage :local do
+        migrate 1 do |t|
+          t.string :title
+        end
+      end
+    end
+
+    Object.const_set(:WipeNote, Class.new(Funicular::Model))
+    WipeNote.class_eval do
+      table_name "wipe_notes"
+
+      def self.replica_db
+        $wipe_replica_db
+      end
+    end
+    WipeNote.load_schema(NOTE_SCHEMA)
+  end
+
+  def pump(ms)
+    JS.global.eval("new Promise((r) => setTimeout(r, #{ms}))").await
+  end
+
+  def respond(payload)
+    block = $wipe_pending.shift
+    block.call(Funicular::HTTP::Response.new(200, payload))
+  end
+
+  def test_wipe_requires_a_booted_writer_or_volatile_tab
+    Funicular::DB.__set_durability(:persistent_reader)
+    assert_raise(Funicular::DB::ReadOnlyTabError) do
+      Funicular::DB.wipe
+    end
+    Funicular::DB.__set_durability(:unbooted)
+    assert_raise(Funicular::DB::Error) do
+      Funicular::DB.wipe
+    end
+  end
+
+  def test_wipe_refuses_during_an_open_transaction
+    # The rebuild would nest into (or be rolled back with) the open
+    # transaction, so the refusal must come BEFORE any side effect.
+    before = Funicular::DB.mutation_generation
+    key = Funicular::DB.snapshot_key($wipe_identity, :local)
+    $wipe_store.data[key] = "kept"
+    $wipe_local_db.execute("BEGIN")
+    $wipe_local_db.execute(
+      "INSERT INTO wipe_drafts (title) VALUES ('open')")
+    begin
+      assert_raise(Funicular::DB::Error) do
+        Funicular::DB.wipe
+      end
+    ensure
+      $wipe_local_db.execute("ROLLBACK")
+    end
+    assert_equal(before, Funicular::DB.mutation_generation)
+    assert_equal("kept", $wipe_store.data[key])
+    # The replica side guards identically.
+    $wipe_replica_db.execute("BEGIN")
+    begin
+      assert_raise(Funicular::DB::Error) do
+        Funicular::DB.wipe
+      end
+    ensure
+      $wipe_replica_db.execute("ROLLBACK")
+    end
+    assert_equal(before, Funicular::DB.mutation_generation)
+  end
+
+  def test_snapshot_deletes_run_after_the_rebuild
+    # The deletes are the only operations in wipe that suspend this
+    # Task; anything before them must already be settled, or another
+    # Task could open a transaction behind the transaction check
+    # (TOCTOU) and the rebuild would run into it.
+    $wipe_probe = []
+    Funicular::DB.__set_snapshot_store(OrderProbeStore.new)
+    $wipe_local_db.execute(
+      "INSERT INTO wipe_drafts (title) VALUES ('secret')")
+    Funicular::DB.wipe
+    assert_equal([0, 0], $wipe_probe)
+  end
+
+  def test_failed_snapshot_delete_notifies_no_watcher
+    # A failing delete leaves the old snapshot able to resurrect on
+    # reload, so wipe raises WITHOUT telling any watcher (a component
+    # must never render a "wiped" state that is not durable) and
+    # without arming a fresh persist.
+    Funicular::DB.configure do
+      config.local_debounce_ms = 10
+      config.replica_debounce_ms = 10
+    end
+    broken = DeleteBrokenStore.new
+    Funicular::DB.__set_snapshot_store(broken)
+    $wipe_events = 0
+    sub = Funicular::DB.subscribe(:local, "wipe_drafts") do |_r, _t|
+      $wipe_events += 1
+    end
+    assert_raise(DeleteBrokenError) do
+      Funicular::DB.wipe
+    end
+    # Past both debounce windows: no watcher ran, no snapshot landed.
+    pump(40)
+    assert_equal(0, $wipe_events)
+    assert_equal(0, broken.put_count)
+    Funicular::DB.unsubscribe(sub)
+  end
+
+  def test_prewipe_queued_events_are_superseded_by_the_wipe_event
+    # A change event queued BEFORE the wipe must not slip out during
+    # the snapshot deletes (the store here suspends mid-delete): the
+    # watcher hears from the wipe exactly once, afterwards.
+    Funicular::DB.__set_snapshot_store(SlowStore.new)
+    $wipe_events = 0
+    sub = Funicular::DB.subscribe(:local, "wipe_drafts") do |_r, _t|
+      $wipe_events += 1
+    end
+    Funicular::DB.notify_changed(:local, "wipe_drafts")
+    Funicular::DB.wipe
+    pump(40)
+    assert_equal(1, $wipe_events)
+    Funicular::DB.unsubscribe(sub)
+  end
+
+  def test_wipe_from_a_subscriber_stops_the_running_drain
+    # The running drain holds its events in a local variable, out of
+    # clear_tick_events' reach: the generation bump must stop it. The
+    # second subscriber (and every later event of the drain) hears only
+    # from the wipe's own notification, one tick later.
+    $wipe_first = 0
+    $wipe_second = 0
+    sub1 = Funicular::DB.subscribe(:local, "wipe_drafts") do |_r, _t|
+      $wipe_first += 1
+      Funicular::DB.wipe if $wipe_first == 1
+    end
+    sub2 = Funicular::DB.subscribe(:local, "wipe_drafts") do |_r, _t|
+      $wipe_second += 1
+    end
+    Funicular::DB.notify_changed(:local, "wipe_drafts")
+    pump(30)
+    # First subscriber: the pre-wipe event plus the wipe's own.
+    # Second subscriber: ONLY the wipe's own.
+    assert_equal(2, $wipe_first)
+    assert_equal(1, $wipe_second)
+    Funicular::DB.unsubscribe(sub1)
+    Funicular::DB.unsubscribe(sub2)
+  end
+
+  def test_prewipe_queued_events_die_with_a_failed_wipe
+    Funicular::DB.__set_snapshot_store(DeleteBrokenStore.new)
+    $wipe_events = 0
+    sub = Funicular::DB.subscribe(:local, "wipe_drafts") do |_r, _t|
+      $wipe_events += 1
+    end
+    Funicular::DB.notify_changed(:local, "wipe_drafts")
+    assert_raise(DeleteBrokenError) do
+      Funicular::DB.wipe
+    end
+    pump(10)
+    assert_equal(0, $wipe_events)
+    Funicular::DB.unsubscribe(sub)
+  end
+
+  def test_wipe_advances_the_generation_first
+    before = Funicular::DB.mutation_generation
+    assert_equal(true, Funicular::DB.wipe)
+    assert_equal(before + 1, Funicular::DB.mutation_generation)
+    assert_equal(true, Funicular::DB.stale_generation?(before))
+  end
+
+  def test_wipe_empties_and_rebuilds_both_databases
+    $wipe_local_db.execute(
+      "INSERT INTO wipe_drafts (title) VALUES ('secret')")
+    $wipe_replica_db.execute(
+      "INSERT INTO wipe_notes (id, body) VALUES (1, 'mirrored')")
+    Funicular::DB.wipe
+    # Empty but queryable, schema intact: the migration state and the
+    # fingerprint were rebuilt from scratch.
+    assert_equal([[0]],
+                 $wipe_local_db.execute("SELECT COUNT(*) FROM wipe_drafts"))
+    assert_equal([[0]],
+                 $wipe_replica_db.execute("SELECT COUNT(*) FROM wipe_notes"))
+    assert_equal(1, Funicular::DB.stored_table_version(
+                      $wipe_local_db, "wipe_drafts"))
+    fingerprint = Funicular::DB.read_meta(
+      $wipe_replica_db, Funicular::DB::REPLICA_FINGERPRINT_KEY)
+    assert_equal(Funicular::DB.canonical_replica_schema([WipeNote]),
+                 fingerprint)
+  end
+
+  def test_wipe_drops_a_table_whose_name_contains_a_quote
+    $wipe_local_db.execute(
+      'CREATE TABLE "wipe""quoted" (id INTEGER PRIMARY KEY)')
+    Funicular::DB.wipe
+    rows = $wipe_local_db.execute(
+      "SELECT name FROM sqlite_master WHERE name = ?", ['wipe"quoted'])
+    assert_equal([], rows)
+  end
+
+  def test_wipe_deletes_only_this_namespaces_snapshots
+    local_key = Funicular::DB.snapshot_key($wipe_identity, :local)
+    replica_key = Funicular::DB.snapshot_key($wipe_identity, :replica)
+    other = Funicular::DB.namespace_identity("app", "someone-else", false)
+    other_key = Funicular::DB.snapshot_key(other, :local)
+    $wipe_store.data[local_key] = "old-local"
+    $wipe_store.data[replica_key] = "old-replica"
+    $wipe_store.data[other_key] = "kept"
+    Funicular::DB.wipe
+    assert_equal(false, $wipe_store.data.has_key?(local_key))
+    assert_equal(false, $wipe_store.data.has_key?(replica_key))
+    assert_equal("kept", $wipe_store.data[other_key])
+  end
+
+  def test_wipe_invalidates_queued_timer_callbacks
+    Funicular::DB.configure do
+      config.local_debounce_ms = 20
+    end
+    Funicular::DB.notify_changed(:local, "wipe_drafts")
+    stale = Funicular::DB.__persist_timer_token(:local)
+    Funicular::DB.wipe
+    # A callback already queued when the wipe cancelled its timer must
+    # come up stale.
+    Funicular::DB.__persist_timer_fired(:local, stale)
+    assert_equal(0, $wipe_store.put_count)
+  end
+
+  def test_post_wipe_snapshots_hold_the_wiped_state
+    Funicular::DB.configure do
+      config.local_debounce_ms = 20
+      config.replica_debounce_ms = 20
+    end
+    $wipe_local_db.execute(
+      "INSERT INTO wipe_drafts (title) VALUES ('secret')")
+    assert_equal(true, Funicular::DB.flush)
+    Funicular::DB.wipe
+    # wipe's own change notifications re-arm the debounce; the fresh
+    # snapshots must hold the EMPTY state.
+    pump(60)
+    fresh = SQLite3::Database.new(":memory:")
+    Funicular::DB.__register_database(:local, fresh, [WipeDraft])
+    assert_equal(true, Funicular::DB.restore_snapshot(:local))
+    assert_equal([[0]], fresh.execute("SELECT COUNT(*) FROM wipe_drafts"))
+    fresh.close
+  end
+
+  def test_wipe_notifies_each_table_once_queryable
+    $wipe_seen = []
+    local_sub = Funicular::DB.subscribe(:local, "wipe_drafts") do |_r, _t|
+      # Queryable already: the handler runs strictly after the rebuild.
+      count = $wipe_local_db.execute("SELECT COUNT(*) FROM wipe_drafts")
+      $wipe_seen << [:local, count[0][0]]
+    end
+    replica_sub = Funicular::DB.subscribe(:replica, "wipe_notes") do |_r, _t|
+      count = $wipe_replica_db.execute("SELECT COUNT(*) FROM wipe_notes")
+      $wipe_seen << [:replica, count[0][0]]
+    end
+    Funicular::DB.wipe
+    assert_equal([], $wipe_seen)
+    pump(10)
+    assert_equal(true, $wipe_seen.include?([:local, 0]))
+    assert_equal(true, $wipe_seen.include?([:replica, 0]))
+    Funicular::DB.unsubscribe(local_sub)
+    Funicular::DB.unsubscribe(replica_sub)
+  end
+
+  def test_stale_rest_response_is_discarded
+    $wipe_result = :untouched
+    $wipe_error = nil
+    WipeNote.all do |result, error|
+      $wipe_result = result
+      $wipe_error = error
+    end
+    Funicular::DB.wipe
+    respond([{ "id" => 1, "body" => "resurrected?" }])
+    assert_equal(nil, $wipe_result)
+    assert_equal(Funicular::DB::Error, $wipe_error.class)
+    # Nothing was applied: a logout can never resurrect the previous
+    # session's rows.
+    assert_equal([[0]],
+                 $wipe_replica_db.execute("SELECT COUNT(*) FROM wipe_notes"))
+  end
+
+  def test_stale_error_wins_over_an_http_error
+    # A request issued before the wipe that completes with an HTTP
+    # error after it is STALE first: the callback must see the
+    # discard, not the original error_message.
+    $wipe_error = nil
+    WipeNote.all do |_result, error|
+      $wipe_error = error
+    end
+    Funicular::DB.wipe
+    block = $wipe_pending.shift
+    block.call(Funicular::HTTP::Response.new(500, nil))
+    assert_equal(Funicular::DB::Error, $wipe_error.class)
+  end
+
+  def test_a_fresh_request_after_the_wipe_applies_normally
+    Funicular::DB.wipe
+    $wipe_result = nil
+    WipeNote.all do |result, error|
+      $wipe_result = result
+    end
+    respond([{ "id" => 2, "body" => "new session" }])
+    assert_equal(1, $wipe_result.size)
+    assert_equal([[1]],
+                 $wipe_replica_db.execute("SELECT COUNT(*) FROM wipe_notes"))
+  end
+
+  def test_wipe_works_on_a_volatile_tab_without_a_store
+    Funicular::DB.__set_durability(:volatile)
+    Funicular::DB.__set_snapshot_store(nil)
+    $wipe_local_db.execute(
+      "INSERT INTO wipe_drafts (title) VALUES ('secret')")
+    assert_equal(true, Funicular::DB.wipe)
+    assert_equal([[0]],
+                 $wipe_local_db.execute("SELECT COUNT(*) FROM wipe_drafts"))
+  end
+end

--- a/test/writer_election_test.rb
+++ b/test/writer_election_test.rb
@@ -1,0 +1,111 @@
+# Tests for the writer election (docs decision 14) against a fake Web
+# Locks API injected through the shim's __funicularLocksApi seam:
+# granted -> persistent_writer (lock held), busy -> persistent_reader,
+# API absent or failing -> volatile; release lets the next election win.
+
+class WriterElectionTest < Picotest::Test
+  FAKE_JS = <<~'FUNICULAR_LOCK_FAKE'
+    globalThis.__lockFake = {
+      mode: "grant",
+      requests: [],
+      releases: 0,
+    };
+    globalThis.__funicularLocksApi = {
+      request(name, opts, cb) {
+        const fake = globalThis.__lockFake;
+        fake.requests.push([name, !!(opts && opts.ifAvailable)]);
+        if (fake.mode === "throw") {
+          throw new Error("locks broke");
+        }
+        if (fake.mode === "busy") {
+          return Promise.resolve(cb(null));
+        }
+        const held = cb({ name: name });
+        Promise.resolve(held).then(() => { fake.releases += 1; });
+        return Promise.resolve(held);
+      }
+    };
+  FUNICULAR_LOCK_FAKE
+
+  def setup
+    JS.global.eval(FAKE_JS)
+  end
+
+  def teardown
+    Funicular::DB.release_writer_lock
+    Funicular::DB.__set_durability(:unbooted)
+    JS.global.eval(FAKE_JS)
+  end
+
+  def fake_state
+    JSON.parse(JS.global.eval(
+      "JSON.stringify(globalThis.__lockFake)").to_s)
+  end
+
+  def test_granted_lock_makes_the_persistent_writer
+    assert_equal(:unbooted, Funicular::DB.durability)
+    state = Funicular::DB.elect_writer("funicular:lock:test")
+    assert_equal(:persistent_writer, state)
+    assert_equal(:persistent_writer, Funicular::DB.durability)
+    requests = fake_state["requests"]
+    assert_equal([["funicular:lock:test", true]], requests)
+  end
+
+  def test_busy_lock_makes_a_persistent_reader
+    JS.global.eval("globalThis.__lockFake.mode = 'busy'")
+    assert_equal(:persistent_reader,
+                 Funicular::DB.elect_writer("funicular:lock:test"))
+  end
+
+  def test_absent_api_means_volatile
+    # Neither the injected API nor navigator.locks (absent under Node).
+    JS.global.eval("globalThis.__funicularLocksApi = null")
+    assert_equal(:volatile,
+                 Funicular::DB.elect_writer("funicular:lock:test"))
+  end
+
+  def test_api_failure_means_volatile
+    JS.global.eval("globalThis.__lockFake.mode = 'throw'")
+    assert_equal(:volatile,
+                 Funicular::DB.elect_writer("funicular:lock:test"))
+  end
+
+  def test_release_frees_the_lock_for_the_next_election
+    Funicular::DB.elect_writer("funicular:lock:test")
+    assert_equal(true, Funicular::DB.release_writer_lock)
+    # Stepping down is one-way: from here on this tab must never gate a
+    # persist on being the writer again.
+    assert_equal(:persistent_reader, Funicular::DB.durability)
+    # The holding promise resolves on a microtask; give it a tick.
+    JS.global.eval("new Promise((r) => setTimeout(r, 10))").await
+    assert_equal(1, fake_state["releases"])
+    # A fresh election (new page in reality) wins again.
+    Funicular::DB.__set_durability(:unbooted)
+    assert_equal(:persistent_writer,
+                 Funicular::DB.elect_writer("funicular:lock:test"))
+  end
+
+  def test_election_is_one_shot
+    Funicular::DB.elect_writer("funicular:lock:test")
+    assert_raise(Funicular::DB::Error) do
+      Funicular::DB.elect_writer("funicular:lock:test")
+    end
+  end
+
+  def test_election_in_flight_blocks_reentry
+    # The awaiting Task suspends mid-election: a concurrent call must
+    # hit the one-shot guard while the state is :electing.
+    Funicular::DB.__set_durability(:electing)
+    assert_raise(Funicular::DB::Error) do
+      Funicular::DB.elect_writer("funicular:lock:test")
+    end
+  end
+
+  def test_release_without_a_lock_is_a_noop
+    assert_equal(false, Funicular::DB.release_writer_lock)
+    JS.global.eval("globalThis.__lockFake.mode = 'busy'")
+    Funicular::DB.elect_writer("funicular:lock:test")
+    # Readers hold nothing to release.
+    assert_equal(false, Funicular::DB.release_writer_lock)
+  end
+end


### PR DESCRIPTION
This pull request introduces the first release of the Funicular local database subsystem, providing an ActiveRecord-like, reactive local store powered by in-browser SQLite. It includes extensive new features for local data persistence, migration, reactivity, and session isolation, along with breaking changes to REST callbacks and removal of the old HTTP cache. A new demo page, `demo/local_notes.html`, showcases these capabilities in a no-server example.

**Local Database Subsystem and API:**

* Added a globally opt-in SQLite local-database subsystem, configurable via `config.local_database`, with support for in-browser persistence, writer election, and session epoch isolation. Extensive design documentation and API contracts are included in `docs/local_database.md` and `docs/architecture.md`.
* Introduced the local-query foundation (`Funicular::Relation`), model declaration DSL (`storage`, `.local`, migration blocks), client-only-table migration machinery, and the change-event bus for reactive updates.
* Implemented writer election using Web Locks, snapshot persistence via IndexedDB, and a robust boot process (`Funicular::DB.boot`) with failure handling and session epoch enforcement.
* Added support for local CRUD operations, guarded database handles, namespace identity, and REST integration with the local database layer.

**Breaking and Removed Changes:**

* Changed all `Funicular::Model` REST callbacks to the uniform `(result, error)` signature (was previously inconsistent), requiring updates to callsites that relied on boolean-first responses.
* Removed the dead IndexedDB-backed HTTP response cache, as the new local database layer supersedes its purpose.

**Demo and Documentation:**

* Added `demo/local_notes.html`, a static, server-less demo showcasing the local database layer with note creation, deletion, snapshot persistence, writer election, and full reactivity using `.local` queries and `watch`.
* Updated `CHANGELOG.md` to document all new features, breaking changes, and removals for the `0.5.0` release.