### PR TITLE
Name the culprit when callbacks raise; alias Response#body to data

### DIFF
--- a/minitest/callback_error_visibility_test.rb
+++ b/minitest/callback_error_visibility_test.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# The mrblib runtime is plain Ruby, so the CRuby suite can cover the
+# Response#body alias and the handler error report format directly;
+# the browser-side wiring ships with the next picoruby.wasm rebuild.
+class CallbackErrorVisibilityTest < Minitest::Test
+  def setup
+    Funicular::SSR::Runtime.load_framework!
+  end
+
+  # Assigning the anonymous class to a constant names it, so the report
+  # prints a real component name. Defined lazily: Funicular::Component
+  # only exists after the framework loads.
+  def probe_component
+    unless defined?(::CheckoutProbeComponent)
+      Object.const_set(:CheckoutProbeComponent, Class.new(Funicular::Component) do
+        def render; end
+      end)
+    end
+    ::CheckoutProbeComponent.new
+  end
+
+  def test_response_body_is_an_alias_of_data
+    response = Funicular::HTTP::Response.new(200, { "id" => 1 })
+    assert_equal response.data, response.body
+    assert_equal({ "id" => 1 }, response.body)
+  end
+
+  def test_report_handler_error_names_component_handler_and_event
+    error = ArgumentError.new("wrong number of arguments (given 1, expected 0)")
+
+    out, _err = capture_io do
+      probe_component.report_handler_error("click", "#handle_save", error)
+    end
+
+    assert_includes out, "CheckoutProbeComponent#handle_save"
+    assert_includes out, "(onclick)"
+    assert_includes out, "ArgumentError: wrong number of arguments"
+  end
+
+  def test_report_handler_error_never_raises
+    capture_io do
+      assert_nil probe_component.report_handler_error("click", "#x", RuntimeError.new("y"))
+    end
+  end
+end

--- a/mrblib/component.rb
+++ b/mrblib/component.rb
@@ -656,6 +656,7 @@ module Funicular
             begin
               self.send(value, event)
             rescue => e
+              report_handler_error(event_name, "##{value}", e)
               component_raised(e) if respond_to?(:component_raised)
               raise e
             end
@@ -672,6 +673,7 @@ module Funicular
                 value.call(event)
               end
             rescue => e
+              report_handler_error(event_name, "##{value.name}", e)
               component_raised(e) if respond_to?(:component_raised)
               raise e
             end
@@ -688,6 +690,7 @@ module Funicular
                 value.call(event)
               end
             rescue => e
+              report_handler_error(event_name, "(proc)", e)
               component_raised(e) if respond_to?(:component_raised)
               raise e
             end
@@ -718,6 +721,18 @@ module Funicular
           end
         end
       end
+    end
+
+    # Name the culprit before an event handler error is re-raised into
+    # the JS bridge, where "Callback <id>: ArgumentError: ..." carries no
+    # hint of which component or handler it came from. Uses puts so the
+    # message reaches the browser console (same idiom as the
+    # ErrorBoundary logger). Never raises itself.
+    def report_handler_error(event_name, handler, error)
+      puts "[Funicular] #{self.class}#{handler} (on#{event_name}) raised " \
+           "#{error.class}: #{error.message}"
+    rescue
+      nil
     end
 
     # Collect ref elements from VDOM

--- a/mrblib/http.rb
+++ b/mrblib/http.rb
@@ -3,6 +3,10 @@ module Funicular
     class Response
       attr_reader :data, :status, :ok
 
+      # Every mainstream HTTP client calls the payload `body`; keep
+      # that name working alongside `data`.
+      alias body data
+
       def initialize(status, data)
         @status = status
         @ok = @status >= 200 && @status < 300
@@ -125,8 +129,16 @@ module Funicular
           # invalid URL) must still deliver a response -- a hanging
           # callback would hang the schema barrier and every REST
           # caller. An exception out of the caller's OWN block must
-          # NOT settle a second time.
-          raise e if settled
+          # NOT settle a second time. It is re-raised into the JS
+          # bridge, where it can vanish silently, so name the culprit
+          # on the console first: a swallowed typo in a response
+          # handler otherwise just freezes the page in its loading
+          # state.
+          if settled
+            puts "[Funicular::HTTP] #{method} #{url} callback raised " \
+                 "#{e.class}: #{e.message}"
+            raise e
+          end
           settled = true
           if block
             block.call(Response.new(0,


### PR DESCRIPTION
## Why

Dogfooding notes from the tsunematsu app (FUNICULAR_NOTES proposals 1 and 5):

1. Event handler errors surface as `Callback <id>: ArgumentError: wrong number of arguments (given 1, expected 0)` with no component or handler name — arity mistakes (`def handler` vs `def handler(event)`) take real digging to find.
2. Exceptions raised inside `Funicular::HTTP` response callbacks re-raise into the JS bridge and can vanish silently. Six storefront components written against `response.body` (instead of `#data`) froze on their loading state with zero console output; only a real-browser selenium test caught it.

## What

- `bind_events` prints `[Funicular] SomeComponent#handler (onclick) raised ArgumentError: ...` before re-raising (Symbol / Method / Proc handlers all covered; the reporter itself never raises)
- `HTTP.request` prints `[Funicular::HTTP] GET /url callback raised NoMethodError: ...` before re-raising an exception that came out of the caller's own block (the exactly-once settle semantics are unchanged)
- `Response#body` becomes an alias of `#data` — the name every mainstream HTTP client uses

## Notes

The mrblib changes reach browsers with the next picoruby.wasm rebuild; the SSR (CRuby) side is live immediately. New minitest coverage for the alias and the report format; full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)