### PR TITLE
Remove unmatched String children in keyed diffs

### DIFF
--- a/mrblib/differ.rb
+++ b/mrblib/differ.rb
@@ -156,10 +156,12 @@ module Funicular
         #    unkeyed ones) is gone from the new render and must be removed.
         #    Skipping unkeyed olds here left stale nodes in the DOM, e.g. a
         #    "Loading..." placeholder that never disappeared once the keyed
-        #    list it was replaced by arrived.
+        #    list it was replaced by arrived. Raw String children are text
+        #    nodes in the DOM (normalize_children keeps them as Strings), so
+        #    they must be collected here as well; only nil slots are skipped.
         removes = [] #: Array[[Integer, child_t]]
         old_children.each_with_index do |old_child, old_index|
-          next unless old_child.is_a?(VNode)
+          next if old_child.nil?
           next if matched_old_indices[old_index]
           removes << [old_index, old_child]
           has_change = true

--- a/test/vdom_differ_test.rb
+++ b/test/vdom_differ_test.rb
@@ -245,6 +245,43 @@ class VDOMDifferTest < Picotest::Test
     assert_nil(removes[0][1].key)
   end
 
+  def test_diff_children_with_keys_removes_unmatched_string_old
+    # A raw String child is a text node in the DOM. When the keyed list
+    # replaces it, it must be collected in removes like any other child;
+    # otherwise the text stays visible after the keyed children arrive.
+    old_element = Funicular::VDOM::Element.new('div', {}, ['Loading...'])
+    new_element = Funicular::VDOM::Element.new('div', {}, [
+      Funicular::VDOM::Element.new('li', {key: 'a'}),
+      Funicular::VDOM::Element.new('li', {key: 'b'})
+    ])
+    patches = @differ.diff(old_element, new_element)
+    assert_equal(1, patches.length)
+    assert_equal(:keyed_children, patches[0][0])
+    ops = patches[0][1]
+    removes = patches[0][2]
+    assert_equal(:insert, ops[0][0])
+    assert_equal(:insert, ops[1][0])
+    assert_equal([[0, 'Loading...']], removes)
+  end
+
+  def test_diff_children_with_keys_removes_trailing_string_old
+    # ['x', li a] -> [li a]: the keyed li is matched by key, the String at
+    # old_index 0 is unmatched and must be removed.
+    old_element = Funicular::VDOM::Element.new('div', {}, [
+      'x',
+      Funicular::VDOM::Element.new('li', {key: 'a'})
+    ])
+    new_element = Funicular::VDOM::Element.new('div', {}, [
+      Funicular::VDOM::Element.new('li', {key: 'a'})
+    ])
+    patches = @differ.diff(old_element, new_element)
+    assert_equal(1, patches.length)
+    ops = patches[0][1]
+    removes = patches[0][2]
+    assert_equal([[:keep, 1, 0, []]], ops)
+    assert_equal([[0, 'x']], removes)
+  end
+
   def test_diff_children_with_keys_element_props_changed
     old_element = Funicular::VDOM::Element.new('ul', {}, [
       Funicular::VDOM::Element.new('li', {key: 'a', class: 'foo'}),

--- a/test/vdom_patcher_test.rb
+++ b/test/vdom_patcher_test.rb
@@ -491,6 +491,24 @@ class VDOMPatcherTest < Picotest::Test
     assert_nil(old_root.parent_element)
   end
 
+  def test_keyed_children_remove_text_placeholder
+    first_vdom = Funicular::VDOM::Element.new('ul', {}, ['Loading...'])
+    dom = Funicular::VDOM::Renderer.new(@doc).render(first_vdom)
+    placeholder = dom.children[0]
+    assert(placeholder.is_a?(MockTextNode))
+
+    second_vdom = Funicular::VDOM::Element.new('ul', {}, [
+      Funicular::VDOM::Element.new('li', {key: 'a'}, ['A']),
+      Funicular::VDOM::Element.new('li', {key: 'b'}, ['B'])
+    ])
+    @patcher.apply(dom, Funicular::VDOM::Differ.diff(first_vdom, second_vdom))
+
+    assert_equal(2, dom.children.length)
+    assert_equal('A', dom.children[0].children[0].text_content)
+    assert_equal('B', dom.children[1].children[0].text_content)
+    assert_nil(placeholder.parent_element)
+  end
+
   def test_create_element_from_string
     element = @patcher.send(:create_element, 'hello')
 


### PR DESCRIPTION
diff_children_with_keys skipped raw String children when collecting removes, so a text child that no new child matched survived every keyed re-render. Rendering ['Loading...'] and then a keyed list left the placeholder text in the DOM forever; ['x', li a] -> [li a] kept the text node while the VDOM had one child. normalize_children keeps Strings as Strings, so they are text nodes in the DOM and must be removed like any other unmatched child. Only nil slots are skipped now.


Claude-Session: https://claude.ai/code/session_01UEqz6NQtU7MrdjUqbzgwEM