### PR TITLE
Add a router-level navigation guard for unsaved changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ of truth. Entries below accumulate as the feature lands.
 
 ### Added
 
+- Navigation guard: a component can veto leaving by overriding
+  `navigation_guard` to return a confirmation message (nil allows).
+  The router consults it before `navigate` (including `link_to
+  navigate: true`), on browser back/forward (restoring the history
+  entry when the user stays), and through a synchronous `beforeunload`
+  listener for reload / tab close via the browser's native dialog.
+  `Funicular.confirm_handler=` injects the dialog for tests or custom
+  UIs; SSR never blocks. The guard must not suspend.
+
 - The SQLite local-database subsystem is now globally opt-in through
   `config.local_database = true` and defaults off. REST-only applications do
   not start SQLite, IndexedDB, Web Locks, replica write-through, or session

--- a/minitest/navigation_guard_test.rb
+++ b/minitest/navigation_guard_test.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+Funicular::SSR::Runtime.load_framework!
+
+# Router-side navigation guard: a component may veto navigation with a
+# confirmation message (mrblib logic exercised under CRuby; the browser
+# integration is covered by test/navigation_guard_test.rb and the
+# beforeunload listener).
+class NavigationGuardTest < Minitest::Test
+  class FreeComponent
+    def navigation_guard
+      nil
+    end
+  end
+
+  class GuardedComponent
+    def navigation_guard
+      "Unsaved changes will be lost. Leave?"
+    end
+  end
+
+  def setup
+    @router = Funicular::Router.new(nil)
+  end
+
+  def teardown
+    Funicular.confirm_handler = nil
+  end
+
+  def test_leaving_is_allowed_without_a_current_component
+    assert_equal true, @router.leave_allowed?
+  end
+
+  def test_leaving_is_allowed_when_the_guard_returns_nil
+    @router.instance_variable_set(:@current_component, FreeComponent.new)
+    assert_equal true, @router.leave_allowed?
+  end
+
+  def test_guard_message_is_prompted_and_denial_blocks_leaving
+    @router.instance_variable_set(:@current_component, GuardedComponent.new)
+    asked = []
+    Funicular.confirm_handler = ->(message) { asked << message; false }
+
+    assert_equal false, @router.leave_allowed?
+    assert_equal [ "Unsaved changes will be lost. Leave?" ], asked
+  end
+
+  def test_confirmation_allows_leaving
+    @router.instance_variable_set(:@current_component, GuardedComponent.new)
+    Funicular.confirm_handler = ->(_message) { true }
+
+    assert_equal true, @router.leave_allowed?
+  end
+
+  def test_confirm_defaults_to_true_on_the_server
+    # SSR must never block: without a handler, server mode allows leaving.
+    assert_equal true, Funicular.confirm("anything")
+  end
+
+  def test_component_guard_defaults_to_nil
+    assert_nil Funicular::Component.new.navigation_guard
+  end
+end

--- a/mrblib/component.rb
+++ b/mrblib/component.rb
@@ -548,6 +548,22 @@ module Funicular
       end
     end
 
+    # Navigation guard: return a String message to ask the user for
+    # confirmation before this component is navigated away from (router
+    # navigation, browser back/forward, reload, tab close), or nil to
+    # allow leaving freely. Consulted by the router and its beforeunload
+    # listener; override in components with unsaved work:
+    #
+    #   def navigation_guard
+    #     state[:dirty] ? "Unsaved changes will be lost. Leave?" : nil
+    #   end
+    #
+    # Must not suspend (no fetch/HTTP): the beforeunload path runs it on
+    # the synchronous JS event dispatch stack.
+    def navigation_guard
+      nil
+    end
+
     # Unmount component from DOM
     def unmount
       return unless @mounted

--- a/mrblib/funicular.rb
+++ b/mrblib/funicular.rb
@@ -60,6 +60,23 @@ module Funicular
     @router
   end
 
+  # Confirmation dialog used by the router's navigation guard. The
+  # default asks through window.confirm; tests (and apps wanting a
+  # custom dialog) can replace it with a proc taking the message and
+  # returning true to leave, false to stay.
+  @confirm_handler = nil
+
+  def self.confirm_handler=(handler)
+    @confirm_handler = handler
+  end
+
+  def self.confirm(message)
+    handler = @confirm_handler
+    return !!handler.call(message) if handler
+    return true if server?
+    !!JS.global.confirm(message)
+  end
+
   # Read the SSR state embedded by the server (funicular_state_tag) as a
   # Ruby Hash with string keys. Returns {} when absent or on the server.
   # Goes through JSON.stringify/parse for a reliable JS->Ruby conversion.

--- a/mrblib/router.rb
+++ b/mrblib/router.rb
@@ -63,10 +63,14 @@ module Funicular
 
       @hydrate_initial = hydrate
 
-      # Clean up existing listener if any (prevents duplicate registration)
+      # Clean up existing listeners if any (prevents duplicate registration)
       if @popstate_callback_id
         JS::Object.removeEventListener(@popstate_callback_id)
         @popstate_callback_id = nil
+      end
+      if @beforeunload_callback_id
+        JS::Object.removeEventListener(@beforeunload_callback_id)
+        @beforeunload_callback_id = nil
       end
 
       # Set up popstate listener. The history entry has already moved by

--- a/mrblib/router.rb
+++ b/mrblib/router.rb
@@ -9,6 +9,7 @@ module Funicular
       @current_component = nil
       @current_path = nil
       @popstate_callback_id = nil
+      @beforeunload_callback_id = nil
       @url_helpers = Module.new
       @route_helpers = Object.new
       @route_helpers.extend(@url_helpers)
@@ -68,9 +69,26 @@ module Funicular
         @popstate_callback_id = nil
       end
 
-      # Set up popstate listener
+      # Set up popstate listener. The history entry has already moved by
+      # the time popstate fires; when the current component's navigation
+      # guard vetoes leaving, push the guarded path back (the one thing
+      # popstate cannot cancel).
       @popstate_callback_id = JS.global.addEventListener('popstate') do |event|
-        handle_route_change
+        if leave_allowed?
+          handle_route_change
+        elsif @current_path
+          JS.global.history.pushState(JS::Bridge.to_js({}), '', @current_path)
+        end
+      end
+
+      # Reload / tab close: ask through the browser's native dialog when
+      # a guard is active. sync: the decision must be made on the JS
+      # event dispatch stack, so the guard must not suspend.
+      @beforeunload_callback_id = JS.global.addEventListener('beforeunload', sync: true) do |event|
+        if @current_component&.navigation_guard
+          event.preventDefault
+          event[:returnValue] = ''
+        end
       end
 
       # Handle initial route. Skip the default-route redirect when hydrating
@@ -90,14 +108,31 @@ module Funicular
         @popstate_callback_id = nil
       end
 
+      if @beforeunload_callback_id
+        JS::Object.removeEventListener(@beforeunload_callback_id)
+        @beforeunload_callback_id = nil
+      end
+
       unmount_current_component
     end
 
-    # Navigate to a path programmatically using History API
+    # Navigate to a path programmatically using History API. A vetoing
+    # navigation guard on the current component cancels the navigation
+    # before any history change.
     def navigate(path)
+      return unless leave_allowed?
       JS.global.history.pushState(JS::Bridge.to_js({}), '', path)
       # Manually trigger route change because pushState doesn't fire popstate
       handle_route_change
+    end
+
+    # Ask the current component's navigation guard whether leaving is
+    # allowed; a String from the guard prompts the user via
+    # Funicular.confirm. True when no component or no guard.
+    def leave_allowed?
+      message = @current_component&.navigation_guard
+      return true unless message
+      Funicular.confirm(message)
     end
 
     # Get current path from location

--- a/sig/component.rbs
+++ b/sig/component.rbs
@@ -60,6 +60,7 @@ module Funicular
     def suspense_error: (Symbol name) -> untyped
     def render_suspense: (Symbol name, fallback: untyped, ?error: untyped) { (ResourceAccessor) -> untyped } -> untyped
 
+    def navigation_guard: () -> String?
     def patch: (Hash[Symbol, untyped] new_state) -> void
     def mount: (JS::Element container) -> void
     def hydrate: (JS::Element dom_element) -> void

--- a/sig/funicular.rbs
+++ b/sig/funicular.rbs
@@ -8,7 +8,7 @@ module Funicular
   def self.env: () -> EnvironmentInquirer
   def self.env=: (EnvironmentInquirer | String environment) -> EnvironmentInquirer?
   def self.router: () -> Router?
-  def self.confirm_handler=: (^(String) -> boolish | nil handler) -> void
+  def self.confirm_handler=: ((^(String) -> boolish)? handler) -> (^(String) -> boolish)?
   def self.confirm: (String message) -> bool
 
   # SSR / hydration support

--- a/sig/funicular.rbs
+++ b/sig/funicular.rbs
@@ -8,6 +8,8 @@ module Funicular
   def self.env: () -> EnvironmentInquirer
   def self.env=: (EnvironmentInquirer | String environment) -> EnvironmentInquirer?
   def self.router: () -> Router?
+  def self.confirm_handler=: (^(String) -> boolish | nil handler) -> void
+  def self.confirm: (String message) -> bool
 
   # SSR / hydration support
   def self.server?: () -> bool

--- a/sig/router.rbs
+++ b/sig/router.rbs
@@ -21,6 +21,7 @@ module Funicular
     def start: (?hydrate: bool) -> void
     def stop: () -> void
     def navigate: (String path) -> void
+    def leave_allowed?: () -> bool
     def current_location_path: () -> String
 
     private def add_route_with_method: (Symbol method, String path, singleton(Component) component_class, String? name, ?route_constraints_t? constraints) -> void

--- a/test/navigation_guard_test.rb
+++ b/test/navigation_guard_test.rb
@@ -1,0 +1,51 @@
+class NavigationGuardTest < Picotest::Test
+  class FreeComponent
+    def navigation_guard
+      nil
+    end
+  end
+
+  class GuardedComponent
+    def navigation_guard
+      "Unsaved changes will be lost. Leave?"
+    end
+  end
+
+  def setup
+    @container = stub(Object.new) # JS::Object
+    @router = Funicular::Router.new(@container)
+  end
+
+  def teardown
+    Funicular.confirm_handler = nil
+  end
+
+  def test_leave_allowed_without_component
+    assert_equal(true, @router.leave_allowed?)
+  end
+
+  def test_leave_allowed_with_nil_guard
+    @router.instance_variable_set(:@current_component, FreeComponent.new)
+    assert_equal(true, @router.leave_allowed?)
+  end
+
+  def test_denied_confirmation_blocks_leaving
+    @router.instance_variable_set(:@current_component, GuardedComponent.new)
+    asked = []
+    Funicular.confirm_handler = ->(message) { asked << message; false }
+
+    assert_equal(false, @router.leave_allowed?)
+    assert_equal(["Unsaved changes will be lost. Leave?"], asked)
+  end
+
+  def test_accepted_confirmation_allows_leaving
+    @router.instance_variable_set(:@current_component, GuardedComponent.new)
+    Funicular.confirm_handler = ->(_message) { true }
+
+    assert_equal(true, @router.leave_allowed?)
+  end
+
+  def test_component_guard_defaults_to_nil
+    assert_equal(nil, Funicular::Component.new.navigation_guard)
+  end
+end


### PR DESCRIPTION
Requested while dogfooding the admin CMS of a Rails EC app: leaving an edit form silently discarded typed input, and only the router can veto every leave path.

Components override `navigation_guard` to return a confirmation message (nil allows leaving). The router consults it on every way out:

| Leave path | Mechanism |
|------------|-----------|
| `link_to navigate: true` / `router.navigate` | `window.confirm` before the History API is touched |
| Browser back / forward | `window.confirm`; when the user stays, the history entry is restored |
| Reload / tab close | Native browser dialog via a synchronous `beforeunload` listener (`sync: true`) |

`Funicular.confirm_handler=` injects the dialog for tests and custom UIs; SSR never blocks; the guard must not suspend (documented on the method).

Covered by `minitest/navigation_guard_test.rb` (CRuby) and `test/navigation_guard_test.rb` (browser runtime); RBS signatures and CHANGELOG updated. A docs addition for picoruby.org (funicular-on-rails-routing) is written separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)