### PR TITLE
Reload edited app sources for SSR in development

### DIFF
--- a/lib/funicular/railtie.rb
+++ b/lib/funicular/railtie.rb
@@ -9,6 +9,11 @@ module Funicular
     initializer "funicular.middleware" do |app|
       if Rails.env.development?
         app.middleware.use Funicular::Middleware
+        # The middleware recompiles the client bundle on change; SSR
+        # must reload the same sources, or server-rendered markup goes
+        # stale until a restart while hydration is already fresh.
+        require "funicular/ssr/runtime"
+        Funicular::SSR::Runtime.auto_reload = true
       end
     end
 

--- a/lib/funicular/ssr/runtime.rb
+++ b/lib/funicular/ssr/runtime.rb
@@ -15,6 +15,7 @@ module Funicular
     # (Funicular.start, Router#start, FileUpload.mount, Debug) no-ops.
     module Runtime
       MRBLIB_DIR = File.expand_path("../../../mrblib", __dir__)
+      BOOT_MUTEX = Mutex.new
 
       # Load order is by dependency at *class-body* evaluation time. Most
       # files reference JS / other classes only inside methods, so only a
@@ -79,23 +80,32 @@ module Funicular
         # Funicular.start builds a fresh router, so routes refresh too.
         # Without it, restart the server to pick up changes.
         def boot!(source_dir)
-          load_framework!
-          if @app_loaded
-            return unless auto_reload && sources_changed?(source_dir)
-          end
+          # Fast path for the steady production/test state: everything
+          # loaded and nobody watching for changes, no lock to take.
+          return if @framework_loaded && @app_loaded && !auto_reload
 
-          files = Funicular::Compiler.source_files(source_dir.to_s)
-          files.each do |file|
-            begin
-              Kernel.load(file)
-            rescue TypeError => e
-              # Funicular model name conflicts with an already-loaded AR model.
-              # The constant is already defined; safe to skip.
-              warn "[Funicular SSR] Skipped #{File.basename(file)}: #{e.message}"
+          # Concurrent renders (Puma threads in development) must not
+          # interleave two reloads: constants and the router would pass
+          # through inconsistent states mid-request.
+          BOOT_MUTEX.synchronize do
+            load_framework!
+            if @app_loaded
+              next unless auto_reload && sources_changed?(source_dir)
             end
+
+            files = Funicular::Compiler.source_files(source_dir.to_s)
+            files.each do |file|
+              begin
+                Kernel.load(file)
+              rescue TypeError => e
+                # Funicular model name conflicts with an already-loaded AR model.
+                # The constant is already defined; safe to skip.
+                warn "[Funicular SSR] Skipped #{File.basename(file)}: #{e.message}"
+              end
+            end
+            @app_loaded = true
+            @sources_snapshot = sources_snapshot(source_dir)
           end
-          @app_loaded = true
-          @sources_snapshot = sources_snapshot(source_dir)
         end
 
         # Reload edited app sources on the next boot! instead of
@@ -108,7 +118,7 @@ module Funicular
 
         def sources_snapshot(source_dir)
           Funicular::Compiler.source_files(source_dir.to_s).map do |file|
-            [ file, File.exist?(file) ? File.mtime(file).to_f : nil ]
+            [ file, mtime_or_nil(file) ]
           end
         end
 
@@ -116,10 +126,22 @@ module Funicular
         # app (or a reload) can be booted. Does not unload the framework.
         def reset_app!
           @app_loaded = false
+          @sources_snapshot = nil
         end
 
         def framework_loaded?
           !!@framework_loaded
+        end
+
+        private
+
+        # The mtime read races with editors deleting or renaming files
+        # mid-edit; a vanished file counts as nil instead of breaking
+        # the render.
+        def mtime_or_nil(file)
+          File.mtime(file).to_f
+        rescue SystemCallError
+          nil
         end
       end
     end

--- a/lib/funicular/ssr/runtime.rb
+++ b/lib/funicular/ssr/runtime.rb
@@ -73,10 +73,16 @@ module Funicular
         # In that case we rescue and continue: the AR constant is already defined
         # and is all that load_schemas needs (it ignores the hash on the server).
         #
-        # Loaded once per process. Restart the server to pick up changes.
+        # Loaded once per process. With auto_reload (the railtie enables
+        # it in development), edited sources are picked up on the next
+        # render: reloading re-runs the initializer, and the server-side
+        # Funicular.start builds a fresh router, so routes refresh too.
+        # Without it, restart the server to pick up changes.
         def boot!(source_dir)
           load_framework!
-          return if @app_loaded
+          if @app_loaded
+            return unless auto_reload && sources_changed?(source_dir)
+          end
 
           files = Funicular::Compiler.source_files(source_dir.to_s)
           files.each do |file|
@@ -89,6 +95,21 @@ module Funicular
             end
           end
           @app_loaded = true
+          @sources_snapshot = sources_snapshot(source_dir)
+        end
+
+        # Reload edited app sources on the next boot! instead of
+        # requiring a server restart (meant for development).
+        attr_accessor :auto_reload
+
+        def sources_changed?(source_dir)
+          @sources_snapshot != sources_snapshot(source_dir)
+        end
+
+        def sources_snapshot(source_dir)
+          Funicular::Compiler.source_files(source_dir.to_s).map do |file|
+            [ file, File.exist?(file) ? File.mtime(file).to_f : nil ]
+          end
         end
 
         # Test/escape hatch: forget loaded application state so a different

--- a/minitest/ssr_reload_test.rb
+++ b/minitest/ssr_reload_test.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+require "fileutils"
+require "tmpdir"
+
+require "test_helper"
+
+# Development-mode SSR reload: with auto_reload enabled (the railtie
+# turns it on in development), editing an app source makes the next
+# boot! re-load the sources, so server-rendered markup matches what the
+# recompiled client bundle will hydrate.
+class SSRReloadTest < Minitest::Test
+  def setup
+    Funicular::SSR::Runtime.load_framework!
+  end
+
+  def teardown
+    Funicular::SSR::Runtime.auto_reload = false
+    Funicular::SSR::Runtime.reset_app!
+  end
+
+  def write_component(dir, title)
+    File.write(File.join(dir, "components", "reload_probe_component.rb"), <<~RUBY)
+      class ReloadProbeComponent < Funicular::Component
+        def render
+          div { "#{title}" }
+        end
+      end
+    RUBY
+  end
+
+  def build_app(dir)
+    FileUtils.mkdir_p(File.join(dir, "components"))
+    write_component(dir, "before reload")
+    File.write(File.join(dir, "initializer.rb"), <<~RUBY)
+      Funicular.start(container: "app") do |router|
+        router.get("/probe", to: ReloadProbeComponent, as: "probe")
+      end
+    RUBY
+  end
+
+  def render_probe(dir)
+    Funicular::SSR.render(path: "/probe", source_dir: dir)[:html]
+  end
+
+  def quietly
+    original_verbose = $VERBOSE
+    $VERBOSE = nil
+    yield
+  ensure
+    $VERBOSE = original_verbose
+  end
+
+  def test_edited_sources_are_reloaded_when_auto_reload_is_on
+    Dir.mktmpdir do |dir|
+      build_app(dir)
+      Funicular::SSR::Runtime.reset_app!
+      assert_includes render_probe(dir), "before reload"
+
+      write_component(dir, "after reload")
+      bump_mtime(dir)
+
+      # Off (the default): still the stale markup.
+      assert_includes render_probe(dir), "before reload"
+
+      Funicular::SSR::Runtime.auto_reload = true
+      quietly do
+        assert_includes render_probe(dir), "after reload"
+      end
+    end
+  end
+
+  def test_unchanged_sources_are_not_reloaded
+    Dir.mktmpdir do |dir|
+      build_app(dir)
+      Funicular::SSR::Runtime.reset_app!
+      Funicular::SSR::Runtime.auto_reload = true
+      quietly { render_probe(dir) }
+
+      refute Funicular::SSR::Runtime.sources_changed?(dir)
+    end
+  end
+
+  private
+
+  # mtime comparison, not equality of content: make the edit observable
+  # even on filesystems with coarse timestamps.
+  def bump_mtime(dir)
+    future = Time.now + 2
+    Dir.glob(File.join(dir, "**", "*.rb")).each do |file|
+      File.utime(future, future, file)
+    end
+  end
+end

--- a/minitest/ssr_reload_test.rb
+++ b/minitest/ssr_reload_test.rb
@@ -70,6 +70,18 @@ class SSRReloadTest < Minitest::Test
     end
   end
 
+  def test_reset_app_discards_the_snapshot
+    Dir.mktmpdir do |dir|
+      build_app(dir)
+      Funicular::SSR::Runtime.reset_app!
+      quietly { render_probe(dir) }
+      refute Funicular::SSR::Runtime.sources_changed?(dir)
+
+      Funicular::SSR::Runtime.reset_app!
+      assert Funicular::SSR::Runtime.sources_changed?(dir)
+    end
+  end
+
   def test_unchanged_sources_are_not_reloaded
     Dir.mktmpdir do |dir|
       build_app(dir)


### PR DESCRIPTION
## Why

Dogfooding note from the tsunematsu app (FUNICULAR_NOTES proposal 6): `Funicular::SSR::Runtime` loads app sources once per process, while the dev middleware recompiles app.mrb on change. After editing a component, the hydrated page is new but the server-rendered HTML stays stale until the Rails server restarts — confusing precisely because half the stack did update.

## What

- `Runtime.boot!` snapshots the source file list + mtimes; with `Runtime.auto_reload` enabled it re-loads the app sources when the snapshot changed (re-running the initializer also rebuilds the server-side router, so routes refresh)
- The railtie enables `auto_reload` in development, next to the recompile middleware
- Production/test keep the load-once behavior

## Verification

New minitest cases (reload picks up an edited component; unchanged sources are not re-loaded); full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)