### PR TITLE
Add StyleValue#+ for one-off class additions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,14 @@ of truth. Entries below accumulate as the feature lands.
 
 - `Funicular::StyleValue#+`: styles now support one-off class
   additions (`styles.field + " col-span-2"`) instead of raising
-  NoMethodError. `+` concatenates verbatim like String#+; `|` remains
-  the space-joining combinator. `to_str` is deliberately not defined:
-  the mruby client's String#+ never coerces implicitly, so defining it
-  on CRuby would let SSR accept `"base " + styles.field` while the
-  browser raises; both VMs reject that form identically instead.
+  NoMethodError. `+` concatenates verbatim like String#+, accepts
+  String or StyleValue, and raises TypeError for anything else
+  (matching String#+ instead of silently to_s-ing mistakes); `|`
+  remains the space-joining combinator. `to_str` is deliberately not
+  defined: the mruby client's String#+ never coerces implicitly, so
+  defining it on CRuby would let SSR accept `"base " + styles.field`
+  while the browser raises; both VMs reject that form identically
+  instead.
 
 - Navigation guard: a component can veto leaving by overriding
   `navigation_guard` to return a confirmation message (nil allows).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ of truth. Entries below accumulate as the feature lands.
 
 ### Added
 
+- `Funicular::StyleValue#+`: styles now support one-off class
+  additions (`styles.field + " col-span-2"`) instead of raising
+  NoMethodError. `+` concatenates verbatim like String#+; `|` remains
+  the space-joining combinator. `to_str` is deliberately not defined:
+  the mruby client's String#+ never coerces implicitly, so defining it
+  on CRuby would let SSR accept `"base " + styles.field` while the
+  browser raises; both VMs reject that form identically instead.
+
 - Navigation guard: a component can veto leaving by overriding
   `navigation_guard` to return a confirmation message (nil allows).
   The router consults it before `navigate` (including `link_to

--- a/minitest/dsl_test.rb
+++ b/minitest/dsl_test.rb
@@ -164,6 +164,28 @@ class DSLTest < Minitest::Test
     assert_equal "btn btn--on extra", vnode.children[2].props[:class]
   end
 
+  def test_style_value_behaves_like_the_string_it_wraps
+    klass = Class.new(Funicular::Component) do
+      styles do
+        field "field-base"
+      end
+
+      def render
+        div(class: styles.field + " col-span-2") { "x" }
+      end
+    end
+
+    vnode = klass.new.build_vdom
+    assert_equal "field-base col-span-2", vnode.props[:class]
+
+    value = klass.new.styles.field
+    assert_kind_of Funicular::StyleValue, value + "!"
+    # No to_str on purpose: the mruby client's String#+ never coerces,
+    # so CRuby must reject the reversed form the same way the browser
+    # does instead of letting SSR accept code the client raises on.
+    assert_raises(TypeError) { "prefix " + value }
+  end
+
   def test_unknown_style_raises
     klass = Class.new(Funicular::Component) do
       styles do

--- a/minitest/dsl_test.rb
+++ b/minitest/dsl_test.rb
@@ -179,7 +179,12 @@ class DSLTest < Minitest::Test
     assert_equal "field-base col-span-2", vnode.props[:class]
 
     value = klass.new.styles.field
-    assert_kind_of Funicular::StyleValue, value + "!"
+    combined = value + "!"
+    assert_kind_of Funicular::StyleValue, combined
+    assert_equal "field-base!", combined.to_s
+    assert_equal "field-basefield-base", (value + value).to_s
+    # Like String#+: non-String operands raise instead of being to_s-ed.
+    assert_raises(TypeError) { value + 123 }
     # No to_str on purpose: the mruby client's String#+ never coerces,
     # so CRuby must reject the reversed form the same way the browser
     # does instead of letting SSR accept code the client raises on.

--- a/mrblib/styles.rb
+++ b/mrblib/styles.rb
@@ -20,6 +20,16 @@ module Funicular
       end
     end
 
+    # String-like concatenation: styles.field + " col-span-2". No space
+    # is inserted, matching String#+; use | to join with a space.
+    # to_str is deliberately not defined: the mruby client's String#+
+    # never coerces (no implicit to_str call), so defining it on CRuby
+    # would let SSR accept "base " + styles.field while the browser
+    # raises. Both VMs reject the reversed form the same way instead.
+    def +(other)
+      StyleValue.new("#{@value}#{other}")
+    end
+
     def to_s
       @value
     end

--- a/mrblib/styles.rb
+++ b/mrblib/styles.rb
@@ -21,13 +21,23 @@ module Funicular
     end
 
     # String-like concatenation: styles.field + " col-span-2". No space
-    # is inserted, matching String#+; use | to join with a space.
+    # is inserted and non-String operands raise TypeError, matching
+    # String#+ (a silent to_s would hide mistakes like `+ 123`); use |
+    # to join with a space.
     # to_str is deliberately not defined: the mruby client's String#+
     # never coerces (no implicit to_str call), so defining it on CRuby
     # would let SSR accept "base " + styles.field while the browser
     # raises. Both VMs reject the reversed form the same way instead.
     def +(other)
-      StyleValue.new("#{@value}#{other}")
+      case other
+      when StyleValue
+        StyleValue.new(@value + other.value)
+      when String
+        StyleValue.new(@value + other)
+      else
+        other = other #: untyped
+        raise TypeError, "no implicit conversion of #{other.class} into String"
+      end
     end
 
     def to_s

--- a/sig/styles.rbs
+++ b/sig/styles.rbs
@@ -4,6 +4,7 @@ module Funicular
     attr_reader value: String
     def initialize: (String | untyped value) -> void
     def |: (StyleValue | String | nil other) -> StyleValue
+    def +: (untyped other) -> StyleValue
     def to_s: () -> String
   end
 

--- a/sig/styles.rbs
+++ b/sig/styles.rbs
@@ -4,7 +4,7 @@ module Funicular
     attr_reader value: String
     def initialize: (String | untyped value) -> void
     def |: (StyleValue | String | nil other) -> StyleValue
-    def +: (untyped other) -> StyleValue
+    def +: (StyleValue | String other) -> StyleValue
     def to_s: () -> String
   end
 

--- a/test/dsl_test.rb
+++ b/test/dsl_test.rb
@@ -171,7 +171,12 @@ class DSLTest < Picotest::Test
     assert_equal("field-base col-span-2", vnode.props[:class])
 
     value = klass.new.styles.field
-    assert_equal("field-base!", (value + "!").to_s)
+    combined = value + "!"
+    assert_equal(Funicular::StyleValue, combined.class)
+    assert_equal("field-base!", combined.to_s)
+    assert_equal("field-basefield-base", (value + value).to_s)
+    # Like String#+: non-String operands raise instead of being to_s-ed.
+    assert_raise(TypeError) { value + 123 }
     # String#+ on this VM never coerces via to_str; the reversed form
     # raises here exactly like it does on the CRuby SSR side.
     assert_raise(TypeError) { "prefix " + value }

--- a/test/dsl_test.rb
+++ b/test/dsl_test.rb
@@ -156,6 +156,27 @@ class DSLTest < Picotest::Test
     assert_equal("btn btn--on extra", vnode.children[2].props[:class])
   end
 
+  def test_style_value_behaves_like_the_string_it_wraps
+    klass = Class.new(Funicular::Component) do
+      styles do
+        field "field-base"
+      end
+
+      def render
+        div(class: styles.field + " col-span-2") { "x" }
+      end
+    end
+
+    vnode = klass.new.build_vdom
+    assert_equal("field-base col-span-2", vnode.props[:class])
+
+    value = klass.new.styles.field
+    assert_equal("field-base!", (value + "!").to_s)
+    # String#+ on this VM never coerces via to_str; the reversed form
+    # raises here exactly like it does on the CRuby SSR side.
+    assert_raise(TypeError) { "prefix " + value }
+  end
+
   def test_unknown_style_raises
     klass = Class.new(Funicular::Component) do
       styles do


### PR DESCRIPTION
## Summary

`styles.field + " col-span-2"` raised `NoMethodError`, so one-off class additions had to fall back to string interpolation (`"#{'#{styles.field}'} col-span-2"`). This PR adds `Funicular::StyleValue#+`, which concatenates verbatim like `String#+` and returns a `StyleValue`. `|` remains the space-joining combinator.

## Why no to_str

The original proposal (tsunematsu FUNICULAR_NOTES item 7) also suggested `to_str` for implicit String coercion. That turned out to be a trap: the bundled mruby's `String#+` never coerces via `to_str` — `mrb_ensure_string_type` (src/object.c) raises `TypeError` for any non-String. Defining `to_str` only on the CRuby side would let SSR happily render `"base " + styles.field` while the browser raises. Instead, both suites now assert the reversed form fails identically on both VMs, keeping SSR/client parity.

## Testing

- `bundle exec rake`: 242 tests green (includes the new minitest twin asserting `+` and the symmetric `TypeError`)
- picotest twin added in test/dsl_test.rb
- Dogfooded in the tsunematsu app: mypage profile component now uses `styles.field + " col-span-2"`; selenium system tests against the rebuilt picoruby.wasm are green (10 runs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)