### PR TITLE
Make schema format validators survive translation edge cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -340,6 +340,19 @@ of truth. Entries below accumulate as the feature lands.
 - `Model#initialize` uses key-presence lookups instead of `||`, so a
   string-keyed `false` (boolean columns) no longer collapses to nil.
 
+- `Schema::RegexpTranslator` unescapes Ruby's `\#` identity escape, which
+  survives in `Regexp#source` but is rejected by the JS RegExp engine under
+  the `u` flag (`URI::MailTo::EMAIL_REGEXP` is the common casualty: one such
+  validator used to fail the whole client boot).
+
+- `Schema.serialize` now carries `allow_nil` / `allow_blank` through to the
+  client, so a format validator on an optional attribute no longer rejects
+  the blank value the server accepts.
+
+- A schema `format` regex the client runtime cannot compile downgrades to a
+  console warning and drops that one validator instead of failing the whole
+  schema load.
+
 ### Removed
 
 - The IndexedDB-backed HTTP response cache (`Funicular::HTTP` `cache:`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -346,8 +346,10 @@ of truth. Entries below accumulate as the feature lands.
   validator used to fail the whole client boot).
 
 - `Schema.serialize` now carries `allow_nil` / `allow_blank` through to the
-  client, so a format validator on an optional attribute no longer rejects
-  the blank value the server accepts.
+  client -- including kinds that serialize to a bare `true`, such as
+  `presence` and unconstrained `numericality`, which upgrade to a Hash --
+  so a validator on an optional attribute no longer rejects the nil or
+  blank value the server accepts.
 
 - A schema `format` regex the client runtime cannot compile downgrades to a
   console warning and drops that one validator instead of failing the whole

--- a/lib/funicular/schema.rb
+++ b/lib/funicular/schema.rb
@@ -97,8 +97,12 @@ module Funicular
 
     # allow_nil / allow_blank change what the client may skip; without them
     # a format validator on an optional attribute rejects the blank value
-    # that the server happily accepts.
+    # that the server happily accepts. Kinds that serialize to a bare true
+    # (presence, or numericality without constraints) upgrade to a Hash so
+    # the flags survive for them too.
     def self.attach_shared_options(serialized, options)
+      return serialized unless options[:allow_nil] || options[:allow_blank]
+      serialized = {} if serialized == true
       return serialized unless serialized.is_a?(Hash)
       serialized["allow_nil"] = true if options[:allow_nil]
       serialized["allow_blank"] = true if options[:allow_blank]

--- a/lib/funicular/schema.rb
+++ b/lib/funicular/schema.rb
@@ -79,18 +79,30 @@ module Funicular
     end
 
     def self.serialize(kind, options)
-      case kind
-      when :presence, :absence, :acceptance, :confirmation
-        true
-      when :length
-        serialize_length(options)
-      when :numericality
-        serialize_numericality(options)
-      when :inclusion, :exclusion
-        serialize_set(options)
-      when :format
-        RegexpTranslator.translate(options[:with])
-      end
+      serialized =
+        case kind
+        when :presence, :absence, :acceptance, :confirmation
+          true
+        when :length
+          serialize_length(options)
+        when :numericality
+          serialize_numericality(options)
+        when :inclusion, :exclusion
+          serialize_set(options)
+        when :format
+          RegexpTranslator.translate(options[:with])
+        end
+      attach_shared_options(serialized, options)
+    end
+
+    # allow_nil / allow_blank change what the client may skip; without them
+    # a format validator on an optional attribute rejects the blank value
+    # that the server happily accepts.
+    def self.attach_shared_options(serialized, options)
+      return serialized unless serialized.is_a?(Hash)
+      serialized["allow_nil"] = true if options[:allow_nil]
+      serialized["allow_blank"] = true if options[:allow_blank]
+      serialized
     end
 
     def self.serialize_length(options)
@@ -149,6 +161,11 @@ module Funicular
         end
 
         js_source = source.gsub('\\A', '^').gsub('\\z', '$').gsub('\\Z', '$')
+        # Ruby regexp literals escape "#" to suppress interpolation and the
+        # escape survives in Regexp#source, but "\#" is an invalid identity
+        # escape for a JS RegExp under the u flag. "#" never needs escaping
+        # in JS source (x mode is already rejected above), so unescape it.
+        js_source = js_source.gsub('\\#', '#')
 
         flags = +''
         flags << 'i' if (regexp.options & Regexp::IGNORECASE) != 0

--- a/minitest/schema_test.rb
+++ b/minitest/schema_test.rb
@@ -99,6 +99,20 @@ class SchemaDerivationTest < Minitest::Test
     assert_equal({ "minimum" => 2, "maximum" => 10 }, result["bio"]["length"])
   end
 
+  def test_format_unescapes_ruby_hash_escape
+    # Ruby regexp literals escape "#" to suppress interpolation and the escape
+    # survives in Regexp#source; JS RegExp under the u flag rejects "\#" as an
+    # invalid identity escape (URI::MailTo::EMAIL_REGEXP is the wild example).
+    klass = Class.new do
+      include ActiveModel::Validations
+      def self.name = "Mailish"
+      attr_accessor :email
+      validates :email, format: { with: /\A[a-z.!\#$%&]+\z/ }
+    end
+    result = Funicular::Schema.validations_for(klass, ["email"])
+    assert_equal "^[a-z.!#$%&]+$", result["email"]["format"]["with"]
+  end
+
   def test_format_multiline_flag_is_translated
     klass = Class.new do
       include ActiveModel::Validations

--- a/minitest/schema_test.rb
+++ b/minitest/schema_test.rb
@@ -99,6 +99,19 @@ class SchemaDerivationTest < Minitest::Test
     assert_equal({ "minimum" => 2, "maximum" => 10 }, result["bio"]["length"])
   end
 
+  def test_bare_numericality_keeps_allow_nil
+    # numericality with no constraints serializes to a bare true; the
+    # allow_nil flag must upgrade it to a Hash instead of being dropped.
+    klass = Class.new do
+      include ActiveModel::Validations
+      def self.name = "Aged"
+      attr_accessor :age
+      validates :age, numericality: true, allow_nil: true
+    end
+    result = Funicular::Schema.validations_for(klass, ["age"])
+    assert_equal({ "allow_nil" => true }, result["age"]["numericality"])
+  end
+
   def test_format_unescapes_ruby_hash_escape
     # Ruby regexp literals escape "#" to suppress interpolation and the escape
     # survives in Regexp#source; JS RegExp under the u flag rejects "\#" as an

--- a/minitest/validations_test.rb
+++ b/minitest/validations_test.rb
@@ -30,6 +30,21 @@ class ValidationsTest < Minitest::Test
     assert_equal true, k.new("name" => "Alice").valid?
   end
 
+  def test_uncompilable_format_regex_is_skipped_not_fatal
+    k = model_class
+    k.register_schema_validations(
+      "name" => {
+        "format" => { "with" => "[", "flags" => "" },
+        "presence" => true
+      }
+    )
+    # The broken format validator is dropped; the rest still applies and
+    # schema registration does not raise.
+    blank = k.new("name" => "")
+    assert_equal false, blank.valid?
+    assert_equal true, k.new("name" => "Alice").valid?
+  end
+
   def test_length_maximum_and_minimum
     k = model_class
     k.class_eval { validates :name, length: { minimum: 2, maximum: 5 } }

--- a/minitest/validations_test.rb
+++ b/minitest/validations_test.rb
@@ -32,17 +32,31 @@ class ValidationsTest < Minitest::Test
 
   def test_uncompilable_format_regex_is_skipped_not_fatal
     k = model_class
-    k.register_schema_validations(
-      "name" => {
-        "format" => { "with" => "[", "flags" => "" },
-        "presence" => true
-      }
-    )
+    out, _err = capture_io do
+      k.register_schema_validations(
+        "name" => {
+          "format" => { "with" => "[", "flags" => "" },
+          "presence" => true
+        }
+      )
+    end
+    # The warning names the rejected pattern so it can be found among
+    # many schemas loading at boot.
+    assert_match(/Skipping format validator/, out)
+    assert_match(/pattern: \[/, out)
     # The broken format validator is dropped; the rest still applies and
     # schema registration does not raise.
     blank = k.new("name" => "")
     assert_equal false, blank.valid?
     assert_equal true, k.new("name" => "Alice").valid?
+  end
+
+  def test_schema_numericality_with_allow_nil_skips_nil
+    k = model_class({ "age" => false })
+    k.register_schema_validations("age" => { "numericality" => { "allow_nil" => true } })
+
+    assert_equal true, k.new("age" => nil).valid?
+    assert_equal false, k.new("age" => "abc").valid?
   end
 
   def test_length_maximum_and_minimum

--- a/mrblib/model.rb
+++ b/mrblib/model.rb
@@ -94,7 +94,11 @@ module Funicular
         rescue => e
           # Schema regex translation is best-effort; a source this engine
           # cannot compile must not take down the whole boot sequence.
-          puts "[Funicular] Skipping format validator (#{e.message})"
+          # Name the pattern (truncated) so the offending model/attribute
+          # can be found among many schemas loading at boot.
+          source = opts["with"].to_s
+          source = "#{source[0, 60]}..." if 60 < source.length
+          puts "[Funicular] Skipping format validator (#{e.class}: #{e.message}; pattern: #{source})"
           nil
         end
       else

--- a/mrblib/model.rb
+++ b/mrblib/model.rb
@@ -66,6 +66,10 @@ module Funicular
         next unless rules.is_a?(Hash)
         rules.each do |kind, opts|
           options = normalize_validation_options(kind, opts)
+          # nil means the options could not be materialized on this runtime
+          # (e.g. a format regex the JS RegExp engine rejects): drop that one
+          # validator instead of failing the whole schema load.
+          next if options.nil?
           add_schema_validator(attribute, kind, options)
         end
       end
@@ -82,7 +86,17 @@ module Funicular
         bits = 0
         bits |= Regexp::IGNORECASE if flags.include?("i")
         bits |= Regexp::MULTILINE if flags.include?("m")
-        { with: Regexp.new(opts["with"], bits) }
+        begin
+          normalized = { with: Regexp.new(opts["with"], bits) }
+          normalized[:allow_nil] = true if opts["allow_nil"]
+          normalized[:allow_blank] = true if opts["allow_blank"]
+          normalized
+        rescue => e
+          # Schema regex translation is best-effort; a source this engine
+          # cannot compile must not take down the whole boot sequence.
+          puts "[Funicular] Skipping format validator (#{e.message})"
+          nil
+        end
       else
         opts
       end


### PR DESCRIPTION
Found while dogfooding Funicular in a Rails EC app whose model validates an optional email with `URI::MailTo::EMAIL_REGEXP`:

- `Schema::RegexpTranslator` unescapes Ruby's `\#` identity escape, which survives in `Regexp#source` but is rejected by the JS RegExp engine under the `u` flag. One such validator used to fail the whole client boot.
- `Schema.serialize` carries `allow_nil` / `allow_blank` through to the client, so a format validator on an optional attribute no longer rejects the blank value the server accepts.
- A schema `format` regex the client runtime cannot compile now drops that single validator with a console warning instead of failing the whole schema load.

Covered by new cases in `minitest/schema_test.rb` and `minitest/validations_test.rb`; CHANGELOG updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)