### PR TITLE
Fix keyed child reordering

### DIFF
--- a/mrblib/differ.rb
+++ b/mrblib/differ.rb
@@ -103,8 +103,8 @@ module Funicular
       # The new shape is `[[:keyed_children, ops, removes]]`, applied as
       # three phases by the patcher:
       #   1. removes (descending old_index, against the original DOM snapshot)
-      #   2. content updates for kept children (against the snapshot, no move)
-      #   3. inserts in ascending new_index using insertBefore on the live DOM
+      #   2. content updates for kept children (against the snapshot)
+      #   3. kept-node moves and inserts in new-index order on the live DOM
       def self.diff_children_with_keys(old_children, new_children)
         # 1. Build key map from old children
         old_key_map = {} #: Hash[untyped, [Integer, child_t]]
@@ -127,7 +127,7 @@ module Funicular
               matched_old_indices[old_index] = true
               child_patches = diff(old_child, new_child)
               ops << [:keep, old_index, new_index, child_patches]
-              has_change = true unless child_patches.empty?
+              has_change = true if old_index != new_index || !child_patches.empty?
             else
               ops << [:insert, new_index, new_child]
               has_change = true

--- a/mrblib/patcher.rb
+++ b/mrblib/patcher.rb
@@ -65,13 +65,12 @@ module Funicular
             #   1. snapshot DOM children, then remove unmatched keyed old
             #      children (descending old_index so the snapshot indices
             #      remain valid as removes happen).
-            #   2. apply content updates to kept children in place. The
+            #   2. apply content updates to kept children. The
             #      lookup is by snapshot[old_index], so updates are stable
-            #      regardless of subsequent insertions.
-            #   3. insert new children at their new_index using
-            #      insertBefore on the live DOM. Processed in ascending
-            #      new_index order so each insertion fixes its own
-            #      position before later inserts run.
+            #      regardless of removals.
+            #   3. place kept and new children at their new_index using
+            #      insertBefore on the live DOM. Ops are already in ascending
+            #      new_index order, so each placement fixes the next position.
             ops = patch[1]
             removes = patch[2]
 
@@ -90,7 +89,7 @@ module Funicular
               parent_el.removeChild(target) if parent_el
             end
 
-            # Phase 2: updates against the snapshot (no movement)
+            # Phase 2: updates against the snapshot
             ops.each do |op|
               next unless op[0] == :keep
               old_index = op[1]
@@ -98,19 +97,23 @@ module Funicular
               next if child_patches.empty?
               target = snapshot[old_index]
               next if target.nil?
-              apply(target, child_patches)
+              snapshot[old_index] = apply(target, child_patches)
             end
 
-            # Phase 3: inserts in ascending new_index order
+            # Phase 3: moves and inserts in ascending new_index order
             ops.each do |op|
-              next unless op[0] == :insert
-              new_index = op[1]
-              new_vnode = op[2]
-              new_node = create_element(new_vnode)
+              if op[0] == :keep
+                new_node = snapshot[op[1]]
+                new_index = op[2]
+              elsif op[0] == :insert
+                new_index = op[1]
+                new_node = create_element(op[2])
+              end
               next if new_node.nil?
               live_nodes = element[:childNodes]
               live_arr = live_nodes.is_a?(JS::Object) ? live_nodes.to_a : [] #: Array[untyped]
               ref = live_arr[new_index]
+              next if ref == new_node
               if ref.nil?
                 element.appendChild(new_node) if element.is_a?(JS::Element)
               else

--- a/mrblib/patcher.rb
+++ b/mrblib/patcher.rb
@@ -31,9 +31,13 @@ module Funicular
             # Apply internal patches and get the potentially new root element
             new_dom_element = Patcher.new(@doc, instance.runtime).apply(old_dom_element, internal_patches)
 
-            # Update the instance's reference to its root DOM element if it changed
+            # Update the instance's reference to its root DOM element if it
+            # changed. The new root must also become this apply's return
+            # value; otherwise a caller that stores the result (for example
+            # the keyed_children snapshot) keeps pointing at a detached node.
             if new_dom_element != old_dom_element && new_dom_element.is_a?(JS::Element)
               instance.dom_element = new_dom_element
+              result = new_dom_element
             end
 
             # Update the instance's VDOM to the new one AFTER applying patches
@@ -71,11 +75,17 @@ module Funicular
             #   3. place kept and new children at their new_index using
             #      insertBefore on the live DOM. Ops are already in ascending
             #      new_index order, so each placement fixes the next position.
+            #
+            # Phase 3 tracks the live child order in a Ruby array instead of
+            # re-reading childNodes per op. Every childNodes.to_a allocates a
+            # fresh JS::Object wrapper per node, so wrappers of the same DOM
+            # node never compare equal and the read itself is O(n) across the
+            # wasm boundary. Identity is therefore decided with equal? on the
+            # snapshot objects, which is both exact and free.
             ops = patch[1]
             removes = patch[2]
 
-            child_nodes = element[:childNodes]
-            snapshot = child_nodes.is_a?(JS::Object) ? child_nodes.to_a : [] #: Array[untyped]
+            snapshot = child_nodes_array(element)
 
             # Phase 1: removes (descending old_index)
             sorted_removes = removes.sort { |a, b| b[0] <=> a[0] }
@@ -87,6 +97,7 @@ module Funicular
               unmount_component(old_vnode)
               parent_el = target.parentElement
               parent_el.removeChild(target) if parent_el
+              snapshot[old_index] = nil
             end
 
             # Phase 2: updates against the snapshot
@@ -100,32 +111,42 @@ module Funicular
               snapshot[old_index] = apply(target, child_patches)
             end
 
-            # Phase 3: moves and inserts in ascending new_index order
+            # Phase 3: moves and inserts in ascending new_index order.
+            # `live` mirrors the DOM child order after phases 1 and 2 and is
+            # updated alongside every DOM mutation, so a node already sitting
+            # at new_index is left untouched (no detach/re-attach).
+            live = snapshot.compact #: Array[untyped]
             ops.each do |op|
-              if op[0] == :keep
+              case op[0]
+              when :keep
                 new_node = snapshot[op[1]]
                 new_index = op[2]
-              elsif op[0] == :insert
+              when :insert
                 new_index = op[1]
                 new_node = create_element(op[2])
+              else
+                next
               end
               next if new_node.nil?
-              live_nodes = element[:childNodes]
-              live_arr = live_nodes.is_a?(JS::Object) ? live_nodes.to_a : [] #: Array[untyped]
-              ref = live_arr[new_index]
-              next if ref == new_node
-              if ref.nil?
-                element.appendChild(new_node) if element.is_a?(JS::Element)
+              current = live[new_index]
+              next if current.equal?(new_node)
+              live.delete_if { |n| n.equal?(new_node) }
+              if new_index < live.length
+                live.insert(new_index, new_node)
               else
-                element.insertBefore(new_node, ref) if element.is_a?(JS::Element)
+                live << new_node
+              end
+              next unless element.is_a?(JS::Element)
+              if current.nil?
+                element.appendChild(new_node)
+              else
+                element.insertBefore(new_node, current)
               end
             end
           when Integer
             child_index = patch[0]
             child_patches = patch[1]
-            # Use childNodes instead of children to include text nodes
-            child_nodes = element[:childNodes]
-            children = child_nodes.is_a?(JS::Object) ? child_nodes.to_a : [] #: Array[JS::Object]
+            children = child_nodes_array(element)
             child_element = children[child_index]
             if child_element.nil?
               # No existing child at this index - we need to create new elements
@@ -152,6 +173,14 @@ module Funicular
       end
 
       private
+
+      # childNodes (not children) so that text nodes are included. Each call
+      # crosses the wasm boundary once per child, so callers should read it
+      # once and work on the returned array.
+      def child_nodes_array(element)
+        child_nodes = element[:childNodes]
+        child_nodes.is_a?(JS::Object) ? child_nodes.to_a : [] #: Array[untyped]
+      end
 
       def unmount_component(vnode)
         return unless vnode.is_a?(VDOM::Component) && vnode.instance

--- a/sig/patcher.rbs
+++ b/sig/patcher.rbs
@@ -9,6 +9,7 @@ module Funicular
       def apply: (JS::Object element, Array[patch_t] patches) -> JS::Object
 
       # Accepts JS::Object since callers narrow via is_a?(JS::Element) at runtime
+      private def child_nodes_array: (JS::Object element) -> Array[untyped]
       private def update_props: (JS::Object element, Hash[Symbol, String?] props_patch) -> void
       private def create_element: (untyped vnode) -> JS::Object
       private def unmount_component: (VDOM::VNode vnode) -> void

--- a/test/vdom_differ_test.rb
+++ b/test/vdom_differ_test.rb
@@ -149,9 +149,12 @@ class VDOMDifferTest < Picotest::Test
       Funicular::VDOM::Element.new('li', {key: 'a', class: 'first'})
     ])
     patches = @differ.diff(old_element, new_element)
-    # No content changes (just position swap) means no patches.
-    # Reorder-only is not considered a change in the current implementation.
-    assert_equal([], patches)
+    assert_equal(1, patches.length)
+    assert_equal(:keyed_children, patches[0][0])
+    ops = patches[0][1]
+    assert_equal([:keep, 1, 0, []], ops[0])
+    assert_equal([:keep, 0, 1, []], ops[1])
+    assert_equal([], patches[0][2])
   end
 
   def test_diff_children_with_keys_element_added

--- a/test/vdom_patcher_test.rb
+++ b/test/vdom_patcher_test.rb
@@ -37,6 +37,12 @@ class VDOMPatcherTest < Picotest::Test
 
   class MockElement
     attr_accessor :tag_name, :attributes, :children, :parent_element, :properties
+    # Number of times a child was taken out of this element's child list,
+    # whether by removeChild or by a move through appendChild/insertBefore/
+    # replaceChild. A real DOM detaches and re-attaches a node even when it
+    # is inserted before itself, so a keyed patch that does not move a node
+    # must not call insertBefore on it at all.
+    attr_reader :detach_count
 
     def initialize(tag)
       @tag_name = tag
@@ -44,6 +50,7 @@ class VDOMPatcherTest < Picotest::Test
       @children = []
       @parent_element = nil
       @properties = {}
+      @detach_count = 0
     end
 
     def setAttribute(key, value)
@@ -55,22 +62,24 @@ class VDOMPatcherTest < Picotest::Test
     end
 
     def appendChild(child)
-      @children.delete(child)
+      detach(child)
       @children << child
       child.parent_element = self if child.respond_to?(:parent_element=)
       child
     end
 
     def removeChild(child)
-      @children.delete(child)
+      detach(child)
       child.parent_element = nil if child.respond_to?(:parent_element=)
       child
     end
 
     def replaceChild(new_child, old_child)
+      detach(new_child)
       index = @children.index(old_child)
       if index
         @children[index] = new_child
+        @detach_count += 1
         new_child.parent_element = self if new_child.respond_to?(:parent_element=)
         old_child.parent_element = nil if old_child.respond_to?(:parent_element=)
       end
@@ -78,18 +87,16 @@ class VDOMPatcherTest < Picotest::Test
     end
 
     def insertBefore(new_child, ref_child)
-      return new_child if new_child == ref_child
-
-      @children.delete(new_child)
-      if ref_child.nil?
-        @children << new_child
+      # Mirror the DOM: insertBefore(node, node) is a detach + re-attach at
+      # the same position, not a no-op.
+      self_insert = !ref_child.nil? && new_child.equal?(ref_child)
+      own_index = @children.index(new_child) if self_insert
+      detach(new_child)
+      index = self_insert ? own_index : (ref_child.nil? ? nil : @children.index(ref_child))
+      if index
+        @children.insert(index, new_child)
       else
-        index = @children.index(ref_child)
-        if index
-          @children.insert(index, new_child)
-        else
-          @children << new_child
-        end
+        @children << new_child
       end
       new_child.parent_element = self if new_child.respond_to?(:parent_element=)
       new_child
@@ -123,6 +130,15 @@ class VDOMPatcherTest < Picotest::Test
       else
         super
       end
+    end
+
+    private
+
+    def detach(child)
+      index = @children.index { |c| c.equal?(child) }
+      return if index.nil?
+      @children.delete_at(index)
+      @detach_count += 1
     end
   end
 
@@ -403,6 +419,8 @@ class VDOMPatcherTest < Picotest::Test
 
     assert_equal([b_node, a_node], dom.children)
     assert_equal("B'", b_node.children[0].text_content)
+    # Only b moved; a must not have been detached and re-attached.
+    assert_equal(1, dom.detach_count)
 
     third_vdom = Funicular::VDOM::Element.new('ul', {}, [
       Funicular::VDOM::Element.new('li', {key: 'b'}, ["B''"]),
@@ -412,6 +430,65 @@ class VDOMPatcherTest < Picotest::Test
 
     assert_equal("B''", b_node.children[0].text_content)
     assert_equal('A', a_node.children[0].text_content)
+    # A content-only change must not touch the child list at all.
+    assert_equal(1, dom.detach_count)
+  end
+
+  def test_keyed_insert_and_remove_do_not_detach_kept_children
+    first_vdom = Funicular::VDOM::Element.new('ul', {}, [
+      Funicular::VDOM::Element.new('li', {key: 'a'}, ['A']),
+      Funicular::VDOM::Element.new('li', {key: 'b'}, ['B']),
+      Funicular::VDOM::Element.new('li', {key: 'c'}, ['C'])
+    ])
+    dom = Funicular::VDOM::Renderer.new(@doc).render(first_vdom)
+    a_node, b_node, c_node = dom.children
+
+    # Remove b, insert d at the front, keep a and c in place.
+    second_vdom = Funicular::VDOM::Element.new('ul', {}, [
+      Funicular::VDOM::Element.new('li', {key: 'd'}, ['D']),
+      Funicular::VDOM::Element.new('li', {key: 'a'}, ['A']),
+      Funicular::VDOM::Element.new('li', {key: 'c'}, ['C'])
+    ])
+    @patcher.apply(dom, Funicular::VDOM::Differ.diff(first_vdom, second_vdom))
+
+    assert_equal(3, dom.children.length)
+    assert_equal('D', dom.children[0].children[0].text_content)
+    assert(dom.children[1].equal?(a_node))
+    assert(dom.children[2].equal?(c_node))
+    assert_nil(b_node.parent_element)
+    # Exactly one detach: the removal of b.
+    assert_equal(1, dom.detach_count)
+  end
+
+  class MockComponentInstance
+    attr_accessor :dom_element, :vdom, :runtime
+
+    def initialize(dom_element)
+      @dom_element = dom_element
+      @runtime = nil
+    end
+
+    def collect_refs(_element, _vdom); end
+    def cleanup_events; end
+    def bind_events(_element, _vdom); end
+  end
+
+  def test_update_and_rebind_returns_replaced_root
+    parent = @doc.createElement('ul')
+    old_root = @doc.createElement('li')
+    parent.appendChild(old_root)
+    instance = MockComponentInstance.new(old_root)
+
+    old_vnode = Funicular::VDOM::Element.new('li', {}, [])
+    new_vnode = Funicular::VDOM::Element.new('form', {}, [])
+    patches = [[:update_and_rebind, instance, [[:replace, new_vnode, old_vnode]], new_vnode]]
+
+    result = @patcher.apply(old_root, patches)
+
+    assert_equal('form', result.tag_name)
+    assert(result.equal?(instance.dom_element))
+    assert_equal([result], parent.children)
+    assert_nil(old_root.parent_element)
   end
 
   def test_create_element_from_string

--- a/test/vdom_patcher_test.rb
+++ b/test/vdom_patcher_test.rb
@@ -16,7 +16,7 @@ class VDOMPatcherTest < Picotest::Test
     end
 
     def to_a
-      @elements
+      @elements.dup
     end
   end
 
@@ -55,6 +55,7 @@ class VDOMPatcherTest < Picotest::Test
     end
 
     def appendChild(child)
+      @children.delete(child)
       @children << child
       child.parent_element = self if child.respond_to?(:parent_element=)
       child
@@ -77,6 +78,9 @@ class VDOMPatcherTest < Picotest::Test
     end
 
     def insertBefore(new_child, ref_child)
+      return new_child if new_child == ref_child
+
+      @children.delete(new_child)
       if ref_child.nil?
         @children << new_child
       else
@@ -132,6 +136,10 @@ class VDOMPatcherTest < Picotest::Test
 
     def parentElement
       @parent_element
+    end
+
+    def is_a?(klass)
+      klass == JS::Object || super
     end
   end
 
@@ -377,6 +385,33 @@ class VDOMPatcherTest < Picotest::Test
     result = @patcher.apply(element, [])
 
     assert_equal(element, result)
+  end
+
+  def test_keyed_reorder_keeps_dom_and_vdom_indices_aligned
+    first_vdom = Funicular::VDOM::Element.new('ul', {}, [
+      Funicular::VDOM::Element.new('li', {key: 'a'}, ['A']),
+      Funicular::VDOM::Element.new('li', {key: 'b'}, ['B'])
+    ])
+    dom = Funicular::VDOM::Renderer.new(@doc).render(first_vdom)
+    a_node, b_node = dom.children
+
+    second_vdom = Funicular::VDOM::Element.new('ul', {}, [
+      Funicular::VDOM::Element.new('li', {key: 'b'}, ["B'"]),
+      Funicular::VDOM::Element.new('li', {key: 'a'}, ['A'])
+    ])
+    @patcher.apply(dom, Funicular::VDOM::Differ.diff(first_vdom, second_vdom))
+
+    assert_equal([b_node, a_node], dom.children)
+    assert_equal("B'", b_node.children[0].text_content)
+
+    third_vdom = Funicular::VDOM::Element.new('ul', {}, [
+      Funicular::VDOM::Element.new('li', {key: 'b'}, ["B''"]),
+      Funicular::VDOM::Element.new('li', {key: 'a'}, ['A'])
+    ])
+    @patcher.apply(dom, Funicular::VDOM::Differ.diff(second_vdom, third_vdom))
+
+    assert_equal("B''", b_node.children[0].text_content)
+    assert_equal('A', a_node.children[0].text_content)
   end
 
   def test_create_element_from_string


### PR DESCRIPTION
## Why

Keyed children kept their old DOM positions even when their order changed.

`diff_children_with_keys` recorded both `old_index` and `new_index`, but reorder-only changes returned no patches. When a reordered child also changed, the patcher updated its contents at the old position without moving the DOM node.

This caused the VDOM and DOM orders to diverge. On later renders, index-based patching could update the wrong keyed child.

For example:

- Render 1: `[A, B]`
- Render 2: `[B', A]`
- Render 3: `[B'', A]`

After Render 2, the DOM could remain `[A, B']` while the VDOM became `[B', A]`. Render 3 would then apply the update for `B` to the DOM node for `A`.

## What

- Treat a changed index for a matched keyed child as a diff.
- Apply updates against the original DOM snapshot, then place kept and inserted nodes in new-index order using the native DOM insertion APIs.
- Preserve replacement results so subsequent movement targets the live DOM node.
- Update the mock DOM to reproduce native node-moving behavior.
- Add a regression test covering `[A, B] → [B', A] → [B'', A]`.