### PR TITLE
Add Funicular::SSR.render_component for embedding into ERB pages

### DIFF
--- a/lib/funicular/ssr.rb
+++ b/lib/funicular/ssr.rb
@@ -37,6 +37,27 @@ module Funicular
       { html: html, state: state, component: component_class }
     end
 
+    # Render one component to an HTML string with no route lookup: for
+    # embedding a Funicular component into an otherwise server-rendered
+    # (ERB) page -- a shared site header, say -- so the markup has a
+    # single source of truth. The component is named by string and
+    # resolved after boot!, because host apps keep app/funicular out of
+    # Rails autoloading and the constant does not exist before loading.
+    # Handlers are not bound and no hydration happens: the output is
+    # static HTML (links still work; onclick and friends do not).
+    def self.render_component(component_name, props: {}, state: {}, source_dir: nil)
+      Runtime.boot!(source_dir || default_source_dir)
+
+      router = Funicular.router
+      raise "Funicular router is not configured; check app/funicular/initializer.rb" unless router
+
+      component_class = Object.const_get(component_name.to_s)
+      instance = component_class.new(symbolize_keys(props))
+      instance.runtime = Funicular::Runtime.new(router)
+      instance.seed_state(state)
+      Funicular::VDOM::HTMLSerializer.serialize(instance.build_vdom, instance.runtime)
+    end
+
     def self.default_source_dir
       raise "source_dir is required outside Rails" unless defined?(Rails) && Rails.respond_to?(:root)
       Rails.root.join("app", "funicular")

--- a/lib/funicular/ssr.rb
+++ b/lib/funicular/ssr.rb
@@ -52,6 +52,10 @@ module Funicular
       raise "Funicular router is not configured; check app/funicular/initializer.rb" unless router
 
       component_class = Object.const_get(component_name.to_s)
+      unless component_class.is_a?(Class) && component_class < Funicular::Component
+        raise ArgumentError, "#{component_name} is not a Funicular::Component subclass"
+      end
+
       instance = component_class.new(symbolize_keys(props))
       instance.runtime = Funicular::Runtime.new(router)
       instance.seed_state(state)

--- a/minitest/fixtures/funicular_app/components/probe_component.rb
+++ b/minitest/fixtures/funicular_app/components/probe_component.rb
@@ -1,0 +1,15 @@
+# Reads both props and state so SSR.render_component tests can assert
+# each channel is wired through. Not routed on purpose: rendering it
+# is only possible through the single-component entry point.
+class ProbeComponent < Funicular::Component
+  def initialize_state
+    { note: "default note" }
+  end
+
+  def render
+    div(class: "probe") do
+      h2 { props[:label].to_s }
+      p { state[:note] }
+    end
+  end
+end

--- a/minitest/ssr_test.rb
+++ b/minitest/ssr_test.rb
@@ -122,6 +122,29 @@ class SSRTest < Minitest::Test
     assert_includes result[:html], "greeting"
   end
 
+  # --- Single-component render (no route lookup) ------------------------
+
+  def test_render_component_renders_by_name_with_props_and_state
+    html = Funicular::SSR.render_component(
+      "GreetingComponent",
+      state: { title: "Embedded" },
+      source_dir: APP_DIR
+    )
+    assert_includes html, "<h1>Embedded</h1>"
+    assert_includes html, 'class="greeting"'
+  end
+
+  def test_render_component_uses_initialize_state_without_injection
+    html = Funicular::SSR.render_component("GreetingComponent", source_dir: APP_DIR)
+    assert_includes html, "<h1>Default Title</h1>"
+  end
+
+  def test_render_component_raises_on_unknown_component
+    assert_raises(NameError) do
+      Funicular::SSR.render_component("NoSuchComponent", source_dir: APP_DIR)
+    end
+  end
+
   def test_symbolize_keys_handles_nil_and_string_keys
     assert_equal({}, Funicular::SSR.symbolize_keys(nil))
     assert_equal({ a: 1, b: 2 }, Funicular::SSR.symbolize_keys("a" => 1, "b" => 2))

--- a/minitest/ssr_test.rb
+++ b/minitest/ssr_test.rb
@@ -124,7 +124,7 @@ class SSRTest < Minitest::Test
 
   # --- Single-component render (no route lookup) ------------------------
 
-  def test_render_component_renders_by_name_with_props_and_state
+  def test_render_component_renders_by_name_without_a_route
     html = Funicular::SSR.render_component(
       "GreetingComponent",
       state: { title: "Embedded" },
@@ -132,6 +132,17 @@ class SSRTest < Minitest::Test
     )
     assert_includes html, "<h1>Embedded</h1>"
     assert_includes html, 'class="greeting"'
+  end
+
+  def test_render_component_passes_props_and_state
+    html = Funicular::SSR.render_component(
+      "ProbeComponent",
+      props: { "label" => "From Props" },
+      state: { note: "injected note" },
+      source_dir: APP_DIR
+    )
+    assert_includes html, "<h2>From Props</h2>"
+    assert_includes html, "<p>injected note</p>"
   end
 
   def test_render_component_uses_initialize_state_without_injection
@@ -143,6 +154,13 @@ class SSRTest < Minitest::Test
     assert_raises(NameError) do
       Funicular::SSR.render_component("NoSuchComponent", source_dir: APP_DIR)
     end
+  end
+
+  def test_render_component_rejects_a_non_component_constant
+    error = assert_raises(ArgumentError) do
+      Funicular::SSR.render_component("String", source_dir: APP_DIR)
+    end
+    assert_match(/not a Funicular::Component/, error.message)
   end
 
   def test_symbolize_keys_handles_nil_and_string_keys


### PR DESCRIPTION
SSR.render only renders by route lookup, so a server-rendered (ERB) page could not reuse a Funicular component -- a shared site header, say -- without either duplicating its markup or reaching into SSR internals. render_component renders one component by name to static HTML (no handlers, no hydration; links still work). The name is a string resolved after boot! because host apps keep app/funicular out of Rails autoloading.

First consumer: sake-tsunematsu.com's cart/checkout pages, which are plain ERB but want the same StorefrontNavComponent header as the SPA pages.