### PR TITLE
Add negative assertions and selector_count to DOMTest

### DIFF
--- a/lib/funicular/testing/node_runner.mjs
+++ b/lib/funicular/testing/node_runner.mjs
@@ -105,6 +105,15 @@ module Funicular
         report(!actual.nil?, "Expected selector #{selector.inspect} to exist", selector, actual)
       end
 
+      def assert_no_selector(selector)
+        actual = query(selector)
+        report(actual.nil?, "Expected selector #{selector.inspect} to be absent", selector, actual)
+      end
+
+      def selector_count(selector)
+        JS.eval("document.querySelectorAll(" + JSON.generate(selector) + ").length").to_i
+      end
+
       def text(selector = nil)
         target = selector ? query(selector) : document.body
         target ? target[:textContent].to_s : ''
@@ -115,6 +124,16 @@ module Funicular
         report(
           actual.include?(expected.to_s),
           "Expected text to include #{expected.to_s.inspect}",
+          expected.to_s,
+          actual
+        )
+      end
+
+      def assert_no_text(expected, selector = nil)
+        actual = text(selector)
+        report(
+          !actual.include?(expected.to_s),
+          "Expected text not to include #{expected.to_s.inspect}",
           expected.to_s,
           actual
         )


### PR DESCRIPTION
## Why

Dogfooding note from the tsunematsu app (FUNICULAR_NOTES proposal 3): DOMTest has no way to assert that something is absent, so every plugin and app picotest hand-rolls `JS.eval("document.querySelectorAll(...).length")`.

## What

- `assert_no_selector(selector)` — counterpart of `assert_selector`
- `assert_no_text(expected, selector = nil)` — counterpart of `assert_text`
- `selector_count(selector)` — for cardinality checks (N options rendered, N rows after removal)

## Verification

The tsunematsu app's picotest suite (76 tests) runs green with two of its hand-rolled negative checks converted to the new assertions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)