### PR TITLE
Skip validator introspection for readonly schema attributes

### DIFF
--- a/lib/funicular/schema.rb
+++ b/lib/funicular/schema.rb
@@ -34,10 +34,22 @@ module Funicular
     def self.build(model_class, attributes:, endpoints: {}, except: {})
       merged = {}
       attributes.each do |name, definition|
+        # Readonly attributes are server-managed: the client never
+        # submits them, so validating their (nil) client-side value
+        # against e.g. a presence validator would reject every create.
+        # Skip validator introspection for them entirely.
+        if readonly?(definition)
+          merged[name] = definition
+          next
+        end
         rules = rules_for(model_class, name, except_kinds(except, name))
         merged[name] = rules.empty? ? definition : definition.merge(validations: rules)
       end
       { attributes: merged, endpoints: endpoints }
+    end
+
+    def self.readonly?(definition)
+      definition.is_a?(Hash) && !!(definition[:readonly] || definition["readonly"])
     end
 
     # Returns { "attr" => { "presence" => true, "length" => { "maximum" => 30 } } }

--- a/minitest/schema_test.rb
+++ b/minitest/schema_test.rb
@@ -88,6 +88,26 @@ class SchemaDerivationTest < Minitest::Test
     assert_equal({ "update" => { method: "PATCH", path: "/x/:id" } }, schema[:endpoints])
   end
 
+  def test_build_skips_validators_for_readonly_attributes
+    schema = Funicular::Schema.build(
+      Account,
+      attributes: {
+        # name has a presence validator, but a readonly (server-managed)
+        # attribute is never submitted by the client, so its validators
+        # must not be inlined at all.
+        "name" => { type: "string", readonly: true }
+      }
+    )
+    assert_equal({ type: "string", readonly: true }, schema[:attributes]["name"])
+
+    # String keys behave the same.
+    schema = Funicular::Schema.build(
+      Account,
+      attributes: { "name" => { "type" => "string", "readonly" => true } }
+    )
+    refute schema[:attributes]["name"].key?(:validations)
+  end
+
   def test_length_range_is_serialized_as_min_and_max
     klass = Class.new do
       include ActiveModel::Validations


### PR DESCRIPTION
## Why

Dogfooding note from the tsunematsu app (FUNICULAR_NOTES proposal 2): `Funicular::Schema.build` inlines AR validators even for attributes declared `readonly: true`. A server-managed column (`variants.stock`, writable only through `StockMovement.record!`) then fails client-side presence/numericality validation on create, because the client's value is necessarily nil. The app worked around it with `except: { stock: [:presence, :numericality] }`.

## What

`build` skips validator introspection entirely for attributes whose definition carries `readonly: true` (symbol or string keys). The `except:` denylist remains for the finer-grained cases (e.g. suppressing a scoped uniqueness validator on a writable attribute).

## Verification

New minitest cases; full suite green (231 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)