### PR TITLE
Add Funicular::Testing.ensure_compiled! for the test environment

### DIFF
--- a/lib/funicular/testing.rb
+++ b/lib/funicular/testing.rb
@@ -1,11 +1,58 @@
 # frozen_string_literal: true
 
 require_relative "testing/node_runner"
+require_relative "plugin"
+require_relative "compiler"
 
 module Funicular
   module Testing
     def self.run!(**options)
       NodeRunner.new(**options).run
+    end
+
+    # One-call test-environment setup: syncs plugin assets and compiles
+    # the client bundle when it is missing or older than any source or
+    # plugin file. Development recompiles through the middleware and
+    # production through assets:precompile, but the test environment
+    # serves whatever app.mrb is lying around; call this once from
+    # test_helper and rely on the mtime check to keep it cheap.
+    #
+    #   Funicular::Testing.ensure_compiled!            # Rails.root
+    #   Funicular::Testing.ensure_compiled!(force: true)
+    #
+    # Returns the path of the compiled bundle.
+    def self.ensure_compiled!(root: nil, force: false, debug_mode: true)
+      root = Pathname.new(root || default_root)
+      registry = Funicular::Plugin::Registry.new(root)
+      registry.validate!
+      registry.sync_assets
+
+      source_dir = root.join("app", "funicular").to_s
+      output_file = root.join("app", "assets", "builds", "app.mrb").to_s
+      sources = registry.local_source_files + Funicular::Compiler.source_files(source_dir)
+
+      if force || stale?(output_file, sources)
+        Funicular::Compiler.new(
+          source_dir: source_dir,
+          output_file: output_file,
+          debug_mode: debug_mode,
+          prepend_source_files: registry.local_source_files
+        ).compile
+      end
+      output_file
+    end
+
+    # A bundle is stale when it does not exist or any source file was
+    # modified after it was built.
+    def self.stale?(output_file, source_files)
+      return true unless File.exist?(output_file)
+      build_time = File.mtime(output_file)
+      source_files.any? { |f| File.exist?(f) && File.mtime(f) > build_time }
+    end
+
+    def self.default_root
+      raise ArgumentError, "root is required outside Rails" unless defined?(Rails) && Rails.respond_to?(:root)
+      Rails.root
     end
 
     def self.assert_picotests(test_case, result, print_summary: true)

--- a/minitest/testing_ensure_compiled_test.rb
+++ b/minitest/testing_ensure_compiled_test.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "fileutils"
+require "tmpdir"
+
+require "test_helper"
+
+# Covers the freshness decision behind Funicular::Testing.ensure_compiled!.
+# The actual compile (Node + vendored mrbc) is integration-only, matching
+# the compiler tests' scope.
+class TestingEnsureCompiledTest < Minitest::Test
+  def test_stale_when_bundle_is_missing
+    Dir.mktmpdir do |dir|
+      assert Funicular::Testing.stale?(File.join(dir, "app.mrb"), [])
+    end
+  end
+
+  def test_fresh_when_bundle_is_newer_than_every_source
+    Dir.mktmpdir do |dir|
+      source = File.join(dir, "component.rb")
+      output = File.join(dir, "app.mrb")
+      File.write(source, "")
+      File.write(output, "")
+      File.utime(Time.now - 60, Time.now - 60, source)
+
+      refute Funicular::Testing.stale?(output, [ source ])
+    end
+  end
+
+  def test_stale_when_any_source_is_newer_than_the_bundle
+    Dir.mktmpdir do |dir|
+      old_source = File.join(dir, "old.rb")
+      new_source = File.join(dir, "new.rb")
+      output = File.join(dir, "app.mrb")
+      [ old_source, new_source, output ].each { |f| File.write(f, "") }
+      File.utime(Time.now - 60, Time.now - 60, old_source)
+      File.utime(Time.now - 30, Time.now - 30, output)
+      File.utime(Time.now, Time.now, new_source)
+
+      assert Funicular::Testing.stale?(output, [ old_source, new_source ])
+    end
+  end
+
+  def test_missing_sources_do_not_count
+    Dir.mktmpdir do |dir|
+      output = File.join(dir, "app.mrb")
+      File.write(output, "")
+
+      refute Funicular::Testing.stale?(output, [ File.join(dir, "gone.rb") ])
+    end
+  end
+end


### PR DESCRIPTION
## Why

Dogfooding note from the tsunematsu app (FUNICULAR_NOTES proposal 4): the test environment has no compile hook, so apps accumulate boilerplate in test_helper (plugin asset sync + compile-if-missing) and in their system test case (unconditional recompile), and still risk stale bundles.

## What

`Funicular::Testing.ensure_compiled!(root: nil, force: false, debug_mode: true)`:

- syncs plugin assets via the registry
- compiles when app.mrb is missing **or older than any app/plugin source** (mtime check) — cheaper than always recompiling, safer than compile-if-missing
- returns the bundle path; `force: true` for unconditional rebuilds

## Verification

- New minitest coverage for the staleness decision (suite green, 234 tests)
- The tsunematsu app replaced both boilerplate blocks with the single call; unit + system suites run green, and touching a component source triggers the recompile path

🤖 Generated with [Claude Code](https://claude.com/claude-code)